### PR TITLE
Fix bug on EthereumService

### DIFF
--- a/examples/not-ready-examples/25-proof-of-authority-manual/component-blockchain.py
+++ b/examples/not-ready-examples/25-proof-of-authority-manual/component-blockchain.py
@@ -12,7 +12,7 @@ emu = Emulator()
 # Note: right now we need to manually create the folder for each node (see README.md). 
 eth = EthereumService(saveState = True, manual=True)
 
-eth.setBaseConsensusMechanism("poa")
+eth.setBaseConsensusMechanism(ConsensusMechanism.POA)
 
 # Create Ethereum nodes (nodes in this layer are virtual)
 start=1

--- a/examples/not-ready-examples/27-blockchain-two-consensus/component-blockchain.py
+++ b/examples/not-ready-examples/27-blockchain-two-consensus/component-blockchain.py
@@ -12,7 +12,7 @@ emu = Emulator()
 # Note: right now we need to manually create the folder for each node (see README.md). 
 eth = EthereumService(saveState = True, manual=False)
 
-eth.setBaseConsensusMechanism("poa")
+eth.setBaseConsensusMechanism(ConsensusMechanism.POA)
 
 # Create Ethereum nodes (nodes in this layer are virtual)
 start=1
@@ -48,7 +48,7 @@ start = end
 end = start + 2
 for i in range(start, end):
     e = eth.install("eth{}".format(i))
-    e.setConsensusMechanism("pow")
+    e.setConsensusMechanism(ConsensusMechanism.POW)
     e.unlockAccounts().startMiner()
     emu.getVirtualNode("eth{}".format(i)).setDisplayName('Ethereum-pow-{}'.format(i))
 

--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -118,12 +118,12 @@ class Genesis():
         self.__consensusMechaism = consensus
         self.__genesis = json.loads(self.__genesisPoA) if self.__consensusMechaism == ConsensusMechanism.POA else json.loads(self.__genesisPoW)
     
-    def allocAccount(self, accounts:List[EthAccount]) -> Genesis:
+    def allocateBalance(self, accounts:List[EthAccount]) -> Genesis:
         '''
-        @brief alloce balance to account on genesis. It will update the genesis file
+        @brief allocate balance to account on genesis. It will update the genesis file
         '''
         for account in accounts:
-            self.__alllocAccount(account.address,account.alloc_balance)
+            self.__allocateBalance(account.address,account.alloc_balance)
         return self
 
     def setSealer(self, accounts:List[EthAccount]) -> Genesis:
@@ -145,7 +145,7 @@ class Genesis():
         
         return extraData + "0" * 130
     
-    def __alllocAccount(self, address:str, balance:str) -> None:
+    def __allocateBalance(self, address:str, balance:str) -> None:
         self.__genesis["alloc"][address[2:]] = {"balance":"{}".format(balance)}
         
     def __replaceExtraData(self, content:str) -> None:
@@ -351,7 +351,7 @@ class EthereumServer(Server):
             node.appendStartCommand('(\n {})&'.format(smartContractCommand))
     
     def __updateGenesis(self, genesis: Genesis, prefunded_accounts:List[EthAccount]) -> Genesis:
-        genesis.allocAccount(prefunded_accounts)
+        genesis.allocateBalance(prefunded_accounts)
         genesis.setSealer(prefunded_accounts)
         return genesis
 

--- a/seedemu/services/__init__.py
+++ b/seedemu/services/__init__.py
@@ -3,7 +3,7 @@ from .BotnetService import BotnetClientService, BotnetClientServer, BotnetServic
 from .DomainRegistrarService import DomainRegistrarService, DomainRegistrarServer
 from .DomainNameService import DomainNameServer, DomainNameService, Zone
 from .TorService import TorService, TorServer, TorNodeType
-from .EthereumService import EthereumService, EthereumServer, SmartContract
+from .EthereumService import EthereumService, EthereumServer, SmartContract, ConsensusMechanism
 from .DomainNameCachingService import DomainNameCachingServer, DomainNameCachingService
 from .CymruIpOrigin import CymruIpOriginService, CymruIpOriginServer
 from .ReverseDomainNameService import ReverseDomainNameService, ReverseDomainNameServer


### PR DESCRIPTION
**1. Fix bug**
- Bug description: When we import `seedemu`, it will import `EthereumService`, which cause a not module error about `eth_account` and stop the program when machine does not install `eth_account`, even the program is not related to `EthereumService`
- Solution: move the `import eth_account` inside to `EthAccount`. Only when user call Ethereum Server's APIs that are related to prefunded account and machine does not install `eth_account`, the not module error will be throw and the program stop.

**2.  Update example**
use the `ConsensusMechanism` Enum to set consensus mechanism
 - examples/not-ready-examples/25-proof-of-authority-manual
 - examples/not-ready-examples/27-blockchain-two-consensus/component-blockchain.py

**3. fix typo**
- fix typo about allocate balance method in `EthAccount`

**4. update seedemu/services/__init__.py**
- add `ConsensusMechanism` to import list