### PR TITLE
Make SCION layers compatible with Python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ client/backend/bin
 *.bin
 output
 project-words.txt
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ eth_account==0.5.9
 requests==2.22.0
 eth-rlp<0.3
 web3==5.31.1
+PyYAML==6.0.1

--- a/seedemu/layers/Scion.py
+++ b/seedemu/layers/Scion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import Enum
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 from seedemu.core import (Emulator, Interface, Layer, Network, Registry,
                           Router, ScionAutonomousSystem, ScionRouter,
@@ -71,7 +71,7 @@ class Scion(Layer, Graphable):
     def getName(self) -> str:
         return "Scion"
 
-    def addXcLink(self, a: IA|Tuple[int, int], b: IA|Tuple[int, int],
+    def addXcLink(self, a: Union[IA, Tuple[int, int]], b: Union[IA, Tuple[int, int]],
                   linkType: LinkType, count: int=1) -> 'Scion':
         """!
         @brief Create a direct cross-connect link between to ASes.
@@ -94,7 +94,7 @@ class Scion(Layer, Graphable):
 
         return self
 
-    def addIxLink(self, ix: int, a: IA|Tuple[int, int], b: IA|Tuple[int, int],
+    def addIxLink(self, ix: int, a: Union[IA, Tuple[int, int]], b: Union[IA, Tuple[int, int]],
                   linkType: LinkType, count: int=1) -> 'Scion':
         """!
         @brief Create a private link between two ASes at an IX.

--- a/seedemu/layers/ScionIsd.py
+++ b/seedemu/layers/ScionIsd.py
@@ -3,7 +3,7 @@ import subprocess
 from collections import defaultdict
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
-from typing import Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from seedemu.core import Emulator, Layer, Node, ScionAutonomousSystem
 from seedemu.core.ScionAutonomousSystem import IA
@@ -91,7 +91,7 @@ class ScionIsd(Layer):
         """
         return asn in self.__isd_core[isd]
 
-    def setCertIssuer(self, as_: IA|Tuple[int, int], issuer: int) -> 'ScionIsd':
+    def setCertIssuer(self, as_: Union[IA, Tuple[int, int]], issuer: int) -> 'ScionIsd':
         """!
         @brief Set certificate issuer for a non-core AS. Ignored for core ASes.
 
@@ -102,7 +102,7 @@ class ScionIsd(Layer):
         self.__cert_issuer[IA(*as_)] = issuer
         return self
 
-    def getCertIssuer(self, as_: IA|Tuple[int, int]) -> Optional[Tuple[int, int]]:
+    def getCertIssuer(self, as_: Union[IA, Tuple[int, int]]) -> Optional[Tuple[int, int]]:
         """!
         @brief Get the cert issuer for a SCION AS in a certain ISD.
 

--- a/test/scion/ScionTestCase.py
+++ b/test/scion/ScionTestCase.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from test.SeedEmuTestCase import SeedEmuTestCase
 
@@ -34,7 +34,7 @@ class ScionTestCase(SeedEmuTestCase):
             return False
 
     def scion_path_test(self, container, dst: str, pred: str = "0*", ret_paths: bool = False
-                        ) -> bool | Tuple[bool, List]:
+                        ) -> Union[bool, Tuple[bool, List]]:
         """!
         @brief Test whether a path matching the given path predicate exists and is alive.
 


### PR DESCRIPTION
* Replace use of operator | in type hints with Union[] for compatibility with Python < 3.10 (cf. PEP 604).
* Add PyYAML to requirements.txt