### PR TITLE
option system framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/output/*
+**/.scion_build_output/*
 **/eth-states*/*
 **/test_log*/*
 **/__pycache__/*

--- a/examples/scion/S02_scion_bgp_mixed/README.md
+++ b/examples/scion/S02_scion_bgp_mixed/README.md
@@ -16,7 +16,7 @@ from seedemu.layers.Scion import LinkType as ScLinkType
 emu = Emulator()
 base = ScionBase()
 # change global defaults here .. .
-routing = ScionRouting(loglevel='error')
+routing = ScionRouting(loglevel=ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME))
 ospf = Ospf()
 scion_isd = ScionIsd()
 scion = Scion()
@@ -26,7 +26,7 @@ ebgp = Ebgp()
 
 In addition to the SCION layers we instantiate the `Ibgp` and `Ebgp` layers for BGP as well as `Ospf` for AS-internal routing.
 Note that the ScionRouting layer accepts global default values for options as constructor parameters.
- We use it here to decrease the loglevel from 'debug' to 'error' for all SCION distributables in the whole emulation if not overriden elsewhere.
+ We use it here to decrease the loglevel from 'debug' to 'error' for all SCION distributables in the whole emulation if not overriden elsewhere. Also we change the mode for `LOGLEVEL` from `BUILD_TIME`(default) to `RUN_TIME` in the same statement.
 ## Step 2: Create isolation domains and internet exchanges
 
 ```python
@@ -92,8 +92,10 @@ This section overrides some global defaults:
 As a result the following `.env` file will be generated next to the `docker-compose.yml` containing all instantiated `RUN_TIME` options:
 ```
 LOGLEVEL_150_BR0=debug
+DISABLE_BFD_150_BRDNODE=true
 SERVE_METRICS_150_BR1=true
-DISABLE_BFD_150=true
+LOGLEVEL_150=info
+LOGLEVEL=error
 ```
 These variables are referenced from the `docker-compose.yml` file:
 
@@ -111,7 +113,7 @@ These variables are referenced from the `docker-compose.yml` file:
             - SERVE_METRICS=${SERVE_METRICS_150_BR1}
             - DISABLE_BFD=${DISABLE_BFD_150_BRDNODE}
 
-    brdnode_150_br3:
+    brdnode_150_br2|3:
         ...
         environment:
             - LOGLEVEL=${LOGLEVEL_150}
@@ -120,6 +122,11 @@ These variables are referenced from the `docker-compose.yml` file:
         ...
         environment:
             - LOGLEVEL=${LOGLEVEL_150}
+
+      brdnode_151_br0:
+        ...
+        environment:
+            - LOGLEVEL=${LOGLEVEL}
 ```
 Note that each service has in its `environment:` section (only) the runtime variables that apply to it (that is: match its ASN, NodeType or NodeIdentity).
 

--- a/examples/scion/S02_scion_bgp_mixed/README.md
+++ b/examples/scion/S02_scion_bgp_mixed/README.md
@@ -5,18 +5,28 @@ Moreover it serves as a demo of how to use the option system.
 
 ## Step 1: Create layers
 
-```python
-from seedemu.compiler import Docker, Graphviz
-from seedemu.core import Emulator, OptionMode
+```pythonfrom seedemu.compiler import Docker, Graphviz
+from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType
 from seedemu.layers import (
-    ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship)
+    ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship,
+    SetupSpecification, CheckoutSpecification)
 from seedemu.layers.Scion import LinkType as ScLinkType
 
 # Initialize
 emu = Emulator()
 base = ScionBase()
 # change global defaults here .. .
-routing = ScionRouting(loglevel=ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME))
+loglvl = ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME)
+
+spec = SetupSpecification.LOCAL_BUILD(
+        CheckoutSpecification(
+            mode = "build",
+            git_repo_url = "https://github.com/scionproto/scion.git",
+            checkout = "v0.12.0" # could be tag, branch or commit-hash
+        ))
+opt_spec = ScionRouting.Option.setup_spec(spec)
+routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec)
+
 ospf = Ospf()
 scion_isd = ScionIsd()
 scion = Scion()
@@ -27,6 +37,8 @@ ebgp = Ebgp()
 In addition to the SCION layers we instantiate the `Ibgp` and `Ebgp` layers for BGP as well as `Ospf` for AS-internal routing.
 Note that the ScionRouting layer accepts global default values for options as constructor parameters.
  We use it here to decrease the loglevel from 'debug' to 'error' for all SCION distributables in the whole emulation if not overriden elsewhere. Also we change the mode for `LOGLEVEL` from `BUILD_TIME`(default) to `RUN_TIME` in the same statement.
+ Lastly we specify (as a global default for all nodes) that we want to use a local build of the `v0.12.0` SCION stack, rather than the 'official' `.deb` packages (`SetupSpecification.PACKAGES`). The SetupSpec is just an ordinary option and be overriden for ASes or individual nodes just like any other.
+
 ## Step 2: Create isolation domains and internet exchanges
 
 ```python

--- a/examples/scion/S02_scion_bgp_mixed/README.md
+++ b/examples/scion/S02_scion_bgp_mixed/README.md
@@ -5,18 +5,18 @@ Moreover it serves as a demo of how to use the option system.
 
 ## Step 1: Create layers
 
-```pythonfrom seedemu.compiler import Docker, Graphviz
-from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType
+```python
+from seedemu.compiler import Docker, Graphviz
+from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType, OptionRegistry
 from seedemu.layers import (
     ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship,
     SetupSpecification, CheckoutSpecification)
 from seedemu.layers.Scion import LinkType as ScLinkType
-
 # Initialize
 emu = Emulator()
 base = ScionBase()
 # change global defaults here .. .
-loglvl = ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME)
+loglvl = OptionRegistry().scion_loglevel('error', mode=OptionMode.RUN_TIME)
 
 spec = SetupSpecification.LOCAL_BUILD(
         CheckoutSpecification(
@@ -24,7 +24,7 @@ spec = SetupSpecification.LOCAL_BUILD(
             git_repo_url = "https://github.com/scionproto/scion.git",
             checkout = "v0.12.0" # could be tag, branch or commit-hash
         ))
-opt_spec = ScionRouting.Option.setup_spec(spec)
+opt_spec = OptionRegistry().scion_setup_spec(spec)
 routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec)
 
 ospf = Ospf()
@@ -84,14 +84,17 @@ AS 150 contains four internal network connected in a ring topology by the four b
 
 #### Step 3.1.1:   Option Settings for ISD-AS 1-150
 ```python
+
 # override global default for AS150
-as150.setOption(ScionRouting.Option.disable_bfd(mode = OptionMode.RUN_TIME),
+as150.setOption(OptionRegistry().scion_loglevel('info', OptionMode.RUN_TIME))
+as150.setOption(OptionRegistry().scion_disable_bfd(mode = OptionMode.RUN_TIME),
                 Scope(ScopeTier.AS,
                       as_id=as150.getAsn(),
                       node_type=ScopeType.BRDNODE))
+
 # override AS settings for individual nodes
-as150_br0.setOption(ScionRouting.Option.loglevel('debug', OptionMode.RUN_TIME))
-as150_br1.setOption(ScionRouting.Option.serve_metrics('true', OptionMode.RUN_TIME))
+as150_br0.setOption(OptionRegistry().scion_loglevel('debug', OptionMode.RUN_TIME))
+as150_br1.setOption(OptionRegistry().scion_serve_metrics('true', OptionMode.RUN_TIME))
 as150_br1.addPortForwarding(30442, 30442)
 ```
 This section overrides some global defaults:

--- a/examples/scion/S02_scion_bgp_mixed/README.md
+++ b/examples/scion/S02_scion_bgp_mixed/README.md
@@ -1,19 +1,22 @@
 # SCION and BGP Coexistence
 
 SCION can operate independently from but alongside BGP. This example demonstrates a more complex topology with both SCION and BGP routing.
+Moreover it serves as a demo of how to use the option system.
 
 ## Step 1: Create layers
 
 ```python
 from seedemu.compiler import Docker, Graphviz
-from seedemu.core import Emulator
+from seedemu.core import Emulator, OptionMode
 from seedemu.layers import (
     ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship)
 from seedemu.layers.Scion import LinkType as ScLinkType
 
+# Initialize
 emu = Emulator()
 base = ScionBase()
-routing = ScionRouting()
+# change global defaults here .. .
+routing = ScionRouting(loglevel='error')
 ospf = Ospf()
 scion_isd = ScionIsd()
 scion = Scion()
@@ -22,7 +25,8 @@ ebgp = Ebgp()
 ```
 
 In addition to the SCION layers we instantiate the `Ibgp` and `Ebgp` layers for BGP as well as `Ospf` for AS-internal routing.
-
+Note that the ScionRouting layer accepts global default values for options as constructor parameters.
+ We use it here to decrease the loglevel from 'debug' to 'error' for all SCION distributables in the whole emulation if not overriden elsewhere.
 ## Step 2: Create isolation domains and internet exchanges
 
 ```python
@@ -40,7 +44,8 @@ We have two ISDs and four internet exchanges this time.
 
 ## Step 3: Create autonomous systems
 
-The topology we create contains the two core ASes 150 and 160. AS 150 is in ISD 1 and AS 160 is in ISD 2. ISD 1 has three additional non-core ASes. In ISD 2 we have one non-core AS.
+The topology we create contains the two core ASes 150 and 160. AS 150 is in ISD 1 and AS 160 is in ISD 2.
+ ISD 1 has three additional non-core ASes. In ISD 2 we have one non-core AS.
 
 ### Step 3.1: Core AS of ISD 1
 
@@ -64,6 +69,59 @@ as150_br3.joinNetwork('net3').joinNetwork('net0').joinNetwork('ix103')
 ```
 
 AS 150 contains four internal network connected in a ring topology by the four border routers br0, br1, br2, and br3. There are two control services cs1 and cs2. We will use br0 to connect to the core of ISD 2 (i.e., AS 160) and the other border routers to connect to customer/child ASes 151, 152, and 153.
+
+#### Step 3.1.1:   Option Settings for ISD-AS 1-150
+```python
+# override global default for AS150
+as150.setOption(ScionRouting.Option.disable_bfd(mode = OptionMode.RUN_TIME),
+                Scope(ScopeTier.AS,
+                      as_id=as150.getAsn(),
+                      node_type=ScopeType.BRDNODE))
+# override AS settings for individual nodes
+as150_br0.setOption(ScionRouting.Option.loglevel('debug', OptionMode.RUN_TIME))
+as150_br1.setOption(ScionRouting.Option.serve_metrics('true', OptionMode.RUN_TIME))
+as150_br1.addPortForwarding(30442, 30442)
+```
+This section overrides some global defaults:
+- DISABLE_BFD option is changed from default BUILD_TIME to RUNTIME_MODE (the value is left at the default: 'true') on all SCION border routers of AS150
+- LOGLEVEL is increased from global default 'error' to 'debug' only for node '150_br0' and the mode set to RUN_TIME
+- SERVE_METRICS option is enabled on node '150_br1'.
+    This node will serve collected Prometheus metrics of the SCION border router distributable on port 30442.
+    If this behaviour is no longer desired it can turned of at RUN_TIME again, without re-compile  and container rebuild
+
+As a result the following `.env` file will be generated next to the `docker-compose.yml` containing all instantiated `RUN_TIME` options:
+```
+LOGLEVEL_150_BR0=debug
+SERVE_METRICS_150_BR1=true
+DISABLE_BFD_150=true
+```
+These variables are referenced from the `docker-compose.yml` file:
+
+```
+    brdnode_150_br0:
+        ...
+        environment:
+            - LOGLEVEL=${LOGLEVEL_150_BR0}
+            - DISABLE_BFD=${DISABLE_BFD_150_BRDNODE}
+
+    brdnode_150_br1:
+        ...
+        environment:
+            - LOGLEVEL=${LOGLEVEL_150}
+            - SERVE_METRICS=${SERVE_METRICS_150_BR1}
+            - DISABLE_BFD=${DISABLE_BFD_150_BRDNODE}
+
+    brdnode_150_br3:
+        ...
+        environment:
+            - LOGLEVEL=${LOGLEVEL_150}
+            - DISABLE_BFD=${DISABLE_BFD_150_BRDNODE}
+    csnode_150_cs1:
+        ...
+        environment:
+            - LOGLEVEL=${LOGLEVEL_150}
+```
+Note that each service has in its `environment:` section (only) the runtime variables that apply to it (that is: match its ASN, NodeType or NodeIdentity).
 
 ### Step 3.2 Non-Core ASes of ISD 1
 

--- a/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
+++ b/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 
 from seedemu.compiler import Docker, Graphviz
-from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType
+from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType, OptionRegistry
 from seedemu.layers import (
     ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship,
     SetupSpecification, CheckoutSpecification)
 from seedemu.layers.Scion import LinkType as ScLinkType
-
 # Initialize
 emu = Emulator()
 base = ScionBase()
 # change global defaults here .. .
-loglvl = ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME)
+loglvl = OptionRegistry().scion_loglevel('error', mode=OptionMode.RUN_TIME)
 
 spec = SetupSpecification.LOCAL_BUILD(
         CheckoutSpecification(
@@ -19,7 +18,7 @@ spec = SetupSpecification.LOCAL_BUILD(
             git_repo_url = "https://github.com/scionproto/scion.git",
             checkout = "v0.12.0" # could be tag, branch or commit-hash
         ))
-opt_spec = ScionRouting.Option.setup_spec(spec)
+opt_spec = OptionRegistry().scion_setup_spec(spec)
 routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec)
 
 ospf = Ospf()
@@ -60,15 +59,15 @@ as150_br2.joinNetwork('net2').joinNetwork('net3').joinNetwork('ix102')
 as150_br3.joinNetwork('net3').joinNetwork('net0').joinNetwork('ix103')
 
 # override global default for AS150
-as150.setOption(ScionRouting.Option.loglevel('info', OptionMode.RUN_TIME))
-as150.setOption(ScionRouting.Option.disable_bfd(mode = OptionMode.RUN_TIME),
+as150.setOption(OptionRegistry().scion_loglevel('info', OptionMode.RUN_TIME))
+as150.setOption(OptionRegistry().scion_disable_bfd(mode = OptionMode.RUN_TIME),
                 Scope(ScopeTier.AS,
                       as_id=as150.getAsn(),
                       node_type=ScopeType.BRDNODE))
 
 # override AS settings for individual nodes
-as150_br0.setOption(ScionRouting.Option.loglevel('debug', OptionMode.RUN_TIME))
-as150_br1.setOption(ScionRouting.Option.serve_metrics('true', OptionMode.RUN_TIME))
+as150_br0.setOption(OptionRegistry().scion_loglevel('debug', OptionMode.RUN_TIME))
+as150_br1.setOption(OptionRegistry().scion_serve_metrics('true', OptionMode.RUN_TIME))
 as150_br1.addPortForwarding(30442, 30442)
 
 # Non-core ASes in ISD 1

--- a/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
+++ b/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
@@ -10,7 +10,8 @@ from seedemu.layers.Scion import LinkType as ScLinkType
 emu = Emulator()
 base = ScionBase()
 # change global defaults here .. .
-routing = ScionRouting(loglevel='error')
+routing = ScionRouting(loglevel=ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME))
+o = ScionRouting.Option('loglevel','trace', OptionMode.RUN_TIME)
 ospf = Ospf()
 scion_isd = ScionIsd()
 scion = Scion()

--- a/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
+++ b/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
@@ -3,15 +3,25 @@
 from seedemu.compiler import Docker, Graphviz
 from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType
 from seedemu.layers import (
-    ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship)
+    ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship,
+    SetupSpecification, CheckoutSpecification)
 from seedemu.layers.Scion import LinkType as ScLinkType
 
 # Initialize
 emu = Emulator()
 base = ScionBase()
 # change global defaults here .. .
-routing = ScionRouting(loglevel=ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME))
-o = ScionRouting.Option('loglevel','trace', OptionMode.RUN_TIME)
+loglvl = ScionRouting.Option.loglevel('error', mode=OptionMode.RUN_TIME)
+
+spec = SetupSpecification.LOCAL_BUILD(
+        CheckoutSpecification(
+            mode = "build",
+            git_repo_url = "https://github.com/scionproto/scion.git",
+            checkout = "v0.12.0" # could be tag, branch or commit-hash
+        ))
+opt_spec = ScionRouting.Option.setup_spec(spec)
+routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec)
+
 ospf = Ospf()
 scion_isd = ScionIsd()
 scion = Scion()

--- a/seedemu/compiler/DistributedDocker.py
+++ b/seedemu/compiler/DistributedDocker.py
@@ -118,8 +118,10 @@ class DistributedDocker(Docker):
                 ), file=open('docker-compose.yml', 'w'))
 
                 self._used_images = set()
-
-                print('COMPOSE_PROJECT_NAME=sim_{}'.format(scope), file=open('.env', 'w'))
+          
+                self._addEnvVar('COMPOSE_PROJECT_NAME',f'sim_{scope}',scope)
+                if scope != 'ix':
+                    self.generateEnvFile(scope, f'./{scope}')
 
             chdir('..')
 

--- a/seedemu/compiler/DistributedDocker.py
+++ b/seedemu/compiler/DistributedDocker.py
@@ -1,4 +1,4 @@
-# Distributed Docker Compiler is not maintained 
+# Distributed Docker Compiler is not maintained
 
 from .Docker import Docker, DockerCompilerFileTemplates
 from seedemu.core import Emulator, ScopedRegistry, Node, Network
@@ -35,9 +35,9 @@ class DistributedDocker(Docker):
     DistributedDocker is one of the compiler driver. It compiles the lab to
     docker containers. This compiler will generate one set of containers with
     their docker-compose.yml for each AS, enable you to run the emulator
-    distributed. 
+    distributed.
 
-    This works by making every IX network overlay network. 
+    This works by making every IX network overlay network.
     """
 
     def __init__(self, namingScheme: str = "as{asn}{role}-{name}-{primaryIp}"):
@@ -118,8 +118,7 @@ class DistributedDocker(Docker):
                 ), file=open('docker-compose.yml', 'w'))
 
                 self._used_images = set()
-          
-                self._addEnvVar('COMPOSE_PROJECT_NAME',f'sim_{scope}',scope)
+
                 if scope != 'ix':
                     self.generateEnvFile(scope, f'./{scope}')
 

--- a/seedemu/compiler/DistributedDocker.py
+++ b/seedemu/compiler/DistributedDocker.py
@@ -120,7 +120,7 @@ class DistributedDocker(Docker):
                 self._used_images = set()
 
                 if scope != 'ix':
-                    self.generateEnvFile(scope, f'./{scope}')
+                    self.generateEnvFile(scope, '')
 
             chdir('..')
 

--- a/seedemu/compiler/Docker.py
+++ b/seedemu/compiler/Docker.py
@@ -1158,13 +1158,13 @@ class Docker(Compiler):
         vars = []
         for o,s in self.__config:
             try:
-                if s < scope:
+                if s < scope or s == scope:
                     sndkey = self._sndary_key(o,s)
                     val = o.value
                     vars.append( f'{sndkey}={val}')
             except:
                 pass
-
+        assert len(vars)==len(self.__config), 'implementation error'
         print( '\n'.join(vars) ,file=open(f'{prefix}.env','w'))
 
     def _makeDummies(self) -> str:

--- a/seedemu/core/Configurable.py
+++ b/seedemu/core/Configurable.py
@@ -1,4 +1,5 @@
 from .Emulator import Emulator
+from typing import List
 
 class Configurable(object):
     """!
@@ -20,3 +21,54 @@ class Configurable(object):
         @param emulator emulator object to use.
         """
         return
+
+# other ideas were: FeatureConfigurable, AdaptiveConfigurable or Tunable
+class DynamicConfigurable(Configurable):
+    """!
+    @brief Dynamically Configurable class.
+
+    @copydetails Configurable
+    Opposed to ordinary static configurables, dynamic ones offer users 
+    to tune values for a set of options/parameters beforehand, 
+    which are then considered during configuration.
+    """
+    def __init__(self):
+        """!
+        @brief create a new Configurable object.
+        """
+        super().__init__()
+        
+    def getAvailableOptions(self) -> List['Option']:
+        """!
+            @brief some configurables (such as Layers) might provide a set of options.
+            @note Options are strong-types which are provided alongside the respective Layer.
+            So the user cannot create just any, but only predefined ones,
+            which you can code against in you Layer impl.
+
+        """
+        return []
+    
+    def _prepare(self, emulator: Emulator):
+        """! @brief establish global default settings
+            @note if users do not override options for individual Customizables
+            such as Nodes or ASes the Layers will resort to global defaults as a fallback.
+            Override this method in your Layer if you want more targeted
+            setting of Options i.e. only on border-routers or hosts etc..
+        """
+        from .Scope import Scope, ScopeTier
+             
+        # set options on nodes directly
+        reg = emulator.getRegistry()
+        all_nodes = [ obj for (scope,typ,name),obj  in reg.getAll( ).items() 
+                      if typ in ['rnode','hnode','csnode','rsnode'] ]
+        for n in all_nodes:
+            for o in self.getAvailableOptions():
+                n.setOption(o, Scope(ScopeTier.Global))
+        
+    
+    def configure(self, emulator: Emulator):
+        
+        self._prepare(emulator)
+         # here the options are needed for decision making..
+        super().configure(emulator)
+        

--- a/seedemu/core/Configurable.py
+++ b/seedemu/core/Configurable.py
@@ -63,6 +63,7 @@ class DynamicConfigurable(Configurable):
                       if typ in ['rnode','hnode','csnode','rsnode'] ]
         for n in all_nodes:
             for o in self.getAvailableOptions():
+                assert o, 'implementation error'
                 n.setOption(o, Scope(ScopeTier.Global))
         
     

--- a/seedemu/core/Customizable.py
+++ b/seedemu/core/Customizable.py
@@ -1,0 +1,164 @@
+from typing import List
+from functools import cmp_to_key
+from typing import Optional, Dict, Tuple
+from seedemu.core.Scope import *
+from seedemu.core.Option import BaseOption, OptionMode
+
+class Customizable(object):
+
+    """!
+    @brief something that can be configured by Options
+    """
+    _config: Dict[str,Tuple[BaseOption,Scope]]
+
+    def __init__(self):  # scope param. actually only for debug/tests  , scope: Scope = None        
+        super().__init__()
+        self._config = {}
+        self._scope = None
+    
+    def scope(self)-> Scope:
+        """!@brief returns a scope that includes only this very customizable instance ,nothing else"""
+        # it's only natural for a customizable to know its place in the hierarchy
+        if not self._scope: return Scope(ScopeTier.Global) # maybe introduce a ScopeTier.NONE for this...
+        else: return self._scope
+            
+
+    def getScopedOption(self, key: str, scope: Scope = None) -> Optional[Tuple[BaseOption, Scope]]:
+        """! @brief retrieves an option along with the most specific Scope in which it was set.
+        """
+        if not scope:  scope = self.scope()
+        
+        if key not in self._config: return None
+        
+        # fetch the most specific option setting to the requested scope
+        for ps in filter(None, Customizable._possible_scopes(scope)):
+            for (opt,s ) in self._config[key]:            
+                try:
+                    # scope has equality-relation on all elements
+                    if s==ps: # exact match for this specific scope
+                        return opt, s
+                    elif ps< s: # but this might not be implemented.. and throw
+                        # return fst test scope that is included in a setting
+                        return opt,s
+
+                except :
+                    pass
+            
+        return None
+
+    def getOption(self, key: str, scope: Scope = None ) -> Optional[BaseOption]:
+        """!@brief Retrieves an option(if set) based on the precedence rules (scoping).
+                If not specified the option value for the scope most specific to 'this' customizable 
+                will be returned.
+                However by explicitly asking for a more general scope, all parent 'handDowns' up to the Global settings
+                can be retrieved from any customizable regardless of its scope.
+            @note actually each layer that provides options should at least provide global defaults.
+            So None will be rare if layer implementation is correct and inherits all settings to all nodes.
+        """
+        optn = self.getScopedOption(key, scope)
+        if optn:
+            return optn[0]
+        else:
+            return None
+
+    def _possible_scopes(scope: Scope) -> List[Scope]:
+        possible_scopes = [
+            Scope(ScopeTier.Node, scope._node_type, 
+                  as_id=scope.asn, node_id=scope._node_id) if scope._node_id and scope._as_id and scope._node_type else None,   # Node-specific + type
+            Scope(ScopeTier.Node,node_id=scope._node_id, as_id=scope._as_id) if scope._node_id and scope._as_id else None,   # Node-specific
+            Scope(ScopeTier.AS, scope._node_type, as_id=scope._as_id) if scope._as_id and scope._node_type else None,   # AS & Type
+            Scope(ScopeTier.AS, ScopeType.ANY, as_id=scope._as_id) if scope._as_id else None,    # AS-wide
+            Scope(ScopeTier.Global, scope._node_type),   # Global & Type
+            Scope(ScopeTier.Global)                     # Global (fallback)
+        ]
+        return possible_scopes
+
+    def _getKeys(self) -> List[str]:
+        
+        return list( self._config.keys())
+        
+    # Tuple[ BaseOption, Scope ]  or List[ScopedOption] where ScopedOption is just a wrapper around Tuple[BaseOption, Scope]
+    def getOptions(self, scope: Scope = None )  -> List[BaseOption]:
+        """! @brief return all options included by the given scope.
+        """
+        return [ self.getOption(k, scope) for k in self._getKeys() ]
+    
+    def getScopedOptions(self, scope: Scope = None )  -> List[Tuple[BaseOption,Scope]]:
+        """! @brief return all options included by the given scope.
+        """
+        return [ self.getScopedOption(k, scope) for k in self._getKeys() ]    
+    
+    # this method confines all the scope-related uglyness and spares us to expose get/setOptions() methods
+    def handDown(self, child: 'Customizable'):
+        """! @brief some Customizables are aggregates and own other Customizables.
+            i.e. ASes are a collection of Nodes.
+            This methods performs the inheritance of options from parent to child.
+        """
+        
+        try: # scopes could be incomparable
+            assert self.scope()>child.scope(), 'logic error - cannot inherit options from more general scopes'
+        except :
+            pass
+
+        for k, val in self._config.items():
+            for (op, s) in val:
+                child.setOption(op, s)
+
+    def setOption(self, op: BaseOption, scope: Scope = None ):
+        """! @brief set option within the given scope.
+            If unspecified the option will be overridden only for "this" Customizable i.e. AS
+        """
+        # TODO should we add a check here, that scope is of same or higher Tier ?!
+        # Everything else would be counterintuitive i.e. setting individual node overrides through the 
+        # API of the AS , rather than the respective node's itself
+
+        if not scope:  scope = self.scope()
+
+        if not op.name in self._config: # fst encounter of this option -> no conflict EASY 
+            self._config[op.name] = [(op,scope)]
+            return
+        else: # conflict / or override for another scope
+
+            # keep the list of (scope, opt-val) sorted  ascending (from narrow to broad) by scope
+                
+            def find_index(lst, key):
+            
+                for i, element in enumerate(lst):
+                    try:
+                        if element == key:
+                            return i
+                    except TypeError:
+                        pass  # Skip elements that are truly incomparable
+                return -1  # Not found
+
+
+            def cmp_snd(a, b):
+                """Custom comparator for sorting based on the second tuple element."""
+                try:
+                    if a[1] < b[1]:
+                        return -1
+                    elif a[1] > b[1]:
+                        return 1
+                    else:
+                        return 0
+                except TypeError:
+                    return 0 
+
+
+            # settings for this scope already exist
+            if (i:=find_index( [s for _,s in self._config[op.name]], scope)) !=-1:
+                # update the option value (change of mind)
+                self._config[op.name][i] = (op,scope)
+            else: # add the setting for the new scope
+                self._config[op.name].append((op,scope))
+                res= sorted(self._config[op.name], key=cmp_to_key(cmp_snd) )
+                            # key=cmp_to_key(Scope.collate),reverse=True)
+                self._config[op.name]  = res
+            
+
+    def getRuntimeOptions(self, scope: Scope = None) -> List[BaseOption]:
+        return [ o for o in self.getOptions(scope) if o.mode==OptionMode.RUN_TIME]
+    
+    def getScopedRuntimeOptions(self, scope: Scope = None) -> List[Tuple[BaseOption,Scope]]:
+        scopts = self.getScopedOptions(scope)
+        return [ (o,s) for o,s in scopts if o.mode==OptionMode.RUN_TIME]

--- a/seedemu/core/Graphable.py
+++ b/seedemu/core/Graphable.py
@@ -271,6 +271,7 @@ class Graphable(Registrable):
         """!
         @brief Graphable constructor.
         """
+        super().__init__()
         self.__graphs = {}
         self.__graphs_created = False
 

--- a/seedemu/core/IsolationDomain.py
+++ b/seedemu/core/IsolationDomain.py
@@ -4,7 +4,7 @@ from typing import Optional
 from .Printable import Printable
 
 
-class IsolationDomain(Printable):
+class IsolationDomain(Printable): #TODO: make Customizable
     """!
     @brief SCION isolation domain.
     """

--- a/seedemu/core/Layer.py
+++ b/seedemu/core/Layer.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from .Printable import Printable
 from .Registry import Registrable
 from .Emulator import Emulator
-from .Configurable import Configurable
+from .Configurable import DynamicConfigurable
 from .Merger import Mergeable
 
 from sys import stderr
 from typing import Set, Dict, Tuple
 
 
-class Layer(Printable, Registrable, Configurable, Mergeable):
+class Layer(Printable, Registrable, DynamicConfigurable, Mergeable):
     """!
     @brief The layer interface.
     """

--- a/seedemu/core/Option.py
+++ b/seedemu/core/Option.py
@@ -1,0 +1,55 @@
+from enum import Flag, auto
+
+class OptionMode(Flag):
+    BUILD_TIME = auto() # static/hardcoded (required re-compile to change)
+    RUN_TIME = auto() # i.e. envsubst (required only docker compose stop/start )
+    
+
+
+class BaseOption:
+    """! a base class for KEY-VALUE pairs representing Settings,Parameters or Feature Flags
+    """
+
+    def __eq__(self, other):
+        if not other: return False
+        
+        if issubclass(other, BaseOption):
+            return self.name==other.name
+        else:
+            raise NotImplementedError
+        
+    @property
+    def name(self) -> str:
+        """Should return the name of the option."""
+        pass
+
+    @property
+    def value(self) -> str:
+        """Should return the value of the option."""
+        pass
+
+    @value.setter
+    def value(self, new_value: str):
+        """Should allow setting a new value."""
+        pass
+
+    @property
+    def mode(self)->OptionMode:
+        """Should return the mode of the option."""
+        pass
+    @mode.setter
+    def mode(self, new_mode: OptionMode):
+        pass
+    
+    # def defaultValue(self)
+    
+    def supportedModes(self)->OptionMode:
+        pass
+    # def __eq__(self, other: Option):
+
+    #TODO: add description(self)->str: here
+
+
+#class ScopedOption:
+# wrapper around List[Tuple[ BaseOption, Scope ] ]
+#  that is an option, that is aware, that it has different values in different scopes

--- a/seedemu/core/Option.py
+++ b/seedemu/core/Option.py
@@ -1,27 +1,110 @@
 from enum import Flag, auto
+from typing import List, Optional, Type, Any
+
+
+
+class AutoRegister():
+    """!@brief metaclass to automatically register
+            option types with the option-registry
+    """
+    def __init_subclass__(cls, **kwargs):
+        """Automatically register all subclasses upon definition."""
+
+        from .OptionRegistry import OptionRegistry
+        super().__init_subclass__(**kwargs)
+        #  Auto-register & create factory method
+        OptionRegistry().register(cls)
+        '''
+        if issubclass(cls, BaseComponent):
+            if (children := cls.components()) != None:
+                for c in children:
+                    OptionRegistry.register(c.name(), cls.name() )
+        '''
+
+# makes @property work with @classmethod
+class ClassProperty:
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, instance, owner):
+        return self.func(owner)
+
+class BaseComponent(): # metaclass=OptionGroupMeta
+    """!@note options implement the 'composite' pattern
+            and can be aggregated into groups/composites.
+            i.e. all options that logically belong to BGP or SCION
+    """
+    @classmethod
+    def prefix(cls) -> Optional[str]:
+        """!@brief prefix of the 'composite' (aggregate of multiple options)
+        """
+        if hasattr(cls, '__prefix'):
+            return cls.__prefix
+        else:
+            return None
+
+    @ClassProperty
+    def name(cls) -> str:
+        return cls.__name__.lower()
+
+    @classmethod
+    def getName(cls) -> str:
+        return cls.__name__.lower()
+
+    @classmethod
+    def components(cls) -> Optional[List['BaseComponent']]:
+        return None
 
 class OptionMode(Flag):
-    BUILD_TIME = auto() # static/hardcoded (required re-compile to change)
-    RUN_TIME = auto() # i.e. envsubst (required only docker compose stop/start )
-    
-
-# TODO: make option values typed ! i.e if option is 'bool' and you try to set it to a 'str' value -> exception
-class BaseOption:
-    """! a base class for KEY-VALUE pairs representing Settings,Parameters or Feature Flags
+    """!@brief characteristics of an option,
+        during which time it might be changed or set
     """
+    # static/hardcoded (require re-compile + image-rebuild to change)
+    BUILD_TIME = auto()
+    # i.e. envsubst (require only docker compose stop/start )
+    RUN_TIME = auto()
+
+
+
+class OptionGroupMeta(type): # or BaseComponentMeta ..
+    """Metaclass to auto-register nested options within a group."""
+
+    def __new__(cls, name, bases, class_dict):
+
+        if name.lower() == 'scionstackopts':
+            name = 'scion'
+
+        from .OptionRegistry import OptionRegistry
+
+        new_cls = super().__new__(cls, name, bases, class_dict)
+        # if (cls == OptionGroupMeta): return new_cls
+        qname = class_dict['__qualname__']
+        if name in ['Option','BaseOption', 'BaseOptionGroup']: return new_cls
+        if BaseComponent in bases or any([ issubclass(b, BaseComponent) for b in bases]):
+            new_cls._children = {}
+
+            # Auto-register (nested) Option classes
+            for attr_name, attr_value in class_dict.items():
+                if issubclass(type(attr_value), OptionGroupMeta):
+                    # prefixed_name = f"{name}_{attr_value.name()}"
+                    # better call new_cls.add() # here
+                    new_cls._children[attr_value.name] = attr_value
+            # don't register nested options twice (but only once as child of the parent 'composite')
+            if '.' not in qname or qname.startswith('SEEDEmuOptionSystemTestCase'):
+                OptionRegistry().register(new_cls)
+        return new_cls
+
+# Actually duplicated with 'Option'
+class BaseOption(BaseComponent, metaclass=OptionGroupMeta):
+    """! a base class for KEY-VALUE pairs representing Settings, Parameters or Feature Flags"""
 
     def __eq__(self, other):
         if not other: return False
-        
+
         if issubclass(other, BaseOption):
             return self.name==other.name
         else:
             raise NotImplementedError
-        
-    @property
-    def name(self) -> str:
-        """Should return the name of the option."""
-        pass
 
     @property
     def value(self) -> str:
@@ -40,16 +123,127 @@ class BaseOption:
     @mode.setter
     def mode(self, new_mode: OptionMode):
         pass
-    
-    # def defaultValue(self)
-    
-    def supportedModes(self)->OptionMode:
+
+    @classmethod
+    def supportedModes(cls) -> OptionMode:
         pass
     # def __eq__(self, other: Option):
 
-    #TODO: add description(self)->str: here
+# simple option
+class Option(BaseOption):
+    """!@brief simple base class for all user defined options.
+
+        @note Rarely should users require any more functionality
+            and be compelled to implement their own option base class.
+    """
+    # Immutable class variable to be defined in subclasses
+    value_type: Type[Any]
+
+    def __init__(self, value: Optional[Any] = None, mode: OptionMode = None):
+        cls = self.__class__
+        key = cls.getName().lower()
+        # TODO: ONLY REGISTRY IS ALLOWED TO INSTANTIATE ME !!
+        import inspect
+        caller_frame = inspect.stack()[1]
+        caller_name = caller_frame.function
+        #if cls.__name__ not in caller_name:
+        if caller_name != 'create_option':
+            raise AssertionError('constructor of Option is private - use the respective OptionRegistry factory method insted')
+
+
+        # Ensure default matches the class-level type
+        if value is not None and not isinstance(value, self.value_type):
+            raise TypeError(f"Expected {self.value_type.__name__} for '{self.name}', got {type(value).__name__}")
+
+        self._mutable_value = value if value != None else cls.default()
+        self._mutable_mode = None
+        if not mode in [ OptionMode.BUILD_TIME, None]:
+            assert mode in self.supportedModes(), f'unsupported mode for option {key.upper()}'
+            self._mutable_mode = mode
+
+    def __repr__(self):
+        return f"Option(key={self.name()}, value={self._mutable_value})"
+
+    @classmethod
+    def getType(cls) -> Type:
+        """return this option's value type"""
+        return cls.value_type
+
+    @property
+    def value(self) -> str:
+        """!@brief get the current value of the setting/parameter
+            represented by this option
+        """
+        if (val := self._mutable_value) != None:
+            return val
+        else:
+            return self.default()
+
+    @classmethod
+    def default(cls):
+        """ default option value if unspecified by user"""
+        return None
+
+    @classmethod
+    def defaultMode(cls):
+        """ default mode if unspecified by user"""
+        return OptionMode.BUILD_TIME
+
+    @value.setter
+    def value(self, new_value: Any):
+        """!@brief Allow updating the option's value.
+            Trying to set of value of type other than this option's value_type
+            throws a TypeError
+        """
+        if not isinstance(new_value, self.value_type):
+            raise TypeError(f"Expected {self.value_type.__name__} for '{self.name}', got {type(new_value).__name__}")
+        assert new_value != None, 'Logic Error - option value cannot be None!'
+        self._mutable_value = new_value
+
+    @property
+    def mode(self):
+        if (mode := self._mutable_mode) != None:
+            return mode
+        else:
+            return self.defaultMode()
+
+    @mode.setter
+    def mode(self, new_mode):
+        self._mutable_mode = new_mode
+
+    @classmethod
+    def description(cls) -> str:
+        """!@brief a short description of what this option is for
+            and its allowed values
+        """
+        return cls.__doc__ or "No documentation available."
 
 
 #class ScopedOption:
 # wrapper around List[Tuple[ BaseOption, Scope ] ]
 #  that is an option, that is aware, that it has different values in different scopes
+
+
+
+
+class BaseOptionGroup(BaseComponent , metaclass=OptionGroupMeta):
+    _children = {}
+
+
+    def describe(self) -> str:
+        return f"OptionGroup {self.__class__.__name__}:\n" + "\n".join(
+            #[f"  - {opt.name}" for opt in self._children]
+            [f"  - {name}" for name,_ in self._children.items()]
+            )
+    '''
+    def add(self, option: BaseComponent):
+        #self._children.append( option )
+        self._children[option.name] = [f"  - {opt.name}" for opt in self._children]
+
+    def get(self, option_name: str) -> Optional[BaseComponent]:
+       return self._children.get(option_name, None)
+    '''
+
+    @classmethod
+    def components(cls):
+        return [v for _, v in cls._children.items()]

--- a/seedemu/core/Option.py
+++ b/seedemu/core/Option.py
@@ -5,7 +5,7 @@ class OptionMode(Flag):
     RUN_TIME = auto() # i.e. envsubst (required only docker compose stop/start )
     
 
-
+# TODO: make option values typed ! i.e if option is 'bool' and you try to set it to a 'str' value -> exception
 class BaseOption:
     """! a base class for KEY-VALUE pairs representing Settings,Parameters or Feature Flags
     """

--- a/seedemu/core/OptionRegistry.py
+++ b/seedemu/core/OptionRegistry.py
@@ -1,0 +1,77 @@
+from typing import Dict, Type
+
+
+class SingletonMeta(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class OptionRegistry(metaclass=SingletonMeta):
+    _options: Dict[str, Type['Option']]  = {}
+
+
+    @classmethod
+    def register(cls, option: Type['BaseComponent'], prefix: str = None):
+        """Registers an option by name and creates a factory method for it."""
+
+        # if issubclass(option, BaseOptionGroup): return ?!
+
+        opt_name = option.__name__
+        if opt_name in ['BaseOption', 'Option', 'BaseComponent', 'BaseOptionGroup'] : return
+        opt_name = opt_name.lower()
+        register_name = opt_name
+        if prefix != None:
+            register_name = f'{prefix}_' + opt_name
+            setattr(option, '__prefix', prefix)
+
+        cls._options[register_name] = option
+
+        if prefix != None: prefix += '_'
+        else: prefix = ''
+        # Dynamically add a factory method to the registry class
+        factory_name = f"{prefix}{opt_name}"
+        if not hasattr(cls, factory_name):
+            setattr(cls, factory_name, lambda *args, **kwargs: cls.create_option(factory_name, *args, **kwargs))
+
+        # also register any children
+        if (components := option.components()) != None:
+            for c in components:
+                cls.register(c, prefix + option.getName().lower())
+
+    @classmethod
+    def create_option(cls, name: str, *args, **kwargs) -> 'Option':
+        """Creates an option instance if it's registered."""
+        option_cls = cls._options.get(name)
+        if not option_cls:
+            raise ValueError(f"Option '{name}' is not registered.")
+        # Instantiate with given arguments
+        return option_cls(*args[1:], **kwargs)
+
+
+    @classmethod
+    def getType(cls, name: str, prefix: str = None) -> Type['BaseComponent']:
+        """Retrieves a registered option type"""
+        if prefix != None:
+            name = prefix + '_' + name
+
+        return cls._options.get(name)
+
+    @classmethod
+    def getOption(cls, name: str, *args, prefix: str = None, **kwargs) -> 'BaseComponent':
+        """Retrieves a registered option instance
+            constructed with the given arguments
+        """
+        if prefix != None:
+            name = prefix + '_' + name
+
+        return cls.create_option(name, args, kwargs)
+
+
+    @classmethod
+    def list_options(cls):
+        """Lists all registered options."""
+        return list(cls._options.keys())

--- a/seedemu/core/OptionRegistry.py
+++ b/seedemu/core/OptionRegistry.py
@@ -68,7 +68,7 @@ class OptionRegistry(metaclass=SingletonMeta):
         if prefix != None:
             name = prefix + '_' + name
 
-        return cls.create_option(name, args, kwargs)
+        return cls.create_option(name, *args, **kwargs)
 
 
     @classmethod

--- a/seedemu/core/ScionAutonomousSystem.py
+++ b/seedemu/core/ScionAutonomousSystem.py
@@ -8,6 +8,7 @@ from .AutonomousSystem import AutonomousSystem
 from .Emulator import Emulator
 from .enums import NodeRole
 from .Node import Node, ScionRouter
+from .Scope import Scope, ScopeTier
 
 class ScionASN:
     """!
@@ -136,7 +137,7 @@ class ScionAutonomousSystem(AutonomousSystem):
     __attributes: Dict[int, Set]         # Set of AS attributes per ISD
     __mtu: Optional[int]                 # Minimum MTU in the AS's internal networks
     __control_services: Dict[str, Node]
-    # Origination, propagation, and registration intervals
+    # Origination, propagation, and registration intervals # TODO: those are clearly all Options ...
     __beaconing_intervals: Tuple[Optional[str], Optional[str], Optional[str]]
     __beaconing_policy: Dict[str, Dict]
     __note: str # optional free form parameter that contains interesting information about AS. This will be included in beacons if it is set
@@ -156,7 +157,9 @@ class ScionAutonomousSystem(AutonomousSystem):
         self.__beaconing_policy = {}
         self.__note = None
         self.__generateStaticInfoConfig = False
-    
+
+    def scope(self)-> Scope:
+        return Scope(ScopeTier.AS, as_id=self.getAsn())
 
     def registerNodes(self, emulator: Emulator):
         """!
@@ -166,6 +169,7 @@ class ScionAutonomousSystem(AutonomousSystem):
         reg = emulator.getRegistry()
         asn = str(self.getAsn())
         for (key, val) in self.__control_services.items(): reg.register(asn, 'csnode', key, val)
+
 
     def configure(self, emulator: Emulator):
         """!
@@ -286,7 +290,7 @@ class ScionAutonomousSystem(AutonomousSystem):
 
             localIP = rnode.getLocalIPAddress()
             listen_addr = localIP if localIP else rnode.getLoopbackAddress()
-            #UDP address on which the router receives SCION packets 
+            #UDP address on which the router receives SCION packets
             # from sibling routers and end hosts in this AS.
             border_routers[rnode.getName()] = {
                 "internal_addr": f"{listen_addr}:30042",
@@ -340,7 +344,7 @@ class ScionAutonomousSystem(AutonomousSystem):
         @returns self
         """
         self.__note = note
-        return self 
+        return self
 
     def getNote(self) -> Optional[str]:
         """!

--- a/seedemu/core/Scope.py
+++ b/seedemu/core/Scope.py
@@ -1,0 +1,496 @@
+from enum import Enum, IntEnum
+from typing import Tuple
+
+
+# could be replaced by @total_order
+class ComparableEnum(Enum):
+    def __lt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value < other.value
+        return NotImplemented
+
+    def __gt__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value > other.value
+        return NotImplemented
+
+    def __le__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value <= other.value
+        return NotImplemented
+
+    def __ge__(self, other):
+        if self.__class__ is other.__class__:
+            return self.value >= other.value
+        return NotImplemented
+
+class ScopeTier(ComparableEnum):
+    """!
+    @brief the domain or extent(kind) of a scope
+    """
+    "global(simulation wide setting for all containers)"
+    Global=3
+    #ISD
+    #"AS level setting(all containers of an AS)"
+    AS=2
+    #"individual node setting(per container)"
+    Node=1
+
+#TODO: we could just use NodeRole itself, but SEED folks are afraid of touching it, so we don't ..
+class ScopeType(IntEnum):
+    """Defines the type of entity affected by the scope."""
+    NONE = 0       # only for checks that intersection is empty
+    ANY = 15       # No specific type -> matches everything 
+    RNODE = 1
+    HNODE = 2
+    CSNODE = 4
+    BRDNODE = 8
+    RSNODE = 16
+    @staticmethod
+    def from_node(node: 'Node'):
+        from .enums import NodeRole
+        
+        match node.getRole():
+            case NodeRole.Host:
+                return ScopeType.HNODE
+            case NodeRole.Router:
+                return ScopeType.RNODE
+            case NodeRole.BorderRouter:
+                return ScopeType.BRDNODE
+            case NodeRole.ControlService:
+                return ScopeType.CSNODE
+            case NodeRole.RouteServer:
+                return ScopeType.RSNODE
+
+
+
+
+
+class Scope:
+    """!
+    @brief strong type for the hierarchical scope of configuration settings.
+            i.e. ''(global/simulation wide), '150' (AS level) or '150_brdnode_br0' (individual node  override)
+    @note Scopes are immutable after construction and serve as a multi-level key or index into a set of options.
+        Scopes implement <> comparison to readily determine when options are overriden by more specific scopes.
+        However they do not form a total order (i.e. ScopeTypes like rnode, hnode within the same AS or Globally cannot be compared )
+        Also Scope does not cater for multihomed ASes where nodes can be in more than one AS at the same time.
+    """
+    
+    # NOTE ISD scope could be added here
+    # TODO: it should be possible to support sets of ASNs and NodeIDs within the same scope object (aggregation)
+    # just as is the case with NodeTypes
+    # But this complicates the code ... It would in fact be easier to disaggregate Type into an ordenary Enum,
+    # at the cost of having to set an Option multiple times, once for each NodeType that is to be included
+    def __init__(self,
+                  tier: ScopeTier,
+                  node_type: ScopeType = ScopeType.ANY,
+                  node_id: str = None,
+                  as_id: int = None):
+        '''
+        Ideally, each AS number should be globally unique 
+        (partly to facilitate the comparison and transition from BGP),
+        but the actual requirement is only that each AS number be unique within an ISD.
+        Since an AS can be part of several ISDs, 
+        picking a globally unique AS number also facilitates joining new ISDs.[TheCompleteGuideToSCION]
+        '''
+        if tier==ScopeTier.AS:
+            assert as_id!=None, 'Invalid Input'
+            assert node_id==None, 'Invalid Input'
+        if tier==ScopeTier.Global:
+            assert node_id==None
+            assert as_id==None
+        if tier==ScopeTier.Node:
+            assert node_id!=None
+            assert as_id!=None
+
+        self._tier = tier
+        self._node_type = node_type
+        self._node_id = node_id  # Only set for per-node scopes
+        self._as_id = as_id  # Only set for per-AS scopes
+    '''
+    def __hash__(self):
+        """Allows Scope instances to be used as dictionary keys."""
+        return hash((self.tier, self.node_type, self.node_id, self.as_id))
+    '''
+    @property
+    def tier(self) -> ScopeTier:
+        return self._tier
+    
+    @property
+    def type(self)-> ScopeType:
+        return self._node_type
+    
+    @property
+    def node(self) -> str:
+        return self._node_id
+    
+    @property
+    def asn(self) -> int:
+        return self._as_id
+
+    def _intersection(self, other: 'Scope') -> 'Scope':
+        """!
+        @brief return a new scope which represents the intersection of both scopes
+        """
+        pass
+
+    def _comparable(self, other: 'Scope') -> Tuple[bool,bool]:
+        """ returns a two bools indicating wheter the scopes are:
+          lt/gt comparable or identical"""
+
+        same_type = True if self.type == other.type else False
+        common_type = self.type & other.type
+        otherTypeInSelf = ( (self.type & other.type) == other.type )
+        selfTypeInOther = ( ( (other.type & self.type)==self.type ) )
+        contained_type = selfTypeInOther or otherTypeInSelf
+        same_type = self.type == other.type
+        same_asn = self.asn == other.asn
+        same_node = same_asn and self.node == other.node # and same_type ?!
+
+        if self.tier==other.tier:
+            match self.tier:
+                case ScopeTier.Global:  # asn, nodeID irrelevant
+                    if same_type:
+                        return False, True
+                    else:
+                        return False, False
+
+                case ScopeTier.AS: # nodeID irrelevant
+                    if same_asn:
+                        if same_type:
+                            return False, True
+                        else:
+                            return False, False
+                    else:
+                        return False, False
+                    
+                case ScopeTier.Node: # type should be irrelevant (i.e. redundant ) here
+                    if same_asn:
+                        if same_node:
+                            return False,True
+                        else:
+                            return False, False
+                    else:
+                        return False, False
+        else:
+            match self.tier:
+                case ScopeTier.Global:
+                    # other.tier must be AS or Node
+                    match other.tier:
+                        case ScopeTier.AS:
+                            if same_type:
+                                # other AS scope is subset of self
+                                return True, False
+                            elif otherTypeInSelf:
+                            # other AS scope is a subset of self
+                                return True, False
+                            else:
+                                # types conflict and prevent inclusion
+                                return False, False
+                        case ScopeTier.Node:
+                            if same_type:
+                                return True, False
+                            elif otherTypeInSelf: 
+                                return True, False
+                            else:
+                                return False, False
+                    
+                case ScopeTier.AS:
+                    
+                    match  other.tier:
+                        case ScopeTier.Global:
+                            if same_type: # self is subset of other
+                                return True, False
+                            elif selfTypeInOther:
+                                return True, False
+                            else:
+                                # both scopes make statements about different types of scopes
+                                return False, False
+                        case ScopeTier.Node:
+                            if same_asn:
+                                if same_type:
+                                    return True, False
+                                elif otherTypeInSelf:
+                                    return True, False
+                                else:
+                                    return False, False
+                            else:
+                                return False, False
+                    
+                case ScopeTier.Node:
+
+                    match other.tier:
+                        case ScopeTier.AS:
+                            if same_asn:
+                                if same_type:
+                                    return True, False
+                                elif selfTypeInOther:
+                                    return True, False
+                                else:
+                                    return False, False
+                            else:
+                                return False, False
+
+                        case ScopeTier.Global:
+                            if same_type:
+                                return True, False
+                            elif selfTypeInOther:
+                                return True, False
+                            else:
+                                return False, False
+                    
+
+    def __eq__(self, other):
+        """Compares two Scope objects for equality."""
+        assert isinstance(other, Scope)
+        _, eq2= self._comparable(other)
+        return eq2
+
+
+    def __gt__(self, other):        
+        """!@brief defines scope hierarchy comparison i.e. broader more general(less specific) > more specific).
+            i.e. LHS supserset RHS
+        """
+        if not isinstance(other, Scope):
+            return NotImplemented
+
+        same_type = True if self.type == other.type else False
+        common_type = self.type & other.type
+        otherTypeInSelf = ( (self.type & other.type) == other.type )
+        selfTypeInOther = ( ( (other.type & self.type)==self.type ) )
+        contained_type = selfTypeInOther or otherTypeInSelf
+        same_type = self.type == other.type
+        same_asn = self.asn == other.asn
+        same_node = same_asn and self.node == other.node # and same_type ?!
+
+        if self.tier==other.tier:
+            match self.tier:
+                case ScopeTier.Global:  # asn, nodeID irrelevant
+                    if same_type:
+                        return False # they are equal not gt
+                    elif otherTypeInSelf:
+                        return True
+                    else:
+                        return NotImplemented
+
+                case ScopeTier.AS: # nodeID irrelevant
+                    if same_asn:
+                        if same_type:
+                            return False # they are equal not gt
+                        elif otherTypeInSelf:
+                            return True
+                        else:
+                            return NotImplemented
+                    else:
+                        # scopes of different ASes are disjoint
+                        return NotImplemented
+                    
+                case ScopeTier.Node: # type should be irrelevant (i.e. redundant ) here
+                    if same_asn:
+                        if same_node:
+                            return False # equal and not gt
+                        else:
+                            return NotImplemented
+                    else:
+                        return NotImplemented
+        else:
+            match self.tier:
+                case ScopeTier.Global:
+                    # other.tier must be AS or Node
+                    match other.tier:
+                        case ScopeTier.AS:
+                            if same_type:
+                                # other AS scope is subset of self (gt)
+                                return True
+                            elif otherTypeInSelf:
+                                # other AS scope is a subset of self (gt)
+                                return True
+                            else:                                
+                                return False
+                        case ScopeTier.Node:
+                            if same_type:
+                                # other is subset of self (gt)
+                                return True
+                            elif otherTypeInSelf: 
+                                # other is subset of self (gt)
+                                return True
+                            else:
+                                return False
+                    
+                case ScopeTier.AS:
+                    
+                    match  other.tier:
+                        case ScopeTier.Global:
+                            
+                                return False
+                        case ScopeTier.Node:
+                            if same_asn:
+                                if same_type:
+                                    return True
+                                elif otherTypeInSelf:
+                                    return True
+                                else:
+                                    return False
+                            else:
+                                return False
+                    
+                case ScopeTier.Node:
+
+                    match other.tier:
+                        case ScopeTier.AS:
+                            
+                            return False
+
+                        case ScopeTier.Global:
+                            return False        
+       
+
+    def lt_old(self, other):
+        if self._tier != other._tier:
+            return self._tier < other._tier  # Higher tier value means broader scope
+        if self._node_type != other._node_type:   # More specific node type wins
+            if   selfTypeInOther := ( ( (other.type & self.type)==self.type ) ):
+                return True
+            else:
+                return False
+        if self._node_id or other._node_id:
+            return bool(self._node_id) and not bool(other._node_id)  # Node scope is most specific
+        return False
+
+    def __lt__(self, other):
+        """!@brie fDefines scope hierarchy comparison (more specific < broader).
+            i.e. LHS subset RHS
+        """
+        if not isinstance(other, Scope):
+            return NotImplemented
+        
+        same_type = True if self.type == other.type else False
+        common_type = self.type & other.type
+        otherTypeInSelf = ( (self.type & other.type) == other.type )
+        selfTypeInOther = ( ( (other.type & self.type)==self.type ) )
+        contained_type = selfTypeInOther or otherTypeInSelf
+        same_type = self.type == other.type
+        same_asn = self.asn == other.asn
+        same_node = same_asn and self.node == other.node # and same_type ?!
+
+        if self.tier==other.tier:
+            match self.tier:
+                case ScopeTier.Global:  # asn, nodeID irrelevant
+                    if same_type:
+                        return False # they are equal not lt
+                    elif selfTypeInOther:
+                        return True
+                    else:
+                        return NotImplemented
+
+                case ScopeTier.AS: # nodeID irrelevant
+                    if same_asn:
+                        if same_type:
+                            return False # they are equal not lt
+                        elif selfTypeInOther:
+                            return True
+                        else:
+                            return NotImplemented
+                    else:
+                        # scopes of different ASes are disjoint
+                        return NotImplemented
+                    
+                case ScopeTier.Node: # type should be irrelevant (i.e. redundant ) here
+                    if same_asn:
+                        if same_node:
+                            return False # equal and not lt
+                        else:
+                            return NotImplemented
+                    else:
+                        return NotImplemented
+        else:
+            match self.tier:
+                case ScopeTier.Global:
+                    # other.tier must be AS or Node
+                    match other.tier:
+                        case ScopeTier.AS:
+                            if same_type:
+                                # other AS scope is subset of self (gt)
+                                return False
+                            elif otherTypeInSelf:
+                                # other AS scope is a subset of self (gt)
+                                return False
+                            else:                                
+                                return False
+                        case ScopeTier.Node:
+                            if same_type:
+                                # other is subset of self (gt)
+                                return False
+                            elif otherTypeInSelf: 
+                                # other is subset of self (gt)
+                                return False
+                            else:
+                                return False
+                    
+                case ScopeTier.AS:
+                    
+                    match  other.tier:
+                        case ScopeTier.Global:
+                            if same_type: # self is subset of other
+                                return True
+                            elif selfTypeInOther:
+                                return True
+                            else:
+                                # both scopes make statements about different types of scopes
+                                return False
+                        case ScopeTier.Node:
+                            if same_asn:
+                                if same_type:
+                                    return False
+                                elif otherTypeInSelf:
+                                    return False
+                                else:
+                                    return False
+                            else:
+                                return False
+                    
+                case ScopeTier.Node:
+
+                    match other.tier:
+                        case ScopeTier.AS:
+                            if same_asn:
+                                if same_type:
+                                    return True
+                                elif selfTypeInOther:
+                                    return True
+                                else:
+                                    return False
+                            else:
+                                return False
+
+                        case ScopeTier.Global:
+                            if same_type:
+                                return True
+                            elif selfTypeInOther:
+                                return True
+                            else:
+                                return False
+
+    def __repr__(self):
+        """String representation for debugging."""
+        details = []
+        if self._as_id is not None:
+            details.append(f"AS={self._as_id}")
+        if self._node_type != ScopeType.ANY:
+            details.append(f"Type={self._node_type.name}")
+        if self._node_id:
+            details.append(f"Node={self._node_id}")
+        return f"Scope({', '.join(details) or 'Global'})"
+    
+    # for use with functools.cmp_to_key( Scope.collate )
+    @staticmethod
+    def collate(a: 'Scope', b: 'Scope') -> int:
+        #c,_= a._comparable(b)
+        try:
+            if a < b:
+                return -1
+            elif b < a:
+                return 1
+        except TypeError:  # This happens if Python encounters NotImplemented in both cases
+            pass
+        return 0  # Fallback: Treat as equal or use another sorting logic

--- a/seedemu/core/Service.py
+++ b/seedemu/core/Service.py
@@ -8,7 +8,7 @@ from .Binding import Binding
 from typing import Dict, List, Set, Tuple
 from .BaseSystem import BaseSystem
 
-class Server(Printable):
+class Server(Printable): #TODO: make Customizable
     """!
     @brief Server class.
 
@@ -91,7 +91,7 @@ class Server(Printable):
     def getHostNames(self):
         return self.__host_names
 
-class Service(Layer):
+class Service(Layer):#TODO: add availableOptions()
     """!
     @brief Service base class.
 

--- a/seedemu/core/__init__.py
+++ b/seedemu/core/__init__.py
@@ -22,4 +22,5 @@ from .RemoteAccessProvider import RemoteAccessProvider
 from .Compiler import Compiler, OptionHandling
 from .BaseSystem import BaseSystem
 from .Scope import *
-from .Option import BaseOption,OptionMode
+from .Option import BaseOption, OptionMode, Option, BaseComponent, BaseOptionGroup, AutoRegister, OptionGroupMeta
+from .OptionRegistry import OptionRegistry

--- a/seedemu/core/__init__.py
+++ b/seedemu/core/__init__.py
@@ -10,7 +10,8 @@ from .Registry import Registry, ScopedRegistry, Registrable
 from .Graphable import Graphable, Graph, Vertex, Edge
 from .Emulator import Emulator
 from .Merger import Mergeable, Merger
-from .Configurable import Configurable
+from .Configurable import Configurable, DynamicConfigurable
+from .Customizable import Customizable
 from .Hook import Hook
 from .Layer import Layer
 from .Service import Server, Service
@@ -18,5 +19,7 @@ from .Binding import Binding, Action
 from .Filter import Filter
 from .Component import Component
 from .RemoteAccessProvider import RemoteAccessProvider
-from .Compiler import Compiler
+from .Compiler import Compiler, OptionHandling
 from .BaseSystem import BaseSystem
+from .Scope import *
+from .Option import BaseOption,OptionMode

--- a/seedemu/layers/Routing.py
+++ b/seedemu/layers/Routing.py
@@ -121,6 +121,7 @@ class Routing(Layer):
                               RoutingFileTemplates['rnode_bird_direct'].format(interfaces = ifaces))
 
     def configure(self, emulator: Emulator):
+        super().configure(emulator)
         reg = emulator.getRegistry()
         for ((scope, type, name), obj) in reg.getAll().items():
             if type == 'rs':

--- a/seedemu/layers/Scion.py
+++ b/seedemu/layers/Scion.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
+import requests
+import logging
+import os
+import re
+from urllib.parse import urlparse
 from enum import Enum
 from typing import Dict, Tuple, Union, Any, Set
 
+from sys import version
 from seedemu.core import (Emulator, Interface, Layer, Network, Registry,
                           Router, ScionAutonomousSystem, ScionRouter,
-                          ScopedRegistry, Graphable)
+                          ScopedRegistry, Graphable, Node)
 from seedemu.core.ScionAutonomousSystem import IA
 from seedemu.layers import ScionBase, ScionIsd
-
+import shutil
+import tempfile
+from seedemu.utilities.BuildtimeDocker import BuildtimeDockerFile, BuildtimeDockerImage, sh
+from enum import Enum
+from dataclasses import dataclass
 
 class LinkType(Enum):
     """!
@@ -54,6 +64,307 @@ class LinkType(Enum):
                 return "PARENT"
 
 
+
+@dataclass
+class CheckoutSpecification():#SetupSpecification
+    """
+    Identifies a specific SCION release version or RepoCheckout
+    """
+    mode: str # 'release' or 'build'
+    release_location: str
+    version: str
+    git_repo_url: str
+    checkout: str
+    
+    # TODO do some more logic >> version and release_location must not be specified independently
+    def __init__(self,
+                  mode: str = None,
+                  release_location: str = None,
+                  version: str = None,
+                  git_repo_url: str = None,
+                  checkout: str = None
+                  ):
+        if not mode:        self.mode = "release"
+        else: self.mode = mode
+        if not release_location:
+            self.release_location = "https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz"
+        else: self.release_location = release_location
+        if not version:
+            self.version = "v0.12.0"
+        else: self.version = version
+        # "mode": "build",
+        if not git_repo_url:
+            self.git_repo_url = "https://github.com/scionproto/scion.git"
+        else: self.git_repo_url = git_repo_url
+        if not checkout:
+            self.checkout = "v0.12.0" # could be tag, branch or commit (ex "efbbd5835f33ab52389976d4b69d68fa7c087230")
+        else: self.checkout = checkout
+
+
+# InstallationPlan, InstallPolicy
+class SetupSpecification(Enum):
+    """! @brief describes how exactly the SCION distributables
+      shall be installed i.e. either from ubuntu-packages or local checkout and build
+    """
+
+    PACKAGES = "UbuntuPackage"
+    LOCAL_BUILD = "Compile from sources" #CheckoutSpecification
+
+    def __call__(self, *args, **kwargs) -> SetupSpecification:#Union[str, CheckoutSpecification]:
+        """
+        Overloads `()` to return the appropriate object based on the enum variant.
+        """
+        if self == SetupSpecification.PACKAGES:
+            return self # "Ubuntu ETHZ .deb package installation"
+        elif self == SetupSpecification.LOCAL_BUILD:
+            if type(args[0]) == CheckoutSpecification:
+                self.checkout_spec = args[0]
+            else:
+                self.checkout_spec = CheckoutSpecification(*args, **kwargs)
+            return self
+        else:
+            raise TypeError(f"Invalid SetupSpecification variant: {self}")
+
+    def describe(method):
+        match method:
+            case SetupSpecification.PACKAGES:
+                return "Installed via Ubuntu ETHZ .deb package"
+            case SetupSpecification.LOCAL_BUILD:
+                return "Local build from source"
+
+# TODO: add the notion of provided capabilities to SetupSpecification
+# some features(options) of the ScionRouting layer
+#  might require a special checkout on the node (>> conditional options )
+# Currently we are unable to detect inadequate checkouts/setups
+# for a given set of options on a node at build time(the emulation will just not work).
+class ScionBuilder():
+    """!
+    @brief A strategy object who knows how to install 
+    the SCION distributables on a Node as instructed by a specification.
+
+    This neatly separates installation and configuration of the SCION stack.
+    The former is the ScionBuilder's job, whereas the latter is up to the ScionRouting layer,
+    which delegates installatation to the builder.
+    The builder is stateless and all configuration state resides on nodes in form of options.
+    Checks the mode property and either downloads the binaries and builds it from source
+    Also supports local absolute directory file path to use instead in release mode
+    """
+
+
+    def __init__(self):
+        pass
+
+    def installSCION(self, node: Node):
+        """!
+        Installs the right SCION stack distributables on the given node based on its role.
+
+        The install is performed as instructed by the nodes SetupSpec option
+        """
+        spec = node.getOption('setup_spec')
+        assert spec != None, 'implementation error - all nodes are supposed to have a SetupSpecification set by ScionRoutingLayer'
+
+        match s:=spec.value:
+            case SetupSpecification.LOCAL_BUILD:
+                self.__installFromBuild(node, s.checkout_spec)
+
+            case SetupSpecification.PACKAGES:
+                self._installFromDebPackage(node)
+
+    def nameOfCmd(self, cmd, node: Node) -> str:
+        spec = node.getOption('setup_spec')
+        assert spec != None, 'implementation error - all nodes are supposed to have a SetupSpecification set by ScionRoutingLayer'
+        assert cmd in ['router', 'control', 'dispatcher', 'daemon'], f'unknown SCION distributable {cmd}'
+        match spec.value:
+            case SetupSpecification.PACKAGES:                 
+                return {'router': 'scion-border-router',
+                        'control': 'scion-control-service',
+                        'dispatcher': 'scion-dispatcher',
+                        'daemon': 'sciond' }[cmd]
+            case SetupSpecification.LOCAL_BUILD:
+                return cmd
+
+    def _installFromDebPackage(self, node: Node): # TODO: don't install  all distributables on all nodes i.e. no BR for hosts etc.
+        """Install SCION packages on the node."""
+        node.addBuildCommand(
+            'echo "deb [trusted=yes] https://packages.netsec.inf.ethz.ch/debian all main"'
+            " > /etc/apt/sources.list.d/scionlab.list"
+        )
+        node.addBuildCommand(
+            "apt-get update && apt-get install -y"
+            " scion-border-router scion-control-service scion-daemon scion-dispatcher scion-tools"
+            " scion-apps-bwtester"
+        )
+        node.addSoftware("apt-transport-https")
+        node.addSoftware("ca-certificates") # by whom are these required exactly ?! only the deb-packages ?!
+        self.installHelpers(node)
+
+    def __installFromBuild(self, node: Node, s: CheckoutSpecification):
+        """
+        validates the specification and if its sensible 
+        does checkout, build and mount into node as volume
+        """
+        self.__validateBuildConfiguration(s)
+        build_dir = self.__generateBuild(s)
+        path_to_binaries = "/bin/scion/" # path in container TODO move to CheckoutSpec ?!
+        node.addSharedFolder(path_to_binaries, build_dir)
+        #node.addBuildCommand("export PATH=$PATH:/bin/scion/") # FIXME
+        node.addDockerCommand(f'ENV PATH={path_to_binaries}:$PATH ')
+        self.installHelpers(node)
+
+    def installHelpers(self, node: Node):
+        #node.addSoftware("apt-transport-https")
+        #node.addSoftware("ca-certificates") # by whom are these required exactly ?! only the deb-packages ?!
+
+        if node.getOption("rotate_logs").value == "true":
+            node.addSoftware("apache2-utils")  # for rotatelogs
+        # TODO actually i had to check if there's any option on this node
+        # which has OptionMode.RUN_TIME set
+        if node.getOption("use_envsubst").value == "true":  # for envsubst
+            node.addSoftware("gettext")
+
+
+
+    def __validateBuildConfiguration(self, config: CheckoutSpecification):
+        """
+        validate build configuration dict by checking all the required keys and url validity
+        """
+        if not config.mode:
+            raise KeyError("No SCION build configuration provided.")
+        if config.mode not in ["release", "build"]: 
+            raise ValueError("Only two SCION build modes accepted. 'release'|'build'")
+        if config.mode == "release":
+            if not config.release_location:
+                raise KeyError("releaseLocation must be set for the mode 'release'")
+            self.__validateReleaseLocation(config.release_location)
+            if not config.version:
+                raise KeyError("version must be set for the mode 'release'")
+        if config.mode == "build":
+            if not config.git_repo_url:
+                raise KeyError("gitRepoUrl must be set for the mode 'build'")
+            if not config.checkout:
+                raise KeyError("'checkout' must be set for the mode 'build'")
+            self.__validateGitURL(config.git_repo_url)
+
+    def __validateReleaseLocation(self, path: str):
+        """
+        check if the local path exists or the url is valid and reachable 
+        """
+        if (path) and self.__is_local_path(path):
+            if not os.path.exists(path):
+                raise ValueError("SCION local binary location is not valid.")
+            if not os.path.isabs(path):
+                raise ValueError("Absolute path required for the folder containing binaries")
+        elif self.__is_http_url(path):
+            try:
+                response = requests.head(path, allow_redirects=True, timeout=5)
+                if not response.status_code < 400:
+                    raise Exception(f"SCION release url is valid but not reachable")
+            except requests.RequestException as e:
+                logging.error(e)
+                raise Exception(f"SCION release url is valid but not reachable")
+        else:
+            raise ValueError("Release location is Neither a valid HTTP URL nor a local path")
+
+    def __is_http_url(self, url: str) -> bool:
+        try:
+            result = urlparse(url)
+            return result.scheme in ("http", "https") and bool(result.netloc)
+        except ValueError:
+            return False
+
+    def __is_local_path(self, path: str) -> bool:
+        # A local path shouldn't be a URL but should exist in the filesystem
+        return not self.__is_http_url(path)
+
+    def __validateGitURL(self, url: str) : 
+        # Ensure the URL ends with .git for Git repositories
+        if not url.endswith(".git"):
+            raise ValueError("URL does not look like a Git repository (missing .git)")
+        # Check the Git info/refs endpoint
+        git_service_url = f"{url}/info/refs?service=git-upload-pack"
+        try:
+            response = requests.get(git_service_url, timeout=10)
+            if not (response.status_code == 200 and "git-upload-pack" in response.text):
+                raise ValueError("SCION build repository not found (404)")
+        except requests.RequestException as e:
+                logging.error(e)
+                raise ValueError(f"Invalid SCION build repository")
+
+    def __classifyGitCheckout(self, checkout: str) -> str:
+        # Check if it's a commit (40 characters, hexadecimal)
+        if re.match(r'^[0-9a-fA-F]{40}$', checkout):
+            return "commit"
+        # Check if it's a tag (can be any string, usually without slashes and more descriptive)
+        if re.match(r'^[\w.-]+$', checkout):
+            return "tag"
+        # Check if it's a branch (can include slashes, dashes, or numbers)
+        if re.match(r'^[\w/.-]+$', checkout):
+            return "branch"
+        
+        return "unknown"
+
+    def __generateGitCloneString(self, repo_url: str, checkout: str) -> str:
+        """
+        Generates a Git clone string for the specified reference (branch, tag, or commit).
+        """
+        checkout_type = self.__classifyGitCheckout(checkout)
+        if checkout_type == "branch":
+            return f"git clone -b {checkout} {repo_url} scion"
+        elif checkout_type == "tag":
+            return f"git clone --branch {checkout} {repo_url} scion"
+        elif checkout_type == "commit":
+            # Clone first, then checkout the commit
+            return f"git clone {repo_url} scion && cd scion && git checkout {checkout}"
+        else:
+            raise ValueError("Invalid reference type. Must be 'branch', 'tag', or 'commit'.")
+
+    def __generateBuild(self, spec: CheckoutSpecification) -> str :
+        """
+        method to build all SCION binaries and output to .scion_build_output based on the configuration mode
+        """
+        if spec.mode == "release":
+            if not self.__is_local_path(spec.release_location):
+                if not os.path.isdir(f".scion_build_output/scion_binaries_{spec.version}"):
+                    SCION_RELEASE_TEMPLATE = f"""FROM alpine 
+                    RUN apk add --no-cache wget tar
+                    WORKDIR /app
+                    RUN wget -qO- {spec.release_location} | tar xvz -C /app
+                    """
+                    dockerfile = BuildtimeDockerFile(SCION_RELEASE_TEMPLATE)
+                    container = BuildtimeDockerImage(f"scion-release-fetch-container_{spec.version}").build(dockerfile).container()
+                    current_dir = os.getcwd()
+                    output_dir = os.path.join(current_dir, f".scion_build_output/scion_binaries_{spec.version}")
+                    container.entrypoint("sh").mountVolume(output_dir, "/build").run(
+                       "-c \"cp -r /app/* /build\""
+                    )
+                    return output_dir
+
+                else:
+                    output_dir = os.path.join(os.getcwd(), f".scion_build_output/scion_binaries_{spec.version}")
+                    return output_dir
+            else:
+                return spec.release_location 
+        else:
+            if not os.path.isdir(f".scion_build_output/scion_binaries_{spec.checkout}"):
+                SCION_BUILD_TEMPLATE = f"""FROM golang:1.22-alpine 
+                RUN apk add --no-cache git
+                RUN {self.__generateGitCloneString(spec.git_repo_url, spec.checkout)}
+                RUN cd scion && go mod tidy && CGO_ENABLED=0 go build -o bin ./router/... ./control/... ./dispatcher/... ./daemon/... ./scion/... ./scion-pki/... ./gateway/...
+                """
+                dockerfile = BuildtimeDockerFile(SCION_BUILD_TEMPLATE)
+                container = BuildtimeDockerImage(f"scion-build-container-{spec.checkout}").build(dockerfile).container()
+                current_dir = os.getcwd()
+                output_dir = os.path.join(current_dir, f".scion_build_output/scion_binaries_{spec.checkout}")
+                container.entrypoint("sh").mountVolume(output_dir, "/build").run(
+                   "-c \"cp -r scion/bin/* /build\""
+                )
+                return output_dir
+
+            else:
+                output_dir = os.path.join(os.getcwd(), f".scion_build_output/scion_binaries_{spec.checkout}")
+                return output_dir
+
+
 class Scion(Layer, Graphable):
     """!
     @brief This layer manages SCION inter-AS links.
@@ -65,6 +376,7 @@ class Scion(Layer, Graphable):
     __links: Dict[Tuple[IA, IA, str, str, LinkType], int]
     __ix_links: Dict[Tuple[int, IA, IA, str, str, LinkType], Dict[str,Any] ]
     __if_ids_by_as = {} # Dict[IA, Set[int]]
+
     def __init__(self):
         """!
         @brief SCION layer constructor.
@@ -138,7 +450,6 @@ class Scion(Layer, Graphable):
         ifs.add(last+1)
         Scion.__if_ids_by_as[ia] = ifs
         return last+1
-        
 
     def addXcLink(self, a: Union[IA, Tuple[int, int]], b: Union[IA, Tuple[int, int]],
                   linkType: LinkType, count: int=1, a_router: str="", b_router: str="",) -> 'Scion':

--- a/seedemu/layers/ScionIsd.py
+++ b/seedemu/layers/ScionIsd.py
@@ -10,7 +10,7 @@ from seedemu.core.ScionAutonomousSystem import IA
 from seedemu.layers import ScionBase
 
 
-class ScionIsd(Layer):
+class ScionIsd(Layer): # could be made a Customizable as well ..
     """!
     @brief SCION AS to ISD relationship layer.
 

--- a/seedemu/layers/ScionRouting.py
+++ b/seedemu/layers/ScionRouting.py
@@ -8,14 +8,31 @@ from geopy.distance import geodesic
 
 import yaml
 
-from seedemu.core import Emulator, Node, ScionAutonomousSystem, ScionRouter, Network, Router
+from seedemu.core import Emulator, Node, ScionAutonomousSystem, ScionRouter, Network, Router, Scope, ScopeTier, BaseOption, OptionMode, Layer
 from seedemu.core.enums import NetworkType
 from seedemu.core.ScionAutonomousSystem import IA
 from seedemu.layers import Routing, ScionBase, ScionIsd
 from seedemu.layers.Scion import Scion
 from seedemu.core.ScionAutonomousSystem import IA
 
-
+valid_keys = {
+    "rotate_logs",
+    "appropriate_digest",
+    "disable_bfd",
+    "experimental_scmp",
+    "loglevel",
+    "serve_metrics",
+    "use_envsubst",
+}
+supported_modes = {
+        'ROTATE_LOGS': OptionMode.BUILD_TIME,
+        'USE_ENVSUBST': OptionMode.BUILD_TIME,
+        'EXPERIMENTAL_SCMP': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
+        'DISABLE_BFD': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
+        'LOGLEVEL': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
+        'SERVE_METRICS': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
+        'APPROPRIATE_DIGEST': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
+    }
 _Templates: Dict[str, str] = {}
 
 _Templates["general"] = """\
@@ -24,7 +41,21 @@ id = "{name}"
 config_dir = "/etc/scion"
 
 [log.console]
-level = "debug"
+level = "{loglevel}"
+"""
+
+_Templates["metrics"] = """
+[metrics]
+prometheus = "{}:{}"
+"""
+
+_Templates["router"]  = """
+[router]
+
+"""
+_Templates["features"] = """
+[features]
+{}
 """
 
 _Templates["trust_db"] = """\
@@ -57,13 +88,25 @@ local_udp_forwarding = true
 
 _CommandTemplates: Dict[str, str] = {}
 
-_CommandTemplates["br"] = "scion-border-router --config /etc/scion/{name}.toml >> /var/log/scion-border-router.log 2>&1"
+_CommandTemplates["br"] = "{cmd} --config /etc/scion/{name}.toml {log}"
+_CommandTemplates["br_envsubst"] = "envsubst < /etc/scion/{name}.toml > /etc/scion/_{name}_.toml && {cmd} --config /etc/scion/_{name}_.toml {log}"
 
-_CommandTemplates["cs"] = "scion-control-service --config /etc/scion/{name}.toml >> /var/log/scion-control-service.log 2>&1"
 
-_CommandTemplates["disp"] = "scion-dispatcher --config /etc/scion/dispatcher.toml >> /var/log/scion-dispatcher.log 2>&1"
+_CommandTemplates["cs_no_disp"] = """\
+{cmd} --config /etc/scion/{name}.toml {log}\
+"""
 
-_CommandTemplates["sciond"] = "sciond --config /etc/scion/sciond.toml >> /var/log/sciond.log 2>&1"
+_CommandTemplates["cs_no_disp_envsubst"] = """\
+envsubst < /etc/scion/{name}.toml > /etc/scion/_{name}_.toml && {cmd} --config /etc/scion/_{name}_.toml {log}\
+"""
+
+_CommandTemplates["disp"] = "{cmd} --config /etc/scion/dispatcher.toml {log}"
+
+_CommandTemplates["sciond"] = "{cmd} --config /etc/scion/sciond.toml {log}"
+
+_CommandTemplates["disp_envsubst"] = "envsubst < /etc/scion/dispatcher.toml > /etc/scion/_dispatcher_.toml && {cmd} --config /etc/scion/_dispatcher_.toml {log}"
+
+_CommandTemplates["sciond_envsubst"] = "envsubst < /etc/scion/sciond.toml > /etc/scion/_sciond_.toml && {cmd} --config /etc/scion/_sciond_.toml {log}"
 
 
 class ScionRouting(Routing):
@@ -77,18 +120,102 @@ class ScionRouting(Routing):
     During layer configuration Router nodes are replaced with ScionRouters which
     add methods for configuring SCION border router interfaces.
     """
+    # this should be a method of the ScionBuildConfig
+    CMDNAMES: Dict[str,str] = {'router': 'scion-border-router',
+                               'control': 'scion-control-service',
+                               'dispatcher': 'scion-dispatcher',
+                               'daemon': 'sciond' }
     _static_routing: bool = True # this might become an Option
+    # global defaults
+    _serve_metrics: bool = False
+    _rotate_logs: bool = False
+    _use_envsubst: bool = True
+    _disable_bfd: bool = True
+    _loglevel: str = 'error'
+    _experimental_scmp: bool = False
+    _appropriate_digest: bool = True
+
+    # TODO: change the signature or add overload Dict[ScopeType, List[BaseOption]]
+    # so that not all options are set on all nodes (who might not need it for anything i.e. Host the DisableBFD option)
+    def getAvailableOptions(self):
+        return [ScionRouting.Option.disable_bfd(),
+                ScionRouting.Option.serve_metrics(),
+                ScionRouting.Option.rotate_logs(),
+                ScionRouting.Option.appropriate_digest(),
+                ScionRouting.Option.experimental_scmp(),
+                ScionRouting.Option.loglevel(),
+                ScionRouting.Option.use_envsubst()]
 
     def __init__(self, loopback_range: str = '10.0.0.0/16',
-                 static_routing: bool = True):
-        """
+                 static_routing: bool = True,
+                 rotate_logs: bool = False,
+                 disable_bfd: bool = True,
+                 use_envsubst:bool = True,
+                 loglevel: str = 'debug',
+                 experimental_scmp: bool = False,
+                 appropriate_digest: bool = True,
+                 serve_metrics: bool = False ):
+        """!
         @param static_routing install and configure BIRD routing daemon only on routers
                 which are connected to more than one local-net (actual intra-domain routers).
                 Can be disabled to have BIRD on all routers, required or not.
+        @param experimental_scmp Enable the DRKey-based authentication of SCMPs in the router,
+          which is experimental and currently incomplete.
+          When enabled, the router inserts the SCION Packet Authenticator Option(SPAO) for SCMP messages.
+          For now, the MAC is computed based on a dummy key, and consequently is not practically useful.
+        @param appropriate_digest Enables the CA module to sign issued certificates
+           with the appropriate digest algorithm instead of always using ECDSAWithSHA512.
+        @param disable_bfd Bidirectional Forwarding Detection (BFD) is a network protocol that is used to detect faults
+          between two forwarding engines connected by a link.[ RFC 5880, RFC 5881]
+          In SCION, BFD is used to determine the liveness of the link between two border routers and trigger SCMP error messages.
+        @param loglevel LogLevel of SCION distributables
+        @param serve_metrics enable collection of Prometheus metrics by SCION distributables
         """
         super().__init__(loopback_range)
-
         ScionRouting._static_routing = static_routing
+        ScionRouting._use_envsubst = use_envsubst
+        ScionRouting._serve_metrics = serve_metrics
+        ScionRouting._experimental_scmp = experimental_scmp
+        ScionRouting._appropriate_digest = appropriate_digest
+        ScionRouting._disable_bfd = disable_bfd
+        ScionRouting._rotate_logs = rotate_logs
+        ScionRouting._loglevel= loglevel
+
+    @staticmethod
+    def _resolveFlag( flag: str , node: Node = None) -> str:
+        """!
+            @brief return the value of the Flag variable on the given node in the given AS
+            Nodes may have overrides of its AS's configuration
+            which is in turn an override of the ScionRouting layer defaults.
+            @note use this method only for config files of SCION distributables and docker-compose.yml file.
+              (it may return '${VAR}' placeholders if 'use_envsubst' is true)
+        """
+
+        if flag not in ['loglevel',
+                        'use_envsubst',
+                        'rotate_logs',
+                        'serve_metrics',
+                        'disable_bfd',
+                        'experimental_scmp',
+                        'appropriate_digest']:
+            raise ValueError( f"invalid argument - flag {flag} unknown to SCION")
+
+        #TODO: maybe add toLowerTOML(default_val: str) -> str checks here
+        # since user can input any garbage as input i.e. "'False'"(capitalized str) or "False" (bool)
+        # when constructing the option, that is not valid toml expected by SCION distributables
+        if node.getOption('use_envsubst').value == 'true' and node.getOption(flag).mode == OptionMode.RUN_TIME:
+            return f'${{{node.getOption(flag).name.upper()}}}'
+        else:
+            return node.getOption(flag).value
+
+    @staticmethod
+    def _nameOfCmd( cmd: str):# TODO delegate to ScionBuildConfig
+        """!
+        @brief the SCION distributables are named differently in the .deb package,
+        than in the actual build
+        """
+        return ScionRouting.CMDNAMES[cmd]
+
 
     def configure_base(self, emulator: Emulator) -> List[Router]:
         """
@@ -106,7 +233,7 @@ class ScionRouting(Routing):
         except:
             pass
         for ((scope, type, name), obj) in reg.getAll().items():
-            
+
             if type == 'rs' :
                 if not has_bgp:
                     raise RuntimeError('SCION has no concept of Route Servers.')
@@ -134,16 +261,15 @@ class ScionRouting(Routing):
                 localnet_count =   list([ ifn.getNet().isDirect() for ifn in r_ifaces ]).count(True)
                 if localnet_count > 1:
                     actual_routers.append(rnode)
-        
-        return actual_routers
-                
 
+        return actual_routers
 
     def configure(self, emulator: Emulator):
         """!
         @brief Install SCION on router, control service and host nodes.
         """
         if ScionRouting._static_routing:
+            Layer.configure(self,emulator)
             # install BIRD routing daemon only where necessary
             bird_routers = self.configure_base(emulator)
             for br in bird_routers:
@@ -153,6 +279,11 @@ class ScionRouting(Routing):
             super().configure(emulator)
         reg = emulator.getRegistry()
         for ((scope, type, name), obj) in reg.getAll().items():
+
+            if type not in ['hnode', 'csnode', 'brdnode']: continue
+            nologrotate = obj.getOption('rotate_logs').value == "false"
+            useenvsubst = obj.getOption('use_envsubst').value == 'true'
+
             # SCION inter-domain routing affects only border-routers
             if type == 'brdnode':
                 rnode: ScionRouter = obj
@@ -161,22 +292,42 @@ class ScionRouting(Routing):
                     rnode.initScionRouter()
 
                 self.__install_scion(rnode)
-                name = rnode.getName()
-                rnode.appendStartCommand(_CommandTemplates['br'].format(name=name), fork=True)
+                br_log = (">> /var/log/scion-border-router.log 2>&1"
+                           if nologrotate
+                           else "2>&1 | rotatelogs -n 2 /var/log/scion-border-router.log 1M ")
+                router_start_cmd=""
+                if useenvsubst:
+                    router_start_cmd=_CommandTemplates['br_envsubst'].format(name=name,
+                                                                             cmd=ScionRouting._nameOfCmd('router'),
+                                                                             log=br_log)
+                else:
+                    router_start_cmd=_CommandTemplates['br'].format(name=name,
+                                                                    cmd=ScionRouting._nameOfCmd('router'),
+                                                                    log=br_log)
+                rnode.appendStartCommand(router_start_cmd, fork=True)
+
+
 
             elif type == 'csnode':
                 csnode: Node = obj
                 self.__install_scion(csnode)
                 self.__append_scion_command(csnode)
                 name = csnode.getName()
-                csnode.appendStartCommand(_CommandTemplates['cs'].format(name=name), fork=True)
+                ctrl_log = (">> /var/log/scion-control-service.log 2>&1"
+                            if nologrotate
+                            else " 2>&1 | rotatelogs -n 2 /var/log/scion-control-service.log 1M ")
+                cs_tmpl='cs_no_disp' + ("_envsubst" if useenvsubst else '')
+                csnode.appendStartCommand(_CommandTemplates[cs_tmpl].format(name=name,
+                                                                            cmd=ScionRouting._nameOfCmd('control'),
+                                                                            log=ctrl_log),
+                                                                            fork=True)
 
             elif type == 'hnode':
                 hnode: Node = obj
                 self.__install_scion(hnode)
                 self.__append_scion_command(hnode)
 
-    def __install_scion(self, node: Node):
+    def __install_scion(self, node: Node): #TODO: delegate to ScionBuildConfig
         """Install SCION packages on the node."""
         node.addBuildCommand(
             'echo "deb [trusted=yes] https://packages.netsec.inf.ethz.ch/debian all main"'
@@ -187,11 +338,27 @@ class ScionRouting(Routing):
             " scion-apps-bwtester")
         node.addSoftware("apt-transport-https")
         node.addSoftware("ca-certificates")
+        if node.getOption('rotate_logs').value=="true":
+            node.addSoftware('apache2-utils') # for rotatelogs
+        # TODO actually i had to check if there's any option on this node
+        # which has OptionMode.RUN_TIME set
+        if node.getOption('use_envsubst').value=='true': # for envsubst
+            node.addSoftware('gettext')
 
     def __append_scion_command(self, node: Node):
         """Append commands for starting the SCION host stack on the node."""
-        node.appendStartCommand(_CommandTemplates["disp"], fork=True)
-        node.appendStartCommand(_CommandTemplates["sciond"], fork=True)
+        nologrotate = node.getOption('rotate_logs').value == "false"
+        useenvsubst = node.getOption('use_envsubst').value == 'true'
+
+        disp_log = (">> /var/log/scion-dispatcher.log 2>&1"
+                     if nologrotate
+                     else "2>&1 |  rotatelogs -n 2 /var/log/scion-dispatcher.log 1M ")
+        node.appendStartCommand(_CommandTemplates["disp" + ("_envsubst" if useenvsubst else '')]
+                                .format(cmd=ScionRouting._nameOfCmd('dispatcher'),log = disp_log ), fork=True)
+
+        sciond_log = ">> /var/log/sciond.log 2>&1" if nologrotate else " 2>&1 | rotatelogs -n 2 /var/log/sciond.log 1M "
+        node.appendStartCommand(_CommandTemplates["sciond"+ ("_envsubst" if useenvsubst else '')]
+                                .format(cmd=ScionRouting._nameOfCmd('daemon'),log=sciond_log), fork=True)
 
     def render(self, emulator: Emulator):
         """!
@@ -208,7 +375,7 @@ class ScionRouting(Routing):
         for ((scope, type, name), obj) in reg.getAll().items():
             if type in ['brdnode', 'csnode', 'hnode']:
                 node: Node = obj
-                asn = obj.getAsn()                
+                asn = obj.getAsn()
                 as_: ScionAutonomousSystem = base_layer.getAutonomousSystem(asn)
                 isds = isd_layer.getAsIsds(asn)
                 assert len(isds) == 1, f"AS {hex(asn)} must be a member of exactly one ISD"
@@ -217,11 +384,11 @@ class ScionRouting(Routing):
                 as_topology = as_.getTopology(isds[0][0])
                 node.setFile("/etc/scion/topology.json", json.dumps(as_topology, indent=2))
 
-                self._provision_base_config(node, as_)
+                self._provision_base_config(node)
 
             if type == 'brdnode':
                 rnode: ScionRouter = obj
-                self._provision_router_config(rnode, as_)
+                self._provision_router_config(rnode)
             elif type == 'csnode':
                 csnode: Node = obj
                 self._provision_cs_config(csnode, as_)
@@ -232,46 +399,69 @@ class ScionRouting(Routing):
                 hnode: Node = obj
                 self.__provision_dispatcher_config(hnode, isds[0][0], as_)
 
-    def _provision_base_config(self, node: Node, _as: 'AutonomousSystem'):
+    @staticmethod
+    def _provision_base_config(node: Node):
         """Set configuration for sciond and dispatcher."""
 
         node.addBuildCommand("mkdir -p /cache")
 
-        node.setFile("/etc/scion/sciond.toml",
-            _Templates["general"].format(name="sd1") +
-            _Templates["trust_db"].format(name="sd1") +
-            _Templates["path_db"].format(name="sd1"))
-    
+        lvl = ScionRouting._resolveFlag('loglevel',node)
+        sciond_conf = (_Templates["general"].format(name="sd1",
+                                         loglevel=lvl)
+        +             _Templates["trust_db"].format(name="sd1")
+        +             _Templates["path_db"].format(name="sd1"))
+        if node.getOption('serve_metrics').value=='true':
+            sciond_conf += _Templates["metrics"].format(node.getLocalIPAddress(), 30455)
+        # No [features] for daemon
+        node.setFile("/etc/scion/sciond.toml", sciond_conf)
+
     @staticmethod
     def __provision_dispatcher_config(node: Node, isd: int, as_: ScionAutonomousSystem):
         """Set dispatcher configuration on host and cs nodes."""
 
         isd_as = f"{IA(isd, as_.getScionAsn())}"
-        
+
         ip = None
         ifaces = node.getInterfaces()
         if len(ifaces) < 1:
             raise ValueError(f"Node {node.getName()} has no interfaces")
-        net = ifaces[0].getNet()                    
+        net = ifaces[0].getNet()
         control_services = as_.getControlServices()
         for cs in control_services:
             cs_iface = as_.getControlService(cs).getInterfaces()[0]
             if cs_iface.getNet() == net:
                 ip = cs_iface.getAddress()
-                break        
+                break
         if ip is None:
             raise ValueError(f"Node {node.getName()} has no interface in the control service network")
-        
-        node.setFile("/etc/scion/dispatcher.toml", _Templates["dispatcher"].format(isd_as=isd_as, ip=ip))
+
+        dispatcher_conf = _Templates["dispatcher"].format(isd_as=isd_as, ip=ip)
+        if node.getOption('serve_metrics').value == 'true':
+            dispatcher_conf += _Templates["metrics"].format(node.getLocalIPAddress(), 30441)
+        node.setFile("/etc/scion/dispatcher.toml", dispatcher_conf )
 
     @staticmethod
-    def _provision_router_config(router: ScionRouter, _as: 'AutonomousSystem'):
+    def _provision_router_config(router: ScionRouter):
         """Set border router configuration on router nodes."""
 
         name = router.getName()
-        router.setFile(os.path.join("/etc/scion/", name + ".toml"),
-            _Templates["general"].format(name=name))
-    
+        config_content = _Templates["general"].format(name=name,
+                                                      loglevel=ScionRouting._resolveFlag('loglevel', router))
+
+        _keyvals_router = [ "bfd.disable={}".format(ScionRouting._resolveFlag('disable_bfd', router)) ]
+        _kvals_features = [
+            f"experimental_scmp_authentication={ScionRouting._resolveFlag('experimental_scmp', router)}" ]
+
+        config_content += _Templates["router"] +'\n'+ '\n'.join(_keyvals_router) + '\n'
+        if len(_kvals_features) > 0:
+            config_content += _Templates['features'].format('\n'.join(_kvals_features) )
+
+
+        if router.getOption('serve_metrics').value == 'true' and (local_ip:=router.getLocalIPAddress()) != None:
+            config_content += _Templates["metrics"].format(local_ip, 30442)
+
+        router.setFile(os.path.join("/etc/scion/", name + ".toml"), config_content)
+
     @staticmethod
     def _get_networks_from_router(router1 : str, router2 : str, as_ : ScionAutonomousSystem) -> list[Network]:
         """
@@ -291,7 +481,7 @@ class ScionRouting(Routing):
             return joint_nets[0]
         except:
             raise Exception(f"No common network between {router1} and {router2} but they are in the same AS")
-    
+
     @staticmethod
     def _get_BR_from_interface(interface : int, as_ : ScionAutonomousSystem) -> str:
         """
@@ -309,7 +499,7 @@ class ScionRouting(Routing):
         """
 
         this_br_name = ScionRouting._get_BR_from_interface(interface, as_)
-        
+
         ifs = {
             "Latency": {},
             "Bandwidth": {},
@@ -359,8 +549,8 @@ class ScionRouting(Routing):
                         ifs["packetDrop"][str(other_if)] =  f"{packetDrop}"
                         ifs["MTU"][str(other_if)] =  f"{net.getMtu()}"
                         ifs["Hops"][str(other_if)] =  1 # NOTE: if interface is on different router, hops is 1 since we assume all routers are connected through a network
-        
-        
+
+
         return ifs
 
     @staticmethod
@@ -375,11 +565,11 @@ class ScionRouting(Routing):
 
         xcs = this_br.getCrossConnects()
 
-        for xc in xcs:  
+        for xc in xcs:
             (xc_if,_,linkprops) = xcs[xc]
             if if_addr == str(xc_if.ip):
                 return linkprops
-                    
+
     @staticmethod
     def _get_ix_link_properties(interface : int, as_ : ScionAutonomousSystem) -> Tuple[int, int, float, int]:
         """
@@ -389,11 +579,11 @@ class ScionRouting(Routing):
         this_br = as_.getRouter(this_br_name)
 
         if_addr = IPv4Address(this_br.getScionInterface(interface)['underlay']["local"].split(':')[0])
-        
+
         # get a list of all ix networks this Border Router is attached to
         ixs = [ifa.getNet() for ifa in this_br.getInterfaces() if ifa.getNet().getType() == NetworkType.InternetExchange]
 
-        for ix in ixs:  
+        for ix in ixs:
             ix.getPrefix()
             if if_addr in ix.getPrefix():
                 lat,bw,pd = ix.getDefaultLinkProperties()
@@ -426,7 +616,7 @@ class ScionRouting(Routing):
                 lat,bw,pd,mtu = xc_linkprops
             else: # interface is not part of a cross connect thus it must be in an internet exchange
                 lat,bw,pd,mtu = ScionRouting._get_ix_link_properties(interface, as_)
-            
+
 
             # Add Latency
             if not staticInfo["Latency"] or str(interface) not in staticInfo["Latency"]: # if no latencies have been added yet empty dict
@@ -446,9 +636,9 @@ class ScionRouting(Routing):
                         staticInfo["Latency"][str(interface)]["Intra"][str(_if)] = dur
                     else:
                         raise ValueError("scion distributables can't parse floating point durations: pkg/private/util/duration.go")
-            
-            
-            
+
+
+
             # Add Bandwidth
             if bw != 0: # if bandwidth is not 0, add it
                 if not staticInfo["Bandwidth"]: # if no bandwidths have been added yet empty dict
@@ -459,12 +649,12 @@ class ScionRouting(Routing):
 
             # Add LinkType
             staticInfo["LinkType"][str(interface)] = "direct" # NOTE: for now all ASes are connected through CrossConnects which are docker Nets under the hood and thus direct
-             
+
             # Add Geo
             if ifs["Geo"]:
                 staticInfo["Geo"][str(interface)] = ifs["Geo"]
 
-            # Add Hops 
+            # Add Hops
             staticInfo["Hops"][str(interface)] = {
                 "Intra": ifs["Hops"],
             }
@@ -472,7 +662,7 @@ class ScionRouting(Routing):
         # Add Note if exists
         if as_.getNote():
             staticInfo["Note"] = as_.getNote()
-        
+
         # Set file
         node.setFile("/etc/scion/staticInfoConfig.json", json.dumps(staticInfo, indent=2))
 
@@ -498,9 +688,103 @@ class ScionRouting(Routing):
 
         # Concatenate configuration sections
         name = node.getName()
-        node.setFile(os.path.join("/etc/scion/", name + ".toml"),
-            _Templates["general"].format(name=name) +
-            _Templates["trust_db"].format(name=name) +
-            _Templates["beacon_db"].format(name=name) +
-            _Templates["path_db"].format(name=name) +
-            "\n".join(beaconing))
+        _features =[ f"experimental_scmp_authentication={ScionRouting._resolveFlag('experimental_scmp', node)}",
+                     f"appropriate_digest_algorithm={ScionRouting._resolveFlag('appropriate_digest', node)}"
+                   ]
+        cs_config = (_Templates["general"].format(name=name,
+                        loglevel=ScionRouting._resolveFlag('loglevel', node))
+        +  _Templates["trust_db"].format(name=name)
+        +  _Templates["beacon_db"].format(name=name)
+        +  _Templates["path_db"].format(name=name)
+        +  _Templates['features'].format('\n'.join(_features))
+        )
+        if node.getOption('serve_metrics').value == 'true':
+            cs_config += _Templates["metrics"].format(node.getLocalIPAddress(), 30452)
+        cs_config += "\n".join(beaconing)
+        node.setFile(os.path.join("/etc/scion/", name + ".toml"), cs_config)
+
+    class Option(BaseOption):
+        # TODO: add CS tracing
+        # TODO: add dispatchable port range
+        ROTATE_LOGS = "rotate_logs"
+        USE_ENVSUBST = "use_envsubst"
+        EXPERIMENTAL_SCMP = 'experimental_scmp'
+        DISABLE_BFD = 'disable_bfd'
+        LOGLEVEL = 'loglevel'
+        SERVE_METRICS = 'serve_metrics'
+        APPROPRIATE_DIGEST = 'appropriate_digest'
+
+        def __init__(self, key, value, mode: OptionMode = OptionMode.BUILD_TIME):
+            import inspect
+            caller_frame = inspect.stack()[1]
+            caller_name = caller_frame.function
+            assert caller_name in valid_keys or caller_name == 'getAvailableOptions', 'constructor of ScionRouting.Option is private'
+            self._key = key
+            if value == None:
+                value = ScionRouting.Option.defaultValue(caller_name)
+            self._mutable_value = value  # Separate mutable storage
+            self._mutable_mode = None
+            if mode != OptionMode.BUILD_TIME:
+                assert mode in self.supportedModes(), f'unsupported mode for option {key.upper()}'
+            self._mutable_mode = mode
+
+        @property
+        def name(self) -> str:
+            return self._key
+
+        @property
+        def value(self) -> str:
+            return self._mutable_value
+
+        @value.setter
+        def value(self, new_value: str):
+            """Allow updating the value attribute."""
+            self._mutable_value = new_value
+
+        @property
+        def mode(self):
+            return self._mutable_mode
+        @mode.setter
+        def mode(self, new_mode):
+            self._mutable_mode = new_mode
+
+        def supportedModes(self) -> OptionMode:
+            return self._mutable_mode if self._mutable_mode != None else  supported_modes[self._key.upper()]
+
+        @staticmethod
+        def defaultValue( key: str ) -> str:
+            match key.upper():
+                case "ROTATE_LOGS": return str(ScionRouting._rotate_logs).lower()
+                case "APPROPRIATE_DIGEST": return str(ScionRouting._appropriate_digest).lower()
+                case "DISABLE_BFD": return str(ScionRouting._disable_bfd).lower()
+                case "EXPERIMENTAL_SCMP": return str(ScionRouting._experimental_scmp).lower()
+                case "LOGLEVEL": return ScionRouting._loglevel
+                case "SERVE_METRICS": return str(ScionRouting._serve_metrics).lower()
+                case "USE_ENVSUBST": return str(ScionRouting._use_envsubst).lower()
+                case _:
+                    assert False , f'unknown option for ScionRouting Layer: {key}'
+
+        @classmethod
+        def disable_bfd(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('disable_bfd', value, mode)
+        @classmethod
+        def loglevel(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('loglevel', value, mode)
+        @classmethod
+        def serve_metrics(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('serve_metrics', value, mode)
+        @classmethod
+        def appropriate_digest(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('appropriate_digest', value, mode)
+        @classmethod
+        def experimental_scmp(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('experimental_scmp', value, mode)
+        @classmethod
+        def rotate_logs(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('rotate_logs', value, mode)
+        @classmethod
+        def use_envsubst(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
+            return cls('use_envsubst', value, mode)
+
+        def __repr__(self):
+            return f"Option(key={self._key}, value={self._mutable_value})"

--- a/seedemu/layers/ScionRouting.py
+++ b/seedemu/layers/ScionRouting.py
@@ -9,33 +9,118 @@ from geopy.distance import geodesic
 import yaml
 import inspect
 
-from seedemu.core import Emulator, Node, ScionAutonomousSystem, ScionRouter, Network, Router, Scope, ScopeTier, BaseOption, OptionMode, Layer
+from seedemu.core import Emulator, Node, ScionAutonomousSystem, ScionRouter, Network, Router, BaseOption, BaseOptionGroup, OptionMode, Layer, Option
 from seedemu.core.enums import NetworkType
 from seedemu.core.ScionAutonomousSystem import IA
 from seedemu.layers import Routing, ScionBase, ScionIsd
 from seedemu.layers.Scion import Scion, ScionBuilder, SetupSpecification, CheckoutSpecification
 from seedemu.core.ScionAutonomousSystem import IA
 
-valid_keys = {
-    "rotate_logs",
-    "appropriate_digest",
-    "disable_bfd",
-    "experimental_scmp",
-    "loglevel",
-    "serve_metrics",
-    "setup_spec",
-    "use_envsubst",
-}
-supported_modes = {
-        'ROTATE_LOGS': OptionMode.BUILD_TIME,
-        'USE_ENVSUBST': OptionMode.BUILD_TIME,
-        'EXPERIMENTAL_SCMP': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
-        'DISABLE_BFD': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
-        'LOGLEVEL': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
-        'SERVE_METRICS': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
-        'APPROPRIATE_DIGEST': OptionMode.BUILD_TIME | OptionMode.RUN_TIME,
-        'SETUP_SPEC': OptionMode.BUILD_TIME
-    }
+
+class ScionStackOpts(BaseOptionGroup):
+# NOTE: the classname is dynamically changed to just 'scion' so the
+# nested option names don't become too lengthy...
+
+    # TODO: add CS tracing
+    # TODO: add dispatchable port range
+    # make installation of test-tools optional (bwtester etc.)
+
+    class ROTATE_LOGS(Option):
+        """prevent excessive growth of log files for longer running simulations
+        by rotating log files """
+        value_type = str
+        @classmethod
+        def supportedModes(cls) -> OptionMode:
+            return OptionMode.BUILD_TIME
+        @classmethod
+        def default(cls):
+            return "false"
+
+    class APPROPRIATE_DIGEST(Option):
+        """ Enables the CA module to sign issued certificates
+           with the appropriate digest algorithm instead of always using ECDSAWithSHA512."""
+        value_type = str
+        @classmethod
+        def supportedModes() -> OptionMode:
+            return OptionMode.BUILD_TIME | OptionMode.RUN_TIME
+        @classmethod
+        def default(cls):
+            return "true"
+
+    class DISABLE_BFD(Option):
+        """Bidirectional Forwarding Detection (BFD) is a network protocol that is used to detect faults
+          between two forwarding engines connected by a link.[ RFC 5880, RFC 5881]
+          In SCION, BFD is used to determine the liveness of the link
+          between two border routers and trigger SCMP error messages."""
+        value_type = str
+        @classmethod
+        def supportedModes(self) -> OptionMode:
+            return  OptionMode.BUILD_TIME | OptionMode.RUN_TIME
+        @classmethod
+        def default(cls):
+            return "true"
+
+    class EXPERIMENTAL_SCMP(Option):
+        """Enable the DRKey-based authentication of SCMPs in the router,
+          which is experimental and currently incomplete.
+          When enabled, the router inserts the SCION Packet Authenticator Option(SPAO) for SCMP messages.
+          For now, the MAC is computed based on a dummy key, and consequently is not practically useful."""
+        value_type = str
+        @classmethod
+        def supportedModes(cls) -> OptionMode:
+            return OptionMode.BUILD_TIME | OptionMode.RUN_TIME
+        @classmethod
+        def default(cls):
+            return "false"
+
+    class LOGLEVEL(Option): # TODO allow different values per distributable
+        """loglevel of the SCION distributables"""
+        value_type = str
+        @classmethod
+        def supportedModes(cls) -> OptionMode:
+            return OptionMode.BUILD_TIME | OptionMode.RUN_TIME
+        @classmethod
+        def default(cls):
+            return "error"
+
+    class SERVE_METRICS(Option): # TODO allow setting per distributable
+        """enable collection of Prometheus metrics by SCION distributables"""
+        value_type = str
+        @classmethod
+        def supportedModes(cls) -> OptionMode:
+            return OptionMode.BUILD_TIME | OptionMode.RUN_TIME
+        @classmethod
+        def default(cls):
+            return "false"
+
+    # FIXME: what to do about this ?! actually it can be derived from OptionModes of all available options
+    # If any of them has RUN_TIME mode -> this implies USE_ENVSUBST==True
+    class USE_ENVSUBST(Option):
+        """wheter to pipe the config files of SCION distributables
+        through envsubst before passing to application.
+        This allows for dynamic configuration / substitution of ENV variables in the config.
+        """
+        value_type = str
+        @classmethod
+        def supportedModes(cls) -> OptionMode:
+            return OptionMode.BUILD_TIME
+        @classmethod
+        def default(cls):
+            return "true"
+
+    class SETUP_SPEC(Option):
+        """ which SCION stack to deploy in the simulation """
+        value_type = SetupSpecification
+        @classmethod
+        def supportedModes(cls) -> OptionMode:
+            return OptionMode.BUILD_TIME
+        @classmethod
+        def default(cls):
+            return SetupSpecification.LOCAL_BUILD(CheckoutSpecification())
+
+
+# -------------------------------------------------------------------
+
 _Templates: Dict[str, str] = {}
 
 _Templates["general"] = """\
@@ -129,28 +214,15 @@ class ScionRouting(Routing):
     # which depend on the dispatcher socket
     __default_builder: ScionBuilder
     _static_routing: bool = True # this might become an Option
-    # global defaults
-    _serve_metrics: BaseOption = None
-    _rotate_logs: BaseOption = None
-    _use_envsubst: BaseOption = None
-    _disable_bfd: BaseOption = None
-    _loglevel: BaseOption = None
-    _experimental_scmp: BaseOption = None
-    _appropriate_digest: BaseOption = None
-    _setup_spec: BaseOption = None
 
     # TODO: change the signature or add overload Dict[ScopeType, List[BaseOption]]
     # so that not all options are set on all nodes (who might not need it for anything i.e. Host the DisableBFD option)
     # >> Maybe include 'NodeType that the option applies to' into the Option itself
     def getAvailableOptions(self):
-        return [ScionRouting._disable_bfd,
-                ScionRouting._serve_metrics,
-                ScionRouting._rotate_logs,
-                ScionRouting._appropriate_digest,
-                ScionRouting._experimental_scmp,
-                ScionRouting._loglevel,
-                ScionRouting._use_envsubst,
-                ScionRouting._setup_spec ]
+        from seedemu.core.OptionRegistry import OptionRegistry
+        opt_keys = [ o.name for o in ScionStackOpts().components()]
+        opt = [OptionRegistry().getOption(o, prefix='scion') for o in opt_keys]
+        return opt
 
     def __init__(self, loopback_range: str = '10.0.0.0/16',
                  static_routing: bool = True,
@@ -177,38 +249,30 @@ class ScionRouting(Routing):
           In SCION, BFD is used to determine the liveness of the link between two border routers and trigger SCMP error messages.
         @param loglevel LogLevel of SCION distributables
         @param serve_metrics enable collection of Prometheus metrics by SCION distributables
+        @param setup_spec which SCION stack to deploy in the simulation
         """
+        from seedemu.core.OptionRegistry import OptionRegistry
         super().__init__(loopback_range)
         self.__default_builder = ScionBuilder()
         args = inspect.signature(ScionRouting.__init__).parameters.keys()
         vals = locals()
-        assert not any([ vals[name].name != name for name in args
+        option_names = [name for name in args
                         if (vals[name] is not None) and
-                        name not in ['self', 'static_routing', 'loopback_range'] ]), 'option-parameter mismatch!'
+                        name not in ['self', 'static_routing', 'loopback_range'] ]
+        assert not any([ vals[name].name != name for name in option_names]), 'option-parameter mismatch!'
         ScionRouting._static_routing = static_routing
-        # set the global default options here if not overriden by user
-        ScionRouting._use_envsubst = (use_envsubst if use_envsubst != None
-                                      else ScionRouting.Option('use_envsubst', 'true', OptionMode.BUILD_TIME))
-        ScionRouting._serve_metrics = (serve_metrics if serve_metrics != None
-                                       else ScionRouting.Option('serve_metrics', 'false', OptionMode.BUILD_TIME))
-        ScionRouting._experimental_scmp = (experimental_scmp if experimental_scmp != None else
-                                           ScionRouting.Option('experimental_scmp', 'false', OptionMode.BUILD_TIME))
-        ScionRouting._appropriate_digest = (appropriate_digest if appropriate_digest != None else
-                                            ScionRouting.Option('appropriate_digest', 'true', OptionMode.BUILD_TIME))
-        ScionRouting._disable_bfd = (disable_bfd if disable_bfd != None else
-                                      ScionRouting.Option('disable_bfd', 'true', OptionMode.BUILD_TIME))
-        ScionRouting._rotate_logs = (rotate_logs if rotate_logs != None else
-                                     ScionRouting.Option('rotate_logs', 'false', OptionMode.BUILD_TIME))
-        ScionRouting._loglevel = (loglevel if loglevel != None else
-                                  ScionRouting.Option('loglevel', 'error', OptionMode.BUILD_TIME))
-        ScionRouting._setup_spec = (setup_spec if setup_spec != None else
-                                    ScionRouting.Option('setup_spec',
-                                                        SetupSpecification.LOCAL_BUILD(CheckoutSpecification()),
-                                                        OptionMode.BUILD_TIME )
-                                    )
 
+        # let user override the global default options
 
-
+        for n in option_names:
+        # Replace the 'defaults' class methods dynamically
+            v = vals[n]
+            opt_cls = type(v)
+            # Capture 'new_value' as default argument (forces a snapshot of the current value)
+            opt_cls.default = classmethod(lambda cls, new_value=v.value: new_value)
+            opt_cls.defaultMode = classmethod(lambda cls, newmode=v.mode: newmode)
+            prefix = getattr(opt_cls, '__prefix') if hasattr(opt_cls, '__prefix') else None
+            OptionRegistry().register(opt_cls, prefix)
 
     @staticmethod
     def _resolveFlag( flag: str , node: Node = None) -> str:
@@ -220,8 +284,8 @@ class ScionRouting(Routing):
               (it may return '${VAR}' placeholders if 'use_envsubst' is true)
         """
 
-        if flag not in valid_keys:
-            raise ValueError( f"invalid argument - flag {flag} unknown to SCION")
+        #if flag not in valid_keys:
+        #    raise ValueError( f"invalid argument - flag {flag} unknown to SCION")
 
         #TODO: maybe add toLowerTOML(default_val: str) -> str checks here
         # since user can input any garbage as input i.e. "'False'"(capitalized str) or "False" (bool)
@@ -715,97 +779,3 @@ class ScionRouting(Routing):
             cs_config += _Templates["metrics"].format(node.getLocalIPAddress(), 30452)
         cs_config += "\n".join(beaconing)
         node.setFile(os.path.join("/etc/scion/", name + ".toml"), cs_config)
-
-    class Option(BaseOption):
-        # TODO: add CS tracing
-        # TODO: add dispatchable port range
-        # make installation of test-tools optional (bwtester etc.)
-        ROTATE_LOGS = "rotate_logs"
-        USE_ENVSUBST = "use_envsubst"
-        EXPERIMENTAL_SCMP = 'experimental_scmp'
-        DISABLE_BFD = 'disable_bfd'
-        LOGLEVEL = 'loglevel'
-        SERVE_METRICS = 'serve_metrics'
-        APPROPRIATE_DIGEST = 'appropriate_digest'
-
-        def __init__(self, key, value, mode: OptionMode = None):
-            import inspect
-            caller_frame = inspect.stack()[1]
-            caller_name = caller_frame.function
-            assert caller_name in valid_keys or caller_name in [ 'getAvailableOptions', '__init__'], 'constructor of ScionRouting.Option is private'
-            self._key = key
-            default = ScionRouting.Option.default(key)
-            if value == None:
-                value = default.value
-            if mode == None:
-                mode = default.mode
-            self._mutable_value = value  # Separate mutable storage
-            self._mutable_mode = None
-            if mode != OptionMode.BUILD_TIME:
-                assert mode in self.supportedModes(), f'unsupported mode for option {key.upper()}'
-            self._mutable_mode = mode
-
-        @property
-        def name(self) -> str:
-            return self._key
-
-        @property
-        def value(self) -> str:
-            return self._mutable_value
-
-        @value.setter
-        def value(self, new_value: str):
-            """Allow updating the value attribute."""
-            self._mutable_value = new_value
-
-        @property
-        def mode(self):
-            return self._mutable_mode
-        @mode.setter
-        def mode(self, new_mode):
-            self._mutable_mode = new_mode
-
-        def supportedModes(self) -> OptionMode:
-            return self._mutable_mode if self._mutable_mode != None else  supported_modes[self._key.upper()]
-
-        @staticmethod
-        def defaultValue( key: str ) -> str:
-            match key.upper():
-                case "ROTATE_LOGS": return ScionRouting._rotate_logs
-                case "APPROPRIATE_DIGEST": return ScionRouting._appropriate_digest
-                case "DISABLE_BFD": return ScionRouting._disable_bfd
-                case "EXPERIMENTAL_SCMP": return ScionRouting._experimental_scmp
-                case "LOGLEVEL": return ScionRouting._loglevel
-                case "SERVE_METRICS": return ScionRouting._serve_metrics
-                case "USE_ENVSUBST": return ScionRouting._use_envsubst
-                case "SETUP_SPEC": return ScionRouting._setup_spec
-                case _:
-                    assert False , f'unknown option for ScionRouting Layer: {key}'
-
-        @classmethod
-        def disable_bfd(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('disable_bfd', value, mode)
-        @classmethod
-        def loglevel(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('loglevel', value, mode)
-        @classmethod
-        def serve_metrics(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('serve_metrics', value, mode)
-        @classmethod
-        def appropriate_digest(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('appropriate_digest', value, mode)
-        @classmethod
-        def experimental_scmp(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('experimental_scmp', value, mode)
-        @classmethod
-        def rotate_logs(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('rotate_logs', value, mode)
-        @classmethod
-        def use_envsubst(cls, value: str = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('use_envsubst', value, mode)
-        @classmethod
-        def setup_spec(cls, value: SetupSpecification = None, mode: OptionMode = OptionMode.BUILD_TIME) -> 'Option':
-            return cls('setup_spec', value, mode)
-
-        def __repr__(self):
-            return f"Option(key={self._key}, value={self._mutable_value})"

--- a/seedemu/layers/__init__.py
+++ b/seedemu/layers/__init__.py
@@ -8,5 +8,5 @@ from .Mpls import Mpls
 from .ScionBase import ScionBase
 from .ScionRouting import ScionRouting
 from .ScionIsd import ScionIsd
-from .Scion import Scion
+from .Scion import Scion, SetupSpecification, CheckoutSpecification
 from .EtcHosts import EtcHosts

--- a/tests/options/OptionsTestCase.py
+++ b/tests/options/OptionsTestCase.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+import unittest as ut
+from  seedemu.core import Scope, ScopeTier, ScopeType, BaseOption, OptionMode, Customizable
+from enum import Enum
+
+class SEEDEmuOptionSystemTestCase(ut.TestCase):
+
+
+    def test_scope(self):
+        """!@brief tests proper inclusion/exclusion, intersection and union of Scopes"""
+        cmpr =  Scope.collate
+
+        self.assertTrue( Scope(ScopeTier.Global) > Scope(ScopeTier.AS, as_id=150), 'global scope is superset of AS scopes')
+        self.assertTrue( Scope(ScopeTier.AS, as_id=150) < Scope(ScopeTier.Global) , 'AS scopes are subset of global scope')
+
+        self.assertTrue( cmpr(Scope(ScopeTier.AS, as_id=150),
+                              Scope(ScopeTier.AS, as_id=160))==0, 'disjoint AS scopes')
+        self.assertTrue( cmpr(Scope(ScopeTier.Node, as_id=150, node_id='br0'),
+                              Scope(ScopeTier.Node, as_id=160, node_id='br0'))==0,
+                              'disjoint Nodes scopes different ASes')
+        self.assertTrue( cmpr(Scope(ScopeTier.Node, as_id=150, node_id='br0'),
+                              Scope(ScopeTier.Node, as_id=150, node_id='br1'))==0,
+                              'disjoint Nodes scopes same AS')
+        self.assertTrue( cmpr(Scope(ScopeTier.AS, as_id=150,node_type=ScopeType.HNODE),
+                              Scope(ScopeTier.AS, as_id=150,node_type=ScopeType.BRDNODE))==0,
+                              'disjoint Types scopes at AS level')
+        self.assertTrue( cmpr(Scope(ScopeTier.AS, as_id=150,node_type=ScopeType.HNODE),
+                              Scope(ScopeTier.AS, as_id=160,node_type=ScopeType.BRDNODE))==0,
+                              'disjoint Types as well as ASes')
+        self.assertTrue( cmpr(Scope(ScopeTier.Global,node_type=ScopeType.HNODE),
+                              Scope(ScopeTier.Global,node_type=ScopeType.BRDNODE))==0,
+                              'disjoint Types scopes at global level')
+
+        self.assertTrue ( Scope(ScopeTier.AS, as_id=150) >
+                          Scope(ScopeTier.Node, as_id=150, node_id='brd0', node_type=ScopeType.BRDNODE),
+                        'node scope is subset of AS scope')
+
+        self.assertTrue( not ( Scope(ScopeTier.AS, as_id=150) <
+                              Scope(ScopeTier.Node, as_id=150, node_id='brd0', node_type=ScopeType.BRDNODE)))
+
+
+        self.assertTrue( Scope(ScopeTier.AS, as_id=160) ==
+                         Scope(ScopeTier.AS, as_id=160) , 'identical AS scope')
+        self.assertTrue( Scope(ScopeTier.AS, as_id=160, node_type=ScopeType.ANY) ==
+                         Scope(ScopeTier.AS, as_id=160) , 'identical AS scope')
+        self.assertTrue( Scope(ScopeTier.AS, as_id=160, node_type=ScopeType.ANY) >
+                         Scope(ScopeTier.AS, as_id=160, node_type=ScopeType.BRDNODE), 'ANY includes all types')
+        self.assertTrue( Scope(ScopeTier.AS, as_id=150) !=
+                         Scope(ScopeTier.AS, as_id=160) , 'not identical scope')
+        self.assertTrue( Scope(ScopeTier.Node, as_id=150,node_id='brd0') ==
+                         Scope(ScopeTier.Node, as_id=150,node_id='brd0',node_type=ScopeType.BRDNODE),
+                         'same node but with extra type info')
+        self.assertTrue( Scope(ScopeTier.Global) > Scope(ScopeTier.Node, as_id=150, node_id='brd0'))
+        self.assertTrue( not (Scope(ScopeTier.Global, ScopeType.HNODE) >
+                              Scope(ScopeTier.Node, as_id=150, node_id='brd0', node_type=ScopeType.BRDNODE) ),
+                         'node unaffected by global type')
+
+    def test_customizable(self):
+        """!@brief test setting and retrieval of associated options
+        """
+        class _Option(BaseOption,Enum):
+            """!@brief dummy option impl"""
+            ROTATE_LOGS = "rotate_logs"
+            USE_ENVSUBST = "use_envsubst"
+            EXPERIMENTAL_SCMP = 'experimental_scmp'
+            DISABLE_BFD = 'disable_bfd'
+            LOGLEVEL = 'loglevel'
+            SERVE_METRICS = 'serve_metrics'
+            APPROPRIATE_DIGEST = 'appropriate_digest'
+            MAX_BANDWIDTH = 'max_bandwidth'
+
+            def __init__(self, key, value=None):
+                self._key = key
+                #if value==None:
+                #    value = self.defaultValue()
+                self._mutable_value = value  # Separate mutable storage
+                self._mutable_mode = OptionMode.BUILD_TIME
+
+            @property
+            def name(self) -> str:
+                return self._key
+
+            @property
+            def value(self) -> str:
+                return self._mutable_value if self._mutable_value else str(self.defaultValue()).lower()
+
+            @value.setter
+            def value(self, new_value: str):
+                """Allow updating the value attribute."""
+                self._mutable_value = new_value
+
+            @property
+            def mode(self):
+                return self._mutable_mode
+            @mode.setter
+            def mode(self, new_mode):
+                self._mutable_mode = new_mode
+
+            def supportedModes(self) -> OptionMode:
+                return OptionMode.BUILD_TIME
+
+            def defaultValue(self):
+                match self._name_:
+                    case "ROTATE_LOGS": return False
+                    case "APPROPRIATE_DIGEST": return True
+                    case "DISABLE_BFD": return True
+                    case "EXPERIMENTAL_SCMP": return False
+                    case "LOGLEVEL": return "error"
+                    case "SERVE_METRICS": return False
+                    case "USE_ENVSUBST": return False
+                    case "MAX_BANDWIDTH": return -1
+
+            @classmethod
+            def custom(cls, key, value, mode=None ):
+                valid_keys = set()
+                for member in cls:
+                    if isinstance(member.name,str):
+                        valid_keys.add(member.name)
+                if key not in valid_keys:
+                    raise ValueError(f"Invalid Option: {key}. Must be one of {valid_keys}.")
+
+                custom_option = object.__new__(cls)
+                custom_option._key = key
+                custom_option._mutable_value = value
+                custom_option._name_ = key.upper()
+                custom_option._mode = mode if mode else OptionMode.BUILD_TIME
+                return custom_option
+
+            def __repr__(self):
+                return f"Option(key={self._key}, value={self._mutable_value})"
+
+        #----------------------------------------------------------------------
+        config = Customizable()
+
+        # Define scopes
+        global_scope = Scope(ScopeTier. Global)
+        global_router_scope = Scope(ScopeTier. Global, ScopeType.RNODE)
+        as_router_scope = Scope(ScopeTier.AS, ScopeType.RNODE, as_id=42)
+        node_scope = Scope(ScopeTier.Node, ScopeType.RNODE, node_id="A", as_id=42)
+
+        config.setOption( _Option.custom("max_bandwidth", 100), global_scope)
+        config.setOption( _Option.custom("max_bandwidth", 200), global_router_scope)
+        config.setOption( _Option.custom("max_bandwidth", 400), as_router_scope)
+        config.setOption( _Option.custom("max_bandwidth", 500), node_scope)
+
+        # Retrieve values using a Scope object
+        self.assertTrue( (opt:=config.getOption("max_bandwidth", Scope(ScopeTier.Node, ScopeType.RNODE, node_id="A",as_id=42)))   != None and opt.value==500)# 500 (Node-specific)
+        self.assertTrue( (opt:=config.getOption("max_bandwidth", Scope(ScopeTier.Node, ScopeType.HNODE, node_id="C", as_id=42)))  != None and opt.value==100)# 100 (Global fallback)
+        self.assertTrue( (opt:=config.getOption("max_bandwidth", Scope(ScopeTier.Node, ScopeType.RNODE, node_id="D", as_id=99)))  != None and opt.value==200)# 200 (Global & Type)
+        self.assertTrue( (opt:=config.getOption("max_bandwidth", Scope(ScopeTier.Node, ScopeType.HNODE, node_id="E", as_id=99)))  != None and opt.value==100)# 100 (Global-wide)
+        self.assertTrue( (opt:=config.getOption("max_bandwidth", Scope(ScopeTier.Node, ScopeType.RNODE, node_id="B", as_id=42))) != None and opt.value==400)# 400 (AS & Type)
+
+        child_config = Customizable()
+        child_config._scope = node_scope
+        self.assertTrue( not child_config.getOption("max_bandwidth"))
+        config.handDown(child_config)
+        self.assertTrue( (opt:=child_config.getOption("max_bandwidth"))!=None and opt.value==500)
+
+
+    @classmethod
+    def get_test_suite(cls):
+        test_suite = ut.TestSuite()
+        test_suite.addTest(SEEDEmuOptionSystemTestCase('test_scope'))
+        test_suite.addTest(SEEDEmuOptionSystemTestCase('test_customizable'))
+
+        return test_suite
+
+
+if __name__ == "__main__":
+    test_suite = SEEDEmuOptionSystemTestCase.get_test_suite()
+    res = ut.TextTestRunner(verbosity=2).run(test_suite)
+
+    num, errs, fails = res.testsRun, len(res.errors), len(res.failures)
+    print("score: %d of %d (%d errors, %d failures)" % (num - (errs+fails), num, errs, fails))
+

--- a/tests/options/OptionsTestCase.py
+++ b/tests/options/OptionsTestCase.py
@@ -2,10 +2,40 @@
 # encoding: utf-8
 
 import unittest as ut
-from  seedemu.core import Scope, ScopeTier, ScopeType, BaseOption, OptionMode, Customizable
+import os
+from seedemu.core import (
+    Scope,
+    ScopeTier,
+    ScopeType,
+    BaseOption,
+    OptionMode,
+    Customizable,
+)
+from tests import SeedEmuTestCase
 from enum import Enum
 
-class SEEDEmuOptionSystemTestCase(ut.TestCase):
+
+class SEEDEmuOptionSystemTestCase(SeedEmuTestCase):
+
+    @classmethod
+    def gen_emulation_files(cls):
+        """currently there are just no integration tests for options"""
+        pass
+
+    @classmethod
+    def build_emulator(cls):
+        """currently there are just no integration tests for options"""
+        pass
+
+    @classmethod
+    def up_emulator(cls):
+        """currently there are just no integration tests for options"""
+        pass
+
+    @classmethod
+    def down_emulator(cls):
+        """currently there are just no integration tests for options"""
+        pass
 
 
     def test_scope(self):
@@ -157,6 +187,8 @@ class SEEDEmuOptionSystemTestCase(ut.TestCase):
         self.assertTrue( not child_config.getOption("max_bandwidth"))
         config.handDown(child_config)
         self.assertTrue( (opt:=child_config.getOption("max_bandwidth"))!=None and opt.value==500)
+
+
 
 
     @classmethod

--- a/tests/options/__init__.py
+++ b/tests/options/__init__.py
@@ -1,0 +1,1 @@
+from .OptionsTestCase import SEEDEmuOptionSystemTestCase

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -3,6 +3,7 @@
 from internet import IPAnyCastTestCase, MiniInternetTestCase, HostMgmtTestCase
 from ethereum import EthereumPOATestCase, EthereumPOSTestCase, EthereumPOWTestCase
 from scion import ScionBgpMixedTestCase, ScionBwtesterTestCase, ScionLargeASNTestCase
+from options import SEEDEmuOptionSystemTestCase
 from kubo import KuboTestCase, KuboUtilFuncsTestCase, DottedDictTestCase
 from pki import PKITestCase
 from chainlink import ChainlinkPOATestCase
@@ -32,6 +33,7 @@ test_case_list = [
     ScionLargeASNTestCase,
     ScionBgpMixedTestCase,
     ScionBwtesterTestCase,
+    SEEDEmuOptionSystemTestCase,
     KuboTestCase,
     KuboUtilFuncsTestCase,
     DottedDictTestCase,

--- a/tests/scion/tools/scion_output_checker.py
+++ b/tests/scion/tools/scion_output_checker.py
@@ -1,7 +1,7 @@
 import os
 import json
 import yaml
-import sys
+from typing import Optional
 from seedemu.core.enums import NodeRole
 
 class ScionOutputChecker:
@@ -23,18 +23,18 @@ class ScionOutputChecker:
     def check_brdnode(self, node_name, curr_node_json_data ):
 
         local_ia = curr_node_json_data['isd_as']
-        local_asn=local_ia.split('-')[1]
+        local_asn = local_ia.split('-')[1]
         folder = f'brdnode_{local_asn}_{node_name}'
         # also the service name of the node in docker-compose.yml
-        assert folder in self._services, 'SEED output naming scheme violation'
+        assert folder in self._services, f'SEED output naming scheme violation: {folder}'
 
         brd = curr_node_json_data['border_routers'][node_name]
-        internal_addr = brd['internal_addr']
+        internal_addr = brd['internal_addr'] # address on local network 'net0'
         interfaces = brd['interfaces']
 
         brd_service = self._services[folder]
         brd_nets = brd_service['networks'] # networks joined by this service
-
+        hits = {} # map interfaces from .json to networks from .yml
         for i, (id, intf) in enumerate(interfaces.items()):
             underlay = intf['underlay']
             remote_ia = intf['isd_as']
@@ -43,31 +43,68 @@ class ScionOutputChecker:
             local_key = 'local' if 'local' in underlay else 'public'
             local_ip = underlay[local_key].split(':')[0] #.rstrip(':50000')
             remote_ip = underlay['remote'].split(':')[0]
-
+            found_net = False
+            # find the net for the given interface
             for  (name, net) in brd_nets.items():
+                ip = net['ipv4_address']
+                # TODO: account for more than one local net i.e. 'net1'
                 if name.endswith('net0'): # local network within AS
-                        ip = net['ipv4_address']
+
                         #net_name = name.lstrip('net_').rstrip('_net0')
-                        net_name = name.split('_')[1]
-                        assert net_name == local_asn, f'border router must belong to a single AS only: {net_name} {local_asn} [{name}]'
+                        asn_name = name.split('_')[1]
+                        assert asn_name == local_asn, f'border router must belong to a single AS only: {asn_name} {local_asn} [{name}]'
                         router_internal_ip = internal_addr.split(':')[0] #.rstrip(':30042')
                         is_loopback= 'org.seedsecuritylabs.seedemu.meta.loopback_addr' in brd_service['labels']
-                        assert ip==router_internal_ip or is_loopback, f'contradiction between topology.json and docker-compose.yml detected for BR({node_name}) internal address: {name} AS {local_asn} expected: {router_internal_ip} actual: {ip}'
-                if name.startswith('net_ix'):
-                        ip = net['ipv4_address']
-                        net_name = name.split('_')[-1].lstrip('ix')
-                        assert ip == local_ip, f'contradiction between topology.json and docker-compose.yml detected: {name} net: {net_name} docker: {ip} topo.json: {local_ip}'
-                        # check that remote-border-router has 'name' under 'networks'
-                        # and within this network in fact has assigned the IP 'remote_ip'
-                        remote_router_name = f'brdnode_{remote_asn}_router{net_name}'
-                        remote_router = self._services[remote_router_name]
-                        assert name in (remote_nets:=remote_router['networks']) , f'remote border router unreachable - IX: {net_name} from: {local_ia} to: {remote_ia}'
-                        remote_net = remote_nets[name]
-                        assert remote_net['ipv4_address'] == remote_ip  , f'contradiction between topology.json and docker-compose.yml detected for remote BR: {name} AS {remote_asn} router{net_name}'
-                        pass
-                pass
-            pass
+                        if ip==router_internal_ip or is_loopback:
+                            hits[id] = name
+                            # in this case there is no remote BR to check
+                            found_net = True
+                            break
+                elif name.startswith('net_ix'): # internet exchange network
 
+                        net_name = name.split('_')[-1].lstrip('ix')
+                        if ip == local_ip:
+                            hits[id] = name
+                            found_net = True
+                            # check that remote-border-router has 'name' under 'networks'
+                            # and within this network in fact has assigned the IP 'remote_ip'
+                            if not self._search_br(name, remote_ip):
+                                raise AssertionError(f'remote BR of BR {folder} on IF {id} ({name}) doesn\'t exitst in docker-compose.yml (probably wrong remote address in topology.json)')
+
+
+                            break
+                elif name.startswith('net_xc'): # cross connect network
+                    if ip == local_ip:
+                        hits[id] = name
+                        found_net = True
+                        # assert that there exists a node who has the 'remote' address on one of its networks,
+                        # and the name of this network is 'name' (as expected)
+
+                        if not self._search_br(name, remote_ip):
+                            raise AssertionError( f'remote BR of BR {folder} on IF {id} ({name}) doesn\'t exitst in docker-compose.yml (probably wrong remote address in topology.json)')
+
+
+                        break
+                else: # must be service network 000_svc
+                    # but service network doesn't show up in topology.json
+                    pass
+            assert found_net, f'no network in docker-compose.yml for BR {node_name} IF {id} in topology.json file'
+
+        assert len(hits) == len(interfaces), 'mismatch between topology.json and docker-compose.yml'
+
+    def _search_br(self, name: str, remote_ip ) -> Optional[str]:
+        """
+        @brief looks up a router in the docker-compose.yml file,
+            with the given IP on the given network
+        @param name name of the network
+        @param remote_ip IP address on the given network of the router in question
+        """
+        # nodes that are also on the the same network
+        remote_br_candidates = [ (sname, svc)  for sname, svc in self._services.items() if 'networks' in svc and name in svc['networks'] ]
+
+        remote_br = [ sname for (sname, svc) in remote_br_candidates if svc['networks'][name]['ipv4_address'] == remote_ip]
+        assert len(remote_br) <= 1, 'there canno\'t be more than one router on the same net ({name}) with the same address {remote_ip}'
+        return remote_br[0] if len(remote_br) > 0 else None
 
     def do_checks(self):
         """!
@@ -148,12 +185,12 @@ def parse_docker_compose_yaml(dir='.',file_path='docker-compose.yml'):
         except Exception as e:
             print(f"Error reading docker-compose.yml {file_path}: {e}")
     else:
-        print(f"{file_path} does not exist.")
+        raise FileNotFoundError(f"{full_path} does not exist.")
 
 
 
 if __name__ == "__main__":
 
-    sn = ScionOutputChecker(out_dir=sys.argv[1])
+    sn = ScionOutputChecker('/home/lucas/repos/seed-emulator/output')
 
     sn.do_checks()


### PR DESCRIPTION
an option system allows for fine grained overrides of global default settings. 
Its workings are basically as follows:

 Options can be anything from boolean flags to numerical configuration parameters and are best thought of as just a strong type for key-value pairs (where the value is mutable, but the key isn't).
Moreover each option carries with it the notion of supported modes. That is, whether it can be changed only at compile/build-time (because its value gets baked into the container image i.e. as a config file entry ) and any reconfiguration requires a re-compile and image rebuild or whether its existence extends into the runtime (i.e. as a container ENV variable ) and its reconfiguration requires a mere container restart. Some options i.e. Feature Flags might require the installation of additional software on the target node(the `Customizable`) for their implementation and thus will be strickly limited to build-time.


Layers inherit `DynamicConfigurable` and can thus return a set of supported options (`getAvailableOptions()`).
Configurables are the only place to retrieve options, as they cannot just be constructed by the users arbitrarily (i.e. Layers are only considering their own set of options with known predefined keys/names and ignore any unknowns i.e. from other Layers ).

 The counterpart of configurables are `Customizables`, objects that can be configured by options. 
The API of Customizables allows the setting and querying of options at a certain `Scope`(which can i.e. be Global, on AS level, by NodeType like 'All-Routers', or even specific to an individual Node ). If unspecified the scope for both option setters and getters will default to the scope that is most specific (narrow) to the respective Customizable (i.e. AS or Node). This distinctive Scope value can be obtained from any Customizable through the identically named getter function( i.e. for an AutonomousSystem AS150 `scope()` will return `Scope(ScopeTier.AS, as_id=150, node_type=ScopeType.ANY)` ). As a rule of thumb, `Scope`s are technical and users shouldn't have to deal with them during 'daily buisiness' because all methods provide sensible defaults.

Some Customizables are aggregates and own other Customizables (i.e. ASes are a collection of Nodes) to whom they can inherit their options (parent to child) with the `handDown()` method. 

 The base class impl of `DynamicConfigurable` calls the `prepare()` hook just before its configuration (`configure` call) in which its sets all its available options on all the Nodes in the emulation as global defaults. If a node already has more specific overrides for an option ( i.e. because it inherited its local ASes settings that deviate from the global default or the user explicitly changed the option on this particular node) this will be a NoOp (more specific settings preceede). The Base layer (which is configured very first) makes sure that all options which might have been overridden on AS level by the user are inherited down to the resident nodes of that AS.

The resulting state of option settings after the `prepare` call will be the basis for node configuration in the subsequent `configure` step.
As a result of this it should be avoided to create new nodes during configuration(they'd sidestep/slip customization).

The reification of options unifies the implementation of layers. Rather than adding configuration getters/setters to your layer (i.e. `setLoglevel()` bloating its interface) is to just add an option `LOGLEVEL` and pass sensible default values to the constructor of your layer. 

The new OptionRegistry is the single place  for users to retrieve OptionTypes and eventually construct some.

A detailed example on how to use options is given in: `examples/scion/S02_scion_bgp_mixed/README.md`.
The use of options is not obligatory, and any 'legacy' layers can remain option-unaware and continue to function. For now, only the SCION layers are refactored to use them i.e. as a showpiece.
For maintainability a dedicated unittest is added: `tests/options/OptionsTestCase.py`