### PR TITLE
fix bug for POA

### DIFF
--- a/seedemu/services/EthereumService.py
+++ b/seedemu/services/EthereumService.py
@@ -296,7 +296,7 @@ class EthereumServer(Server):
         self.__create_new_account = 0
         self.__enable_external_connection = False
         self.__unlockAccounts = False
-        self.__prefunded_accounts = []
+        self.__prefunded_accounts = [EthAccount(alloc_balance=str(32 * pow(10, 18)), password="admin")] #create a prefunded account by default. It ensure POA network works when create/import prefunded account is not called.
         self.__consensus_mechanism = None # keep as empty to make sure the OR statement works in the install function
 
     def __createNewAccountCommand(self, node: Node):


### PR DESCRIPTION
Fix Bug
- Description: When the consensus mechanism is Proof-Of-Authority and create/import prefunded account API are called, the network will be able to initialize because of no sealer.
- Solution: Each Ethereum node will have one prefund account with balance of 1 eth. This account will be the sealer.