### PR TITLE
feat: better type hints

### DIFF
--- a/seedemu/core/AutonomousSystem.py
+++ b/seedemu/core/AutonomousSystem.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
+from typing import Dict, List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Graphable import Graphable
 from .Printable import Printable
 from .Network import Network
 from .AddressAssignmentConstraint import AddressAssignmentConstraint
 from .enums import NetworkType, NodeRole
 from .Node import Node
-from .Emulator import Emulator
 from .Configurable import Configurable
 from .Node import RealWorldRouter
 from ipaddress import IPv4Network
-from typing import Dict, List
 import requests
 
 RIS_PREFIXLIST_URL = 'https://stat.ripe.net/data/announced-prefixes/data.json'

--- a/seedemu/core/Binding.py
+++ b/seedemu/core/Binding.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
+from typing import List, Callable, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Printable import Printable
-from .Emulator import Emulator
 from .Node import Node
 from .BaseSystem import BaseSystem
 from enum import Enum
-from typing import List, Callable
 from ipaddress import IPv4Network, IPv4Address
 from sys import stderr
 import re, random, string

--- a/seedemu/core/Compiler.py
+++ b/seedemu/core/Compiler.py
@@ -1,4 +1,7 @@
-from seedemu.core.Emulator import Emulator
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from seedemu.core import Registry
 from os import mkdir, chdir, getcwd, path
 from shutil import rmtree

--- a/seedemu/core/Component.py
+++ b/seedemu/core/Component.py
@@ -1,5 +1,7 @@
-from seedemu.core import Emulator
-from typing import List
+from __future__ import annotations
+from typing import List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 
 class Component(object):
     """!

--- a/seedemu/core/Configurable.py
+++ b/seedemu/core/Configurable.py
@@ -1,4 +1,7 @@
-from .Emulator import Emulator
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 
 class Configurable(object):
     """!

--- a/seedemu/core/Emulator.py
+++ b/seedemu/core/Emulator.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
+from typing import Dict, Set, Tuple, List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Binding import Binding
+    from .Layer import Layer
+    from .Hook import Hook
+    from .Service import Server
+    from .Compiler import Compiler
 from seedemu.core.enums import NetworkType, NodeRole
+from .Service import Service
+from .Node import Node
 from .Merger import Mergeable, Merger
 from .Registry import Registry, Registrable, Printable
 from .Network import Network
-from seedemu import core
-from typing import Dict, Set, Tuple, List
 from sys import prefix, stderr
 from ipaddress import IPv4Network
 import pickle
@@ -18,8 +25,8 @@ class BindingDatabase(Registrable, Printable):
     dumps.
     """
 
-    db: List[core.Binding]
-    vpnodes: Dict[str, core.Node]
+    db: List[Binding]
+    vpnodes: Dict[str, Node]
 
     def __init__(self):
         """!
@@ -51,7 +58,7 @@ class LayerDatabase(Registrable, Printable):
     layers database with Registrable allows the layers to be preserved in dumps.
     """
 
-    db: Dict[str, Tuple[core.Layer, bool]]
+    db: Dict[str, Tuple[Layer, bool]]
 
     def __init__(self):
         """!
@@ -84,7 +91,7 @@ class Emulator:
     __dependencies_db: Dict[str, Set[Tuple[str, bool]]]
     __rendered: bool
     __bindings: BindingDatabase
-    __resolved_bindings: Dict[str, core.Node]
+    __resolved_bindings: Dict[str, Node]
 
     __service_net: Network
     __service_net_prefix: str
@@ -141,7 +148,7 @@ class Emulator:
 
         self.__log('entering {}...'.format(layerName))
 
-        hooks: List[core.Hook] = []
+        hooks: List[Hook] = []
         for hook in self.__registry.getByType('seedemu', 'hook'):
             if hook.getTargetLayer() == layerName: hooks.append(hook)
         
@@ -192,7 +199,7 @@ class Emulator:
         """
         return self.__rendered
 
-    def addHook(self, hook: core.Hook) -> Emulator:
+    def addHook(self, hook: Hook) -> Emulator:
         """!
         @brief Add a hook.
 
@@ -204,7 +211,7 @@ class Emulator:
 
         return self
 
-    def addBinding(self, binding: core.Binding) -> Emulator:
+    def addBinding(self, binding: Binding) -> Emulator:
         """!
         @brief Add a binding.
 
@@ -216,7 +223,7 @@ class Emulator:
 
         return self
 
-    def getBindings(self) -> List[core.Binding]:
+    def getBindings(self) -> List[Binding]:
         """!
         @brief Get all bindings.
 
@@ -224,7 +231,7 @@ class Emulator:
         """
         return self.__bindings.db
 
-    def addLayer(self, layer: core.Layer) -> Emulator:
+    def addLayer(self, layer: Layer) -> Emulator:
         """!
         @brief Add a layer.
 
@@ -241,7 +248,7 @@ class Emulator:
 
         return self
 
-    def getLayer(self, layerName: str) -> core.Layer:
+    def getLayer(self, layerName: str) -> Layer:
         """!
         @brief Get a layer.
 
@@ -250,7 +257,7 @@ class Emulator:
         """
         return self.__registry.get('seedemu', 'layer', layerName)
 
-    def getLayers(self) -> List[core.Layer]:
+    def getLayers(self) -> List[Layer]:
         """!
         @brief Get all layers.
 
@@ -258,7 +265,7 @@ class Emulator:
         """
         return self.__registry.getByType('seedemu', 'layer')
     
-    def getServerByVirtualNodeName(self, vnodeName: str) -> core.Server:
+    def getServerByVirtualNodeName(self, vnodeName: str) -> Server:
         """!
         @brief Get server by virtual node name. 
 
@@ -268,13 +275,13 @@ class Emulator:
         @returns server.
         """
         for (layer, _) in self.__layers.db.values():
-            if not isinstance(layer, core.Service): continue
+            if not isinstance(layer, Service): continue
             for (vnode, server) in layer.getPendingTargets().items():
                 if vnode == vnodeName:
                     return server
         return None
     
-    def resolvVnode(self, vnode: str) -> core.Node:
+    def resolvVnode(self, vnode: str) -> Node:
         """!
         @brief resolve physical node for the given virtual node.
 
@@ -289,7 +296,7 @@ class Emulator:
             return pnode
         assert False, 'cannot resolve vnode {}'.format(vnode)
 
-    def getBindingFor(self, vnode: str) -> core.Node:
+    def getBindingFor(self, vnode: str) -> Node:
         """!
         @brief get physical node for the given virtual node from the
         pre-populated vnode-pnode mappings.
@@ -350,7 +357,7 @@ class Emulator:
         self.__log('collecting virtual node names in the emulation...')
         vnodes: List[str] = []
         for (layer, _) in self.__layers.db.values():
-            if not isinstance(layer, core.Service): continue
+            if not isinstance(layer, Service): continue
             for (vnode, _) in layer.getPendingTargets().items():
                 assert vnode not in vnodes, 'duplicated vnode: {}'.format(vnode)
                 vnodes.append(vnode)
@@ -389,7 +396,7 @@ class Emulator:
 
         return self
 
-    def compile(self, compiler: core.Compiler, output: str, override: bool = False) -> Emulator:
+    def compile(self, compiler: Compiler, output: str, override: bool = False) -> Emulator:
         """!
         @brief Compile the simulation.
 
@@ -404,7 +411,7 @@ class Emulator:
 
         return self
     
-    def updateOutputDirectory(self, compiler: core.Compiler, callbacks: list) -> Emulator:
+    def updateOutputDirectory(self, compiler: Compiler, callbacks: list) -> Emulator:
         """!
         @brief update the output directory in a flexible way. Each service might need to update it in a different way
         @param compiler to use
@@ -422,7 +429,7 @@ class Emulator:
         """
         return self.__registry
 
-    def getVirtualNode(self, vnode_name: str) -> core.Node:
+    def getVirtualNode(self, vnode_name: str) -> Node:
         """!
         @brief get a virtual "physical" node.
 
@@ -440,11 +447,11 @@ class Emulator:
         @returns node
         """
         if vnode_name not in self.__bindings.vpnodes:
-            self.__bindings.vpnodes[vnode_name] = core.Node(vnode_name, NodeRole.Host, 0)
+            self.__bindings.vpnodes[vnode_name] = Node(vnode_name, NodeRole.Host, 0)
 
         return self.__bindings.vpnodes[vnode_name]
 
-    def setVirtualNode(self, vnode_name: str, node: core.Node) -> Emulator:
+    def setVirtualNode(self, vnode_name: str, node: Node) -> Emulator:
         """!
         @brief set a virtual node.
 
@@ -464,7 +471,7 @@ class Emulator:
 
         return self
 
-    def getVirtualNodes(self) -> Dict[str, core.Node]:
+    def getVirtualNodes(self) -> Dict[str, Node]:
         """!
         @brief get dict of virtual "physical" nodes.
 
@@ -492,7 +499,7 @@ class Emulator:
         for l in other_layers.values():
             typename = l.getTypeName()
 
-            if isinstance(l, core.Service):
+            if isinstance(l, Service):
                 l.addPrefix(vnodePrefix)
 
             if typename not in new_layers.keys():

--- a/seedemu/core/Graphable.py
+++ b/seedemu/core/Graphable.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from typing import List, Dict
+from typing import List, Dict, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Printable import Printable
 from .Registry import Registry, Registrable
-from .Emulator import Emulator
 from copy import deepcopy
 
 class Vertex:

--- a/seedemu/core/Hook.py
+++ b/seedemu/core/Hook.py
@@ -1,4 +1,7 @@
-from .Emulator import Emulator
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Registry import Registrable
 from .Printable import Printable
 from sys import stderr

--- a/seedemu/core/InternetExchange.py
+++ b/seedemu/core/InternetExchange.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Printable import Printable
 from .enums import NetworkType, NodeRole
 from .Node import Node
 from .Network import Network
 from .AddressAssignmentConstraint import AddressAssignmentConstraint
-from .Emulator import Emulator
 from .Configurable import Configurable
 from ipaddress import IPv4Network
 

--- a/seedemu/core/Layer.py
+++ b/seedemu/core/Layer.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
-
+from typing import Set, Dict, Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Printable import Printable
 from .Registry import Registrable
-from .Emulator import Emulator
 from .Configurable import Configurable
 from .Merger import Mergeable
 
 from sys import stderr
-from typing import Set, Dict, Tuple
 
 
 class Layer(Printable, Registrable, Configurable, Mergeable):

--- a/seedemu/core/Network.py
+++ b/seedemu/core/Network.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+from typing import Dict, Tuple, List, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Node import Node
 from ipaddress import IPv4Network, IPv4Address
 from .RemoteAccessProvider import RemoteAccessProvider
 from .Printable import Printable
@@ -6,7 +9,6 @@ from .enums import NetworkType, NodeRole
 from .Registry import Registrable
 from .AddressAssignmentConstraint import AddressAssignmentConstraint, Assigner
 from .Visualization import Vertex
-from typing import Dict, Tuple, List
 
 class Network(Printable, Registrable, Vertex):
     """!
@@ -21,7 +23,7 @@ class Network(Printable, Registrable, Vertex):
     __aac: AddressAssignmentConstraint
     __assigners: Dict[NodeRole, Assigner]
 
-    __connected_nodes: List['Node']
+    __connected_nodes: List[Node]
 
     __d_latency: int       # in ms
     __d_bandwidth: int     # in bps
@@ -237,7 +239,7 @@ class Network(Printable, Registrable, Vertex):
         if self.__type == NetworkType.InternetExchange: return self.__prefix[self.__aac.mapIxAddress(asn)]
         return self.__prefix[self.__assigners[nodeRole].next()]
 
-    def associate(self, node: 'Node'):
+    def associate(self, node: Node):
         """!
         @brief Associate the node with network.
 
@@ -245,7 +247,7 @@ class Network(Printable, Registrable, Vertex):
         """
         self.__connected_nodes.append(node)
 
-    def getAssociations(self) -> List['Node']:
+    def getAssociations(self) -> List[Node]:
         """!
         @brief Get list of associated nodes.
 

--- a/seedemu/core/Node.py
+++ b/seedemu/core/Node.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
+from typing import List, Dict, Set, Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Printable import Printable
 from .Network import Network
 from .enums import NodeRole
 from .Registry import Registrable
-from .Emulator import Emulator
 from .Configurable import Configurable
 from .enums import NetworkType
 from .Visualization import Vertex
 from ipaddress import IPv4Address, IPv4Interface
-from typing import List, Dict, Set, Tuple
 from string import ascii_letters
 from random import choice
 from .BaseSystem import BaseSystem

--- a/seedemu/core/RemoteAccessProvider.py
+++ b/seedemu/core/RemoteAccessProvider.py
@@ -1,4 +1,9 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
+    from .Network import Network
+    from .Node import Node
 from sys import stderr
 
 class RemoteAccessProvider(object):

--- a/seedemu/core/ScionAutonomousSystem.py
+++ b/seedemu/core/ScionAutonomousSystem.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 import base64
 import os
 from collections import defaultdict
-from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
-
+from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .AutonomousSystem import AutonomousSystem
-from .Emulator import Emulator
 from .enums import NodeRole
 from .Node import Node, ScionRouter
 

--- a/seedemu/core/Service.py
+++ b/seedemu/core/Service.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
+from typing import Dict, List, Set, Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from .Emulator import Emulator
 from .Layer import Layer
 from .Node import Node
 from .Printable import Printable
-from .Emulator import Emulator
 from .enums import NodeRole
 from .Binding import Binding
-from typing import Dict, List, Set, Tuple
 from .BaseSystem import BaseSystem
 
 class Server(Printable):


### PR DESCRIPTION
Previously seedemu adopts a workaround to solve the issue of circular import in an unusual way.
However, some popular lsp server cannot resolve it correctly:
https://github.com/microsoft/pyright/issues/7233
which results in a failure of static reasoning in VSCode.
Though it's probably a bug of lsp, it's better to use the standard practice:
```python
from __future__ import annotations
from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from .Emulator import Emulator
```
 to avoid this.

As there is no CI available, the result of testing is pasted below:

![image](https://github.com/seed-labs/seed-emulator/assets/59462000/ec4d8e5c-cf4e-463f-8ee9-c71ba1248208)
