### PR TITLE
CI: Restore MiniInternetTestCase

### DIFF
--- a/tests/SeedEmuTestCase.py
+++ b/tests/SeedEmuTestCase.py
@@ -19,15 +19,15 @@ class SeedEmuTestCase(ut.TestCase):
     container_count_after_up_container: int
     docker_compose_version:int
     online_testing:bool
-    
+
     @classmethod
     def setUpClass(cls, testLogOverwrite:bool=False, online:bool=True) -> None:
         '''!
-        @brief A classmethod to construct the some thing before 
-        this test case is started. For this test case, it will create 
-        a test_log directory, create emulation files, build containers 
+        @brief A classmethod to construct the some thing before
+        this test case is started. For this test case, it will create
+        a test_log directory, create emulation files, build containers
         and up containers.
-        
+
         Parameters
         ----------
         testLogOverwrite : bool, optional
@@ -70,7 +70,7 @@ class SeedEmuTestCase(ut.TestCase):
             cls.up_emulator()
 
         return
-        
+
     @classmethod
     def tearDownClass(cls) -> None:
         '''
@@ -81,16 +81,16 @@ class SeedEmuTestCase(ut.TestCase):
             cls.down_emulator()
 
         return super().tearDownClass()
-    
+
     @classmethod
     def gen_emulation_files(cls):
         """!
         @brief generate emulation files.
         """
         cls.printLog("Generating Emulation Files...")
-        
+
         os.chdir(cls.emulator_code_dir)
-        
+
         log_file = os.path.join(cls.init_dir, cls.test_log, "compile_log")
         f = open(log_file, 'w')
         if os.path.exists(cls.output_dir):
@@ -109,7 +109,7 @@ class SeedEmuTestCase(ut.TestCase):
         """
         cls.printLog("Building Docker Containers...")
         os.chdir(os.path.join(cls.emulator_code_dir, cls.output_dir))
-        
+
         log_file = os.path.join(cls.init_dir, cls.test_log, "build_log")
         f = open(log_file, 'w')
         if(cls.docker_compose_version == 1):
@@ -176,15 +176,15 @@ class SeedEmuTestCase(ut.TestCase):
     @classmethod
     def wait_until_all_containers_up(cls, total_containers:int) -> None:
         """!
-        @brief wait until all containers up before running a testcase. 
+        @brief wait until all containers up before running a testcase.
 
-        @param total_containers a expected total container counts 
+        @param total_containers a expected total container counts
         """
         current_time = time.time()
         while True:
             cls.printLog("--------------------------------------------------")
             cls.printLog("------ Waiting until all containers up : {} ------".format(total_containers))
-            
+
             cls.containers = cls.client.containers.list()
 
             cur_container_count = len(cls.containers) - cls.container_count_before_up_container
@@ -199,7 +199,7 @@ class SeedEmuTestCase(ut.TestCase):
                 return False
             time.sleep(10)
 
-    @classmethod    
+    @classmethod
     def ping_test(cls, container, ip, expected_exit_code=0):
         """!
         @brief test ping 3 times
@@ -215,7 +215,29 @@ class SeedEmuTestCase(ut.TestCase):
         if exit_code == 0: cls.printLog("ping test {} Succeed".format(ip))
         else: cls.printLog("ping test {} Failed".format(ip))
         return exit_code == expected_exit_code
-    
+
+    @classmethod
+    def http_get_test(cls, container, dst, expected_status_code:int = 200) -> bool:
+        """!
+        @brief Send an HTTP GET request with curl.
+
+        @param container Container to send the request
+        @param dst Request destination
+
+        @returns True if the HTTP status code of the response is `expected_status_code`.
+        """
+        ec, output = container.exec_run(f"curl -so /dev/null -w '%{{http_code}}' {dst}")
+        if ec != 0:
+            cls.printLog(f"http GET {dst} test failed: {output.decode()}")
+            return False
+        http_status = int(output.decode())
+        if http_status != expected_status_code:
+            cls.printLog(f"http GET test {dst} failed with HTTP status {http_status}"
+                         f", expected {expected_status_code}")
+            return False
+        cls.printLog(f"http GET {dst} test succeeded")
+        return True
+
     @classmethod
     def get_test_suite(cls):
         """!
@@ -234,7 +256,7 @@ class SeedEmuTestCase(ut.TestCase):
         '''
 
         raise NotImplementedError('getTestSuite not implemented')
-        
+
     @classmethod
     def printLog(cls, *args, **kwargs):
         """!

--- a/tests/internet/mini_internet/MiniInternetTestCase.py
+++ b/tests/internet/mini_internet/MiniInternetTestCase.py
@@ -5,7 +5,7 @@ import unittest as ut
 from tests import SeedEmuTestCase
 
 class MiniInternetTestCase(SeedEmuTestCase):
-    
+
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
@@ -14,8 +14,8 @@ class MiniInternetTestCase(SeedEmuTestCase):
             if "10.150.0.71" in container.name:
                 cls.source_host = container
                 break
-        return 
-        
+        return
+
     def test_internet_connection(self):
         asns = [151, 152, 153, 154, 160, 161, 162, 163, 164, 170, 171]
         for asn in asns:
@@ -34,11 +34,10 @@ class MiniInternetTestCase(SeedEmuTestCase):
         self.printLog("real world as 11872")
         self.printLog("check real world ip : 128.230.18.63")
         # 128.230.18.63 - ip of syr.edu
-        self.assertTrue(self.ping_test(self.source_host, "128.230.18.63"))
+        self.assertTrue(self.http_get_test(self.source_host, "128.230.18.63", 301))
 
     def test_vpn(self):
         return
-    
 
     @classmethod
     def get_test_suite(cls):
@@ -55,4 +54,3 @@ if __name__ == "__main__":
     MiniInternetTestCase.printLog("==========Test=========")
     num, errs, fails = res.testsRun, len(res.errors), len(res.failures)
     MiniInternetTestCase.printLog("score: %d of %d (%d errors, %d failures)" % (num - (errs+fails), num, errs, fails))
-    

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -40,6 +40,9 @@ test_case_list = [
 
 if args.ci:
     test_case_list = [
+        MiniInternetTestCase,
+        IPAnyCastTestCase,
+        HostMgmtTestCase,
         ScionBgpMixedTestCase,
         ScionBwtesterTestCase,
         DottedDictTestCase,


### PR DESCRIPTION
Add MiniInternetTestCase, IPAnyCastTestCase, and HostMgmtTestCase test cases to the CI pipeline.

Replaces the real world AS ping test in MiniInternetTestCase with an HTTP GET test that can get through the firewall of a GitHub action runner.