### PR TITLE
:Remix connection:

### DIFF
--- a/examples/B06-blockchain/component-blockchain.py
+++ b/examples/B06-blockchain/component-blockchain.py
@@ -29,8 +29,8 @@ e3.startMiner()
 e4.startMiner()
 
 # Create more accounts on e5 and e6
-e5.createNewAccount(3)
-e6.createNewAccount().createNewAccount()
+e5.startMiner()
+e6.startMiner().createNewAccount(9).setAsRemixNode()
 
 # Create a smart contract and deploy it from node e3 
 # We need to put the compiled smart contracts inside the Contracts/ folder
@@ -43,7 +43,7 @@ emu.getVirtualNode('eth2').setDisplayName('Ethereum-2')
 emu.getVirtualNode('eth3').setDisplayName('Ethereum-3')
 emu.getVirtualNode('eth4').setDisplayName('Ethereum-4')
 emu.getVirtualNode('eth5').setDisplayName('Ethereum-5')
-emu.getVirtualNode('eth6').setDisplayName('Ethereum-6')
+emu.getVirtualNode('eth6').setDisplayName('Ethereum-6').addPort(8545, 5555)
 
 # Add the layer and save the component to a file
 emu.addLayer(eth)

--- a/examples/B06-blockchain/component-blockchain.py
+++ b/examples/B06-blockchain/component-blockchain.py
@@ -30,7 +30,7 @@ e4.startMiner()
 
 # Create more accounts on e5 and e6
 e5.startMiner()
-e6.startMiner().createNewAccount(9).setAsRemixNode()
+e6.startMiner().createNewAccount(2).unlockAccounts().setAsRemixNode()
 
 # Create a smart contract and deploy it from node e3 
 # We need to put the compiled smart contracts inside the Contracts/ folder

--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -135,6 +135,7 @@ class EthereumServer(Server):
     __create_new_account: int
     __isRemixNode: bool
     __unlockAccounts: bool
+
     def __init__(self, id: int):
         """!
         @brief create new eth server.
@@ -180,7 +181,6 @@ class EthereumServer(Server):
             for i in range(self.__create_new_account + 1):
                 full_command += base_command.format(str(i))
 
-            print(full_command)
             node.appendStartCommand('(\n {})&'.format(full_command))
 
     def __addMinerStartCommand(self, node: Node):

--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -323,6 +323,8 @@ class EthereumServer(Server):
         """
         self.__isRemixNode = True
 
+        return self
+
     def isRemixNode(self) -> bool:
         """!
         @brief returns wheter a node is a remix node or not
@@ -345,6 +347,7 @@ class EthereumServer(Server):
         executed through Remix without the need to access the geth account in the docker container and unlocking manually
         """
         self.__unlockAccounts = True
+
         return self
         
     def startMiner(self) -> EthereumServer:

--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -133,7 +133,7 @@ class EthereumServer(Server):
     __smart_contract: SmartContract
     __start_Miner_node: bool
     __create_new_account: int
-
+    __isRemixNode: bool
     def __init__(self, id: int):
         """!
         @brief create new eth server.
@@ -146,6 +146,7 @@ class EthereumServer(Server):
         self.__smart_contract = None
         self.__start_Miner_node = False
         self.__create_new_account = 0
+        self.__isRemixNode = False
 
     def __createNewAccountCommand(self, node: Node):
         if self.__create_new_account > 0:
@@ -227,6 +228,9 @@ class EthereumServer(Server):
 
         # launch Ethereum process.
         common_args = '{} --identity="NODE_{}" --networkid=10 --verbosity=2 --mine --allow-insecure-unlock --rpc --rpcport=8549 --rpcaddr 0.0.0.0'.format(datadir_option, self.__id)
+        if self.isRemixNode():
+            remix_args = "--http --http.port=5555 --http.corsdomain '*' --http.api web3,eth,debug,personal,net"
+            common_args = '{} {}'.format(common_args, remix_args)
         if len(bootnodes) > 0:
             node.appendStartCommand('nice -n 19 geth --bootnodes "$(cat /tmp/eth-node-urls)" {}'.format(common_args), True)
         else:
@@ -290,6 +294,18 @@ class EthereumServer(Server):
         @returns port
         """
         return self.__bootnode_http_port
+
+    def setAsRemixNode(self) -> EthereumServer:
+        """!
+        @brief setting a node as a remix node makes it possible for the remix IDE to connect to the node
+        """
+        self.__isRemixNode = True
+
+    def isRemixNode(self) -> bool:
+        """!
+        @brief returns wheter a node is a remix node or not
+        """
+        return self.__isRemixNode
 
     def createNewAccount(self, number_of_accounts = 0) -> EthereumServer:
         """!


### PR DESCRIPTION
This feature was implemented in order to connect the Remix IDE to our emulator.

1. Flag a node as being a remix node. This turns on an HTTP server on this node which accepts external connections
2. Use port forwarding in order to run Remix on the host browser
3. Create more than one account on this node to and have them displayed on Remix
4. Unlock all the accounts on the Remix node automatically to avoid having to `docksh` in the node and unlock the accounts manually
