### PR TITLE
support named docker volumes

### DIFF
--- a/seedemu/compiler/DistributedDocker.py
+++ b/seedemu/compiler/DistributedDocker.py
@@ -1,11 +1,12 @@
 # Distributed Docker Compiler is not maintained
 
 from .Docker import Docker, DockerCompilerFileTemplates
-from seedemu.core import Emulator, ScopedRegistry, Node, Network
+from seedemu.core import Emulator, ScopedRegistry, Node, Network, BaseVolume
 from seedemu.core.enums import NodeRole
 from typing import Dict
 from hashlib import md5
 from os import mkdir, chdir, rmdir
+from yaml import dump
 
 DistributedDockerCompilerFileTemplates: Dict[str, str] = {}
 
@@ -70,6 +71,28 @@ class DistributedDocker(Docker):
 
     def _doCompile(self, emulator: Emulator):
         registry = emulator.getRegistry()
+
+        self._groupSoftware(emulator)
+
+        toplevelvolumes = '' 
+        if len(topvols := self._getVolumes()) > 0:
+            toplevelvolumes += 'volumes:\n'
+            #topvols = set(map( lambda vol: TopLvlVolume(vol), pool.getVolumes() ))
+
+            for v in  topvols:
+                v.mode = 'toplevel'
+
+            #toplevelvolumes += '\n'.join(map( lambda line: '        ' + line ,dump( topvols ).split('\n') ) ) 
+
+            # sharedFolders/bind mounts do not belong in the top-level volumes section
+            for v in [vv  for  vv in topvols if vv.asDict()['type'] == 'volume' ]: 
+                toplevelvolumes += '  {}:\n'.format(v.asDict()['source']) # why not 'name'
+                lines = dump( v ).rstrip('\n').split('\n')
+                toplevelvolumes += '\n'.join( map( lambda x: '        ' if x[0] != 0 
+                                                else '        ' + x[1] if x[1] != ''
+                                                else '', enumerate(lines ) ) )
+                toplevelvolumes += '\n'
+
         scopes = set()
         for (scope, _, _) in registry.getAll().keys(): scopes.add(scope)
 
@@ -114,6 +137,7 @@ class DistributedDocker(Docker):
                 print(DockerCompilerFileTemplates['compose'].format(
                     services = services,
                     networks = networks,
+                    volumes = toplevelvolumes,
                     dummies = self._makeDummies()
                 ), file=open('docker-compose.yml', 'w'))
 

--- a/seedemu/core/Volume.py
+++ b/seedemu/core/Volume.py
@@ -1,0 +1,214 @@
+from .Registry import Registrable
+from yaml import *
+from typing import Dict, Tuple, List, Set
+
+# use collections defaultdict ?!
+class ddict(dict):
+
+    def __getitem__(self, item):
+        try:
+            return dict.__getitem__(self, item)
+        except KeyError:
+            value = self[item] = type(self)()
+            return value
+    
+    def clean_dict(self):
+        return {k: v for k, v in self.items() if v not in [None, [], {}]}
+
+
+class YAMLMultiObjectMetaclass(YAMLObjectMetaclass):
+    """
+    The metaclass for YAMLMultiObject.
+    """
+
+    def __init__(cls, name, bases, kwds):
+        super(YAMLMultiObjectMetaclass, cls).__init__(name, bases, kwds)
+        if "yaml_tag" in kwds and kwds["yaml_tag"] is not None:
+            # cls.yaml_loader.add_multi_constructor(cls.yaml_tag, cls.from_yaml)
+            cls.yaml_dumper.add_multi_representer(cls, cls.to_yaml)
+
+
+class YAMLMultiObject(YAMLObject, metaclass=YAMLMultiObjectMetaclass):
+    """
+    An object that dumps itself to a stream.
+
+    Use this class instead of YAMLObject in case 'to_yaml' and 'from_yaml' should
+    be inherited by subclasses.
+    """
+
+    pass
+
+
+class BaseVolume(YAMLMultiObject):
+    """
+    @brief representation of a docker-compose volume
+
+    It can have one of the following types:
+    - 'bind' for shared folders (bind-mounts)
+    - 'volume' for anonymus or named docker volumes
+        (depending on wether 'name' is set)
+    - tmpfs
+    """
+
+    yaml_tag = "!BaseVolume"
+
+    def __init__(self, **kwargs):
+        self._data = ddict()
+        self.mode = "base"
+
+        # services level volume elements
+        self._data["type"] = "volume"
+        self._data["source"] = None
+        self._data["target"] = None
+
+        # bind: {propagation:  , selinux: , create_host_path: }
+        self._data["read_only"] = False
+        # volume: {nocopy: bool }
+
+        # Volumes top-level elements
+        self._data["driver"] = None  # str
+        self._data["name"] = None  # str
+        self._data["labels"] = []
+        self._data["driver_opts"] = ddict()
+        self._data["external"] = (
+            None  # might be bool or {name: external-name-to-lookup}
+        )
+
+        self._data["subdir"] = None
+
+        for key, value in kwargs.items():
+            # only handle valid keys, docker knows about
+            if key in self._data:
+                if key == "labels":
+                    self._data[key].append(value)
+                else:
+                    self._data[key] = value
+
+        super().__init__()
+
+    def __hash__(self):
+        return hash((self._data["type"], self._data["target"], self._data["source"]))
+
+    def __eq__(self, other):
+        return (self._data["type"], self._data["source"], self._data["target"]) == (
+            other.asDict()["type"],
+            other.asDict()["source"],
+            other.asDict()["target"],
+        )
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return basevol_representer(dumper, data)
+
+    def __repr__(self) -> str:
+        vals = []
+        if self._data["type"] != None:
+            vals.append("type={}".format(self._data["type"]))
+        if self._data["source"] != None:
+            vals.append("source={}".format(self._data["source"]))
+        if self._data["target"] != None:
+            vals.append("target={}".format(self._data["target"]))
+
+        return "Volume(%r)" % (", ".join(vals))
+
+    def asDict(self):
+        return self._data
+
+    def getType(self) -> str:
+        """!@brief  returns the type of the volume
+        one of
+            - sharedFolder -> bind
+            - named or anonymous volume -> volume
+            - tmpfs
+        """
+        return self._data["type"]
+
+    def setType(self, _type: str):
+        """
+        one of 'volume' , 'bind', 'tmpfs'
+        """
+        assert _type in ['volume' , 'bind', 'tmpfs'], f'unknown docker volume type: {_type}'
+        self._data["type"] = _type
+        return self
+
+    def setSource(self, src: str):
+
+        self._data["source"] = src
+        return self
+
+
+# prints all attributes
+def basevol_representer(dumper, data: BaseVolume):
+    if data.mode == "base":
+        return dumper.represent_dict(            
+                data.asDict().clean_dict()          
+        )
+    elif data.mode == "service":
+        return dumper.represent_dict(
+            filter(
+                lambda kv: kv[0] in ["type", "source", "target", "read_only"],
+                data.asDict().clean_dict().items(),
+            )
+        )
+    elif data.mode == "toplevel":
+        return dumper.represent_dict(
+            filter(
+                lambda kv: kv[0] in ["driver", "name", "labels", "external", "driver_opts"],
+                data.asDict().clean_dict().items(),
+            )
+        )
+
+
+add_representer(BaseVolume, basevol_representer)
+
+
+class ServiceLvlVolume(BaseVolume):
+    # def __init__(**kwargs):
+    #    super().__init__(kwargs)
+    yaml_tag = "!SvcVolume"
+
+    def __init__(self, obj):
+        super().__init__()
+        self._data = obj._data
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return svcvol_representer(dumper, data)
+
+
+def svcvol_representer(dumper, data: BaseVolume):
+    return dumper.represent_dict(
+        filter(
+            lambda kv: kv[0] in ["type", "source", "target"],
+            data.asDict().clean_dict().items(),
+        )
+    )
+
+
+add_representer(ServiceLvlVolume, svcvol_representer)
+
+
+class TopLvlVolume(BaseVolume):
+    # def __init__(self,**kwargs):
+    #    super().__init__(kwargs)
+    yaml_tag = "!Volume"
+
+    def __init__(self, obj):
+        super().__init__()
+        self._data = obj._data
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return topvol_representer(dumper, data)
+
+
+def topvol_representer(dumper, data):
+    return dumper.represent_dict(
+        filter(
+            lambda kv:  kv[0] in ["driver", "name", "labels", "external", "driver_opts"],
+            data.asDict().clean_dict().items(),
+        )
+    )
+
+
+add_representer(TopLvlVolume, topvol_representer)

--- a/seedemu/core/__init__.py
+++ b/seedemu/core/__init__.py
@@ -24,3 +24,4 @@ from .BaseSystem import BaseSystem
 from .Scope import *
 from .Option import BaseOption, OptionMode, Option, BaseComponent, BaseOptionGroup, AutoRegister, OptionGroupMeta
 from .OptionRegistry import OptionRegistry
+from .Volume import BaseVolume, ServiceLvlVolume, TopLvlVolume


### PR DESCRIPTION
introduce the notion of docker volumes into seed codebase.
 Thus unify the handling of 'persistentStorage' and 'sharedFolders'.
This also enables multiple nodes to mount the same volume (be referencing its name ) effectively sharing its contents.
Currently only anonymous volumes are supported for persistent storage, which cannot be shared (because the name is unknown random value)