### PR TITLE
/etc/scion config volume option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/.shared/*
 **/output/*
 **/.scion_build_output/*
 **/eth-states*/*

--- a/examples/scion/S02_scion_bgp_mixed/README.md
+++ b/examples/scion/S02_scion_bgp_mixed/README.md
@@ -25,7 +25,8 @@ spec = SetupSpecification.LOCAL_BUILD(
             checkout = "v0.12.0" # could be tag, branch or commit-hash
         ))
 opt_spec = OptionRegistry().scion_setup_spec(spec)
-routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec)
+etc_cfg = OptionRegistry().scion_etc_config_vol(ScionConfigMode.SHARED_FOLDER)
+routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec, etc_config_vol=etc_cfg)
 
 ospf = Ospf()
 scion_isd = ScionIsd()
@@ -37,6 +38,8 @@ ebgp = Ebgp()
 In addition to the SCION layers we instantiate the `Ibgp` and `Ebgp` layers for BGP as well as `Ospf` for AS-internal routing.
 Note that the ScionRouting layer accepts global default values for options as constructor parameters.
  We use it here to decrease the loglevel from 'debug' to 'error' for all SCION distributables in the whole emulation if not overriden elsewhere. Also we change the mode for `LOGLEVEL` from `BUILD_TIME`(default) to `RUN_TIME` in the same statement.
+ Moreover, the SCION related configuration of nodes shall not be baked into their docker images for this example,
+  but bind-mounted from a shared folder on the host instead, to facilitate re-configuration of the SCION stack between simulation runs(without image recompile).
  Lastly we specify (as a global default for all nodes) that we want to use a local build of the `v0.12.0` SCION stack, rather than the 'official' `.deb` packages (`SetupSpecification.PACKAGES`). The SetupSpec is just an ordinary option and be overriden for ASes or individual nodes just like any other.
 
 ## Step 2: Create isolation domains and internet exchanges

--- a/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
+++ b/examples/scion/S02_scion_bgp_mixed/scion_bgp_mixed.py
@@ -5,7 +5,8 @@ from seedemu.core import Emulator, OptionMode, Scope, ScopeTier, ScopeType, Opti
 from seedemu.layers import (
     ScionBase, ScionRouting, ScionIsd, Scion, Ospf, Ibgp, Ebgp, PeerRelationship,
     SetupSpecification, CheckoutSpecification)
-from seedemu.layers.Scion import LinkType as ScLinkType
+from seedemu.layers.Scion import LinkType as ScLinkType, ScionConfigMode
+
 # Initialize
 emu = Emulator()
 base = ScionBase()
@@ -19,7 +20,8 @@ spec = SetupSpecification.LOCAL_BUILD(
             checkout = "v0.12.0" # could be tag, branch or commit-hash
         ))
 opt_spec = OptionRegistry().scion_setup_spec(spec)
-routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec)
+etc_cfg = OptionRegistry().scion_etc_config_vol(ScionConfigMode.SHARED_FOLDER)
+routing = ScionRouting(loglevel=loglvl, setup_spec=opt_spec, etc_config_vol=etc_cfg)
 
 ospf = Ospf()
 scion_isd = ScionIsd()

--- a/seedemu/core/OptionRegistry.py
+++ b/seedemu/core/OptionRegistry.py
@@ -47,7 +47,7 @@ class OptionRegistry(metaclass=SingletonMeta):
         """Creates an option instance if it's registered."""
         option_cls = cls._options.get(name)
         if not option_cls:
-            raise ValueError(f"Option '{name}' is not registered.")
+            raise ValueError(f'Option "{name}" is not registered.')
         # Instantiate with given arguments
         return option_cls(*args[1:], **kwargs)
 


### PR DESCRIPTION
add an option that controls the handling of SCION related configuration files (contents of /etc/scion dir ).
 Now users can choose whether to bake them into the docker images(as it used to be) or have them bind-mounted from a shared folder on the host. This can be used to reduce image build times.