### PR TITLE
Add linters and code formatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,23 @@
+[flake8]
+# maximum recommended by PEP 8 is 99
+max-line-length = 99
+# maximum recommended by PEP 8 is 72
+max-doc-length = 80
+
+ignore =
+    # disable warnings that conflict with Black
+    E203
+    E701
+
+exclude =
+    .git
+    .venv
+    client
+    docker_images
+    docs
+    __pycache__
+    output
+
+per-file-ignores =
+    # Ignore unused star imports in __init__ files
+    __init__.py:F401,F403

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,37 +12,52 @@ figure out where you can best be helpful.
 
 ## How to Contribute
 
-- **Adding new elements**. We will be actively developing new elements 
+- **Adding new elements**. We will be actively developing new elements
   useful for Internet emulation. For example, recently we have added
   DNS, Botnet, Darknet components, and we are currently developing blockchain
-  components. It is these components that will make the emulator 
-  more interesting and more useful. 
+  components. It is these components that will make the emulator
+  more interesting and more useful.
 
-- **Improving existing elements**: Some of the elements are currently quite rudimentary, and 
-  rich features need to be added. You can help us propose and implement 
-  new features to those elements. 
+- **Improving existing elements**: Some of the elements are currently quite rudimentary, and
+  rich features need to be added. You can help us propose and implement
+  new features to those elements.
 
-- **Building more complicated emulation**: The Internet emulators built by the 
+- **Building more complicated emulation**: The Internet emulators built by the
   current examples included in the project are quite small. It will be useful if we can build
   more complicated examples, and share them as components, so others
   can use these components to build their emulators. In the future, we can
-  create a market place so people can share or trade their emulators. 
+  create a market place so people can share or trade their emulators.
 
-- **Testing**. We definitely need more people to help test 
+- **Testing**. We definitely need more people to help test
   the code and provide feedback. You can create issues to tell us
   about the bugs and feedback.
-    
-- **Developing lab exercises**. The emulator created from this project is 
+
+- **Developing lab exercises**. The emulator created from this project is
   intended for being used as a platform for lab exercises, especially in
   the field of cybersecurity and networking. The proposed lab ideas
   can be found in the [labs/](./labs/) folder. You can help develop
-  these labs or propose new ideas. 
+  these labs or propose new ideas.
 
+## Running Linters and Code Formatters
+
+- **flake8** checks compliance with the PEP 8 style guide. You can invoke it
+  globally by running `flake8` in the root of the repository or pass individual
+  files to check. If you are using VS Code, there is also a flake8 plugin
+  running the linter continuously in the background.
+- **black** formats files or sections of code to comply with its style guideline
+  and should fix most formatting errors that flake8 points out. You can invoke
+  `black` on the command line with the path to a file to format. There are also
+  editor plugins that allow formatting code selections easily.
+- **mypy** is a static type checker that makes sure Python type annotations are
+  correct. Running `mypy` in the root of the repository checks all modules in
+  `seedemu`. See the [mypy documentation][mypy-cli] on how to check individual
+  files or modules on the command line.
+
+[mypy-cli]: https://mypy.readthedocs.io/en/stable/command_line.html
 
 ## Community
 
-Discussions about the Open Source Guides take place on 
-this repository's [Issues](https://github.com/seed-labs/SEEDEmulator/issues) and [Pull Requests](https://github.com/seed-labs/SEEDEmulator/pulls) sections. Anybody is welcome to join these conversations. 
+Discussions about the Open Source Guides take place on
+this repository's [Issues](https://github.com/seed-labs/SEEDEmulator/issues) and [Pull Requests](https://github.com/seed-labs/SEEDEmulator/pulls) sections. Anybody is welcome to join these conversations.
 
 Wherever possible, do not take these conversations to private channels, including contacting the maintainers directly. Keeping communication public means everybody can benefit and learn from the conversation.
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+black==25.1.0
+flake8==7.1.2
+mypy==1.15.0
+mypy-extensions==1.0.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+packages = seedemu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+target-version = ["py38", "py39", "py310"]
+line-length = 99

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 eth_account==0.5.9
-requests==2.22.0
 eth-rlp<0.3
-web3==5.31.1
 PyYAML==6.0.1
+requests==2.22.0
+web3==5.31.1


### PR DESCRIPTION
Adding a code style linter has been proposed in #142. This PR makes progress
towards a standardized code format by adding configurations for the Python
style linter flake8 and the auto-formatter Black. Additionally, developers can
use the static type checker mypy as outlined in CONTRIBUTING.md.

* Add configuration files for flake8, black, and mypy.
* Document using flake8 and mypy as linters and code formatting with black.