### PR TITLE
Introduce ControlService NodeRole

### DIFF
--- a/seedemu/compiler/Docker.py
+++ b/seedemu/compiler/Docker.py
@@ -765,6 +765,7 @@ class Docker(Compiler):
         """
         if role == NodeRole.Host: return 'h'
         if role == NodeRole.Router: return 'r'
+        if role == NodeRole.ControlService: return 'cs'
         if role == NodeRole.RouteServer: return 'rs'
         if role == NodeRole.BorderRouter: return 'brd'
         assert False, 'unknown node role {}'.format(role)

--- a/seedemu/core/AddressAssignmentConstraint.py
+++ b/seedemu/core/AddressAssignmentConstraint.py
@@ -165,7 +165,7 @@ class AddressAssignmentConstraint(Printable):
         @throws ValueError if try to get assigner of IX interface.
         """
 
-        if NodeRole.Host == type:
+        if NodeRole.Host == type or NodeRole.ControlService == type:
             return Assigner(self.__hostStart, self.__hostEnd, self.__hostStep)
         if NodeRole.Router == type or type == NodeRole.BorderRouter:
             return Assigner(self.__routerStart, self.__routerEnd, self.__routerStep)

--- a/seedemu/core/Network.py
+++ b/seedemu/core/Network.py
@@ -61,6 +61,8 @@ class Network(Printable, Registrable, Vertex):
         self.__assigners[ NodeRole.BorderRouter ] = arouter
         self.__assigners[ NodeRole.Router ] = arouter
         self.__assigners[ NodeRole.Host ] = ahost
+        self.__assigners[ NodeRole.ControlService ] = ahost
+
         self.__d_latency = 0
         self.__d_bandwidth = 0
         self.__d_drop = 0

--- a/seedemu/core/ScionAutonomousSystem.py
+++ b/seedemu/core/ScionAutonomousSystem.py
@@ -211,7 +211,7 @@ class ScionAutonomousSystem(AutonomousSystem):
         @returns Node.
         """
         assert name not in self.__control_services, 'Control service with name {} already exists.'.format(name)
-        self.__control_services[name] = Node(name, NodeRole.Host, self.getAsn())
+        self.__control_services[name] = Node(name, NodeRole.ControlService, self.getAsn())
 
         return self.__control_services[name]
 

--- a/seedemu/core/enums.py
+++ b/seedemu/core/enums.py
@@ -31,5 +31,7 @@ class NodeRole(Enum):
 
     BorderRouter = "BorderRouter"
 
+    ControlService = "ControlService"
+
     ## Route served node.
     RouteServer = "Route Server"

--- a/tests/scion/scion_bgp_mixed/ScionBgpMixedTestCase.py
+++ b/tests/scion/scion_bgp_mixed/ScionBgpMixedTestCase.py
@@ -23,7 +23,7 @@ class ScionBgpMixedTestCase(ScionTestCase):
         for cntr in self.containers:
             if "cs" in cntr.name:
                 asn, _, ip = cntr.name.split('-')
-                asn = asn.lstrip('as').rstrip('h')
+                asn = asn.removeprefix('as').removesuffix('h').removesuffix('cs')
                 if int(asn) < 160:
                     ia = f"1-{asn}"
                 else:

--- a/tests/scion/scion_bwtester/ScionBwtesterTestCase.py
+++ b/tests/scion/scion_bwtester/ScionBwtesterTestCase.py
@@ -21,7 +21,7 @@ class ScionBwtesterTestCase(ScionTestCase):
         for cntr in self.containers:
             if "bwtest" in cntr.name:
                 asn, _, ip = cntr.name.split('-')
-                asn = asn.lstrip('as').rstrip('h')
+                asn = asn.removeprefix('as').removesuffix('h').removesuffix('cs')
                 self.bwtesters[f"1-{asn}"] = (ip, cntr)
 
     def bwtester_conn_test(self, container, server: str) -> bool:


### PR DESCRIPTION
currently SCION ControlServices (CS) are treated like end hosts by SEED (they are registered under NodeRole.Host).

However this is sub optimal  for at least the following reasons:
- a SCION simulation always requires  at least a CS and border router (BRD) node
 but can make do without a single host (i.e. transit AS)
- a designated 'type'  would ease retrieval/lookup of CS nodes from the registry and facilitate the special treatment it deserves (i.e. branching on node type to select SCION distributables that need to be installed )
- would enable 'assertions' on node type

Accordingly this PR proposes to add a NodeType for CS'es

This was a PR on netsys-lab/seedemu (link to discussion: https://github.com/netsys-lab/seed-emulator/issues/17)