### PR TITLE
Development

### DIFF
--- a/examples/B08-Remix-Connection/component-blockchain.py
+++ b/examples/B08-Remix-Connection/component-blockchain.py
@@ -29,20 +29,29 @@ e4.startMiner()
 
 # Create more accounts on e5 and e6
 e5.startMiner()
-e6.startMiner().createNewAccount(2).unlockAccounts().enableExternalConnection()
+e6.startMiner().createNewAccount(2).unlockAccounts()
 
 # Create a smart contract and deploy it from node e3 
 # We need to put the compiled smart contracts inside the Contracts/ folder
 smart_contract = SmartContract("./Contracts/contract.bin", "./Contracts/contract.abi")
 e3.deploySmartContract(smart_contract)
 
+# Set node port that accepts connections
+e3.enableExternalConnection()
+e6.enableExternalConnection().setGethHttpPort(8549)
+
+# Get node port that accepts connections
+# Same api used in the EthereumService to set the listening port
+e3_port_forward = e3.getGethHttpPort() # Uses default 8545 port
+e6_port_forward = e6.getGethHttpPort() # Uses custom 8549 port
+
 # Customizing the display names (for visualization purpose)
 emu.getVirtualNode('eth1').setDisplayName('Ethereum-1')
 emu.getVirtualNode('eth2').setDisplayName('Ethereum-2')
-emu.getVirtualNode('eth3').setDisplayName('Ethereum-3')
+emu.getVirtualNode('eth3').setDisplayName('Ethereum-3').addPortForwarding(8545, e3_port_forward)
 emu.getVirtualNode('eth4').setDisplayName('Ethereum-4')
 emu.getVirtualNode('eth5').setDisplayName('Ethereum-5')
-emu.getVirtualNode('eth6').setDisplayName('Ethereum-6').addPortForwarding(8545, 8549)
+emu.getVirtualNode('eth6').setDisplayName('Ethereum-6').addPortForwarding(8546, e6_port_forward)
 
 # Add the layer and save the component to a file
 emu.addLayer(eth)

--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -130,6 +130,7 @@ class EthereumServer(Server):
     __id: int
     __is_bootnode: bool
     __bootnode_http_port: int
+    __geth_http_port: int
     __smart_contract: SmartContract
     __start_Miner_node: bool
     __create_new_account: int
@@ -145,6 +146,7 @@ class EthereumServer(Server):
         self.__id = id
         self.__is_bootnode = False
         self.__bootnode_http_port = 8088
+        self.__geth_http_port = 8545
         self.__smart_contract = None
         self.__start_Miner_node = False
         self.__create_new_account = 0
@@ -248,7 +250,7 @@ class EthereumServer(Server):
         node.appendStartCommand('/tmp/eth-bootstrapper')
 
         # launch Ethereum process.
-        common_args = '{} --identity="NODE_{}" --networkid=10 --verbosity=2 --mine --allow-insecure-unlock --http --http.addr 0.0.0.0 --http.port 8549'.format(datadir_option, self.__id)
+        common_args = '{} --identity="NODE_{}" --networkid=10 --verbosity=2 --mine --allow-insecure-unlock --http --http.addr 0.0.0.0 --http.port {}'.format(datadir_option, self.__id, self.getGethHttpPort())
         if self.externalConnectionEnabled():
             remix_args = "--http.corsdomain 'https://remix.ethereum.org' --http.api web3,eth,debug,personal,net"
             common_args = '{} {}'.format(common_args, remix_args)
@@ -309,13 +311,38 @@ class EthereumServer(Server):
 
         return self
 
+
     def getBootNodeHttpPort(self) -> int:
         """!
         @brief get the http server port number hosting the enode url file.
 
         @returns port
         """
+
         return self.__bootnode_http_port
+
+    def setGethHttpPort(self, port: int) -> EthereumServer:
+        """!
+        @brief set the http server port number for normal ethereum nodes
+
+        @param port port
+
+        @returns self, for chaining API calls
+        """
+        
+        self.__geth_http_port = port
+        
+        return self
+
+    def getGethHttpPort(self) -> int:
+        """!
+        @brief get the http server port number for normal ethereum nodes
+
+        @returns int
+        """
+                
+        return self.__geth_http_port
+
 
     def enableExternalConnection(self) -> EthereumServer:
         """!

--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -250,7 +250,7 @@ class EthereumServer(Server):
         # launch Ethereum process.
         common_args = '{} --identity="NODE_{}" --networkid=10 --verbosity=2 --mine --allow-insecure-unlock --http --http.addr 0.0.0.0 --http.port 8549'.format(datadir_option, self.__id)
         if self.externalConnectionEnabled():
-            remix_args = "--http.corsdomain '*' --http.api web3,eth,debug,personal,net"
+            remix_args = "--http.corsdomain 'https://remix.ethereum.org' --http.api web3,eth,debug,personal,net"
             common_args = '{} {}'.format(common_args, remix_args)
         if len(bootnodes) > 0:
             node.appendStartCommand('nice -n 19 geth --bootnodes "$(cat /tmp/eth-node-urls)" {}'.format(common_args), True)


### PR DESCRIPTION
Using the default 8545 port for port forwarding
Created api to change this port to any custom port
Created api to get the port used by the geth HTTP server (regardless of whether the setter api was used or not)
Strictly allowing  connections from remix, should be changed back to an asterix to connect other tools like truffle
