### PR TITLE
Blockchain improvements

### DIFF
--- a/examples/B06-blockchain/README.md
+++ b/examples/B06-blockchain/README.md
@@ -9,7 +9,14 @@
 <a name="emulator"></a>
 # Build Emulator with Blockchain
 
-## A.1 Create the Blockchain Component
+## A.1 Automated setup
+
+Make sure driver.sh has the executable permission by running `chmod +x driver.sh`
+./driver.sh will automate each of the steps mentioned below.
+If any issue occurs, it would be best to do them manually.
+
+
+## A.2 Create the Blockchain Component
 
 We create the Blockchain in `component-blockchain.py`. This 
 program generates a Ethereum component, which can be deployed
@@ -21,7 +28,7 @@ Please refer to the comments in the code to understand
 how the layer is built.
 
 
-## A.2 Deploying the Blockchain
+## A.3 Deploying the Blockchain
 
 We deploy the blockchain in `blockchain.py`. It first loads two pre-built
 components, a base-layer component and a blockchain component. The 
@@ -43,7 +50,7 @@ emu.addBinding(Binding('eth1', filter = Filter(asn = 151)))
 ...
 ```
 
-## A.3 Generate the Emulation Files and Set Up the Data Folders
+## A.4 Generate the Emulation Files and Set Up the Data Folders
 
 After running the two Python programs (make sure to also run the B00 example 
 to generate the base layer first), we will get the `output` folder, which
@@ -62,7 +69,7 @@ $ mkdir -p eth-states/2
 $ mkdir -p eth-states/6 
 ```
 
-## A.4 Start the Emulator 
+## A.5 Start the Emulator 
 
 Now we can run the docker-compose commands inside the `output` folder
 to build the containers and then start them.

--- a/examples/B06-blockchain/blockchain.py
+++ b/examples/B06-blockchain/blockchain.py
@@ -4,7 +4,7 @@
 from seedemu.core import Emulator, Binding, Filter
 from seedemu.mergers import DEFAULT_MERGERS
 from seedemu.compiler import Docker
-
+from env import getSaveState
 
 emuA = Emulator()
 emuB = Emulator()
@@ -22,6 +22,23 @@ emu.addBinding(Binding('eth4', filter = Filter(asn = 164)))
 emu.addBinding(Binding('eth5', filter = Filter(asn = 150)))
 emu.addBinding(Binding('eth6', filter = Filter(asn = 170)))
 
+# Callback that will modify the output directory
+output = './output'
+
+def updateEthStates(compiler):
+    if getSaveState("blockchain.py"):
+        compiler.createDirectoryAtBase(output, "eth-states/")
+        for i in range(1, 7):
+            compiler.createDirectoryAtBase(output, "eth-states/" + str(i))
+    else : # Currently This will never run (check comment below)
+        compiler.deleteDirectoryAtBase(output, "eth-states/")
+
 # Render and compile
 emu.render()
-emu.compile(Docker(), './output')
+
+compiler = Docker()
+
+# If output directory exists and override is set to false, we call exit(1)
+# updateOutputdirectory will not be called
+emu.compile(compiler, output).updateOutputDirectory(compiler, [updateEthStates])
+

--- a/examples/B06-blockchain/component-blockchain.py
+++ b/examples/B06-blockchain/component-blockchain.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 from seedemu import *
+from env import getSaveState
 
 emu = Emulator()
 
@@ -9,7 +10,8 @@ emu = Emulator()
 # saveState=True: will set the blockchain folder using `volumes`, 
 # so the blockchain data will be preserved when containers are deleted.
 # Note: right now we need to manually create the folder for each node (see README.md). 
-eth = EthereumService(saveState = True)
+eth = EthereumService(saveState = getSaveState("component_blockchain.py"))
+
 
 # Create Ethereum nodes (nodes in this layer are virtual)
 e1 = eth.install("eth1")

--- a/examples/B06-blockchain/driver.sh
+++ b/examples/B06-blockchain/driver.sh
@@ -1,0 +1,7 @@
+export SAVE_STATE=False
+cd ../B00-mini-internet/
+./mini-internet.py
+cd ../B06-blockchain/
+./component-blockchain.py
+./blockchain.py
+unset SAVE_STATE

--- a/examples/B06-blockchain/driver.sh
+++ b/examples/B06-blockchain/driver.sh
@@ -1,4 +1,4 @@
-export SAVE_STATE=False
+export SAVE_STATE=True
 cd ../B00-mini-internet/
 ./mini-internet.py
 cd ../B06-blockchain/

--- a/examples/B06-blockchain/env.py
+++ b/examples/B06-blockchain/env.py
@@ -1,0 +1,22 @@
+from os import environ
+
+"""!
+@brief This function returns to us the value of the saveState variable
+If the build is done manually (environment variable not set), set saveState to True.
+If the build is automated (environment variable set), set saveState to whatever is set in driver.sh
+"""
+
+def getSaveState(source:str = "") -> bool:
+    print("=========== Calling getSaveState from " + source)
+
+    env = environ.get('SAVE_STATE')
+    
+    print("=========== initial value retrieved is " + str(env))
+
+    if env == None:
+        state = True
+    else:
+        state = True if env == "True" else False
+
+    print("=========== getSaveState returning " + str(state))
+    return state

--- a/seedemu/core/Compiler.py
+++ b/seedemu/core/Compiler.py
@@ -38,7 +38,7 @@ class Compiler:
         @param emulator emulator object.
         @param output output directory path.
         @param override (optional) override the output folder if it already
-        exist. False by defualt.
+        exist. False by default.
         """
         assert emulator.rendered(), 'Simulation needs to be rendered before compile.'
 
@@ -54,6 +54,29 @@ class Compiler:
         chdir(output)
         self._doCompile(emulator)
         chdir(cur)
+
+    def createDirectoryAtBase(self, base:str, directory: str, override: bool = False):
+        """!
+        @brief Creating a directory at a certain base depending on your current directory
+        @param base is the folder in which we want to create an inner directory
+        @param directory is the name of the directory that will be created
+        @param override (optional) overrides the inner directory if it already exists. False by default.
+        """
+        cur = getcwd()
+        if path.exists(base):
+            chdir(base)
+            if override:
+                self._log('folder "{}" already exists, overriding.'.format(directory))
+                rmtree(directory)
+            mkdir(directory)
+            chdir(cur)
+
+    def deleteDirectoryAtBase(self, base: str, directory: str):
+        cur = getcwd()
+        if path.exists(base):
+            chdir(base)
+            if path.exists(directory):
+                rmtree(directory)
 
     def _log(self, message: str) -> None:
         """!

--- a/seedemu/core/Emulator.py
+++ b/seedemu/core/Emulator.py
@@ -387,6 +387,16 @@ class Emulator:
         compiler.compile(self, output, override)
 
         return self
+    
+    def updateOutputDirectory(self, compiler: core.Compiler, callbacks: list) -> Emulator:
+        """!
+        @brief update the output directory in a flexible way. Each service might need to update it in a different way
+        @param compiler to use
+        @param callbacks which is a list of custom functions that will be executed to update the output directory
+        """
+
+        for func in callbacks:
+            func(compiler)
 
     def getRegistry(self) -> Registry: 
         """!


### PR DESCRIPTION
The `saveState` variable was introduced in order to save the blockchain state if the docker containers are ever shutdown.
Its default value is set to `False` but we overrode it by passing a `True` parameter.
By doing this, the emulator user won't have to restart everything from scratch (e.g., mining).

To be able to save the state, we used to create 6 directories manually in the output folder.

The changes I did are made in order to automate this process.
Since we are updating the output folder, we need to make sure it was successfully created.

By supporting callback functions inside the `updateOutputDirectory` function, we will now be able to update the directory in a flexible manner depending on the service we are using. We can add custom code in any of the other examples in seed-emulator to update the output directory the way we need to without affecting other examples.