### PR TITLE
refactor container sysctl flags

### DIFF
--- a/examples/internet/B00_mini_internet/mini_internet.py
+++ b/examples/internet/B00_mini_internet/mini_internet.py
@@ -87,7 +87,14 @@ def run(dumpfile=None, hosts_per_as=2):
     
     # An example to show how to add a host with customized IP address
     as154 = base.getAutonomousSystem(154)
-    as154.createHost('host_new').joinNetwork('net0', address = '10.154.0.129')
+    new_host = as154.createHost('host_new').joinNetwork('net0', address = '10.154.0.129')
+    from seedemu.core import OptionRegistry, OptionMode
+
+   
+    o = OptionRegistry().sysctl_netipv4_conf_rp_filter({'all': False, 'default': False, 'net0': False}, mode = OptionMode.RUN_TIME)
+    new_host.setOption(o)
+
+
     
     ###############################################################################
     # Peering via RS (route server). The default peering mode for RS is PeerRelationship.Peer, 

--- a/seedemu/core/AutonomousSystem.py
+++ b/seedemu/core/AutonomousSystem.py
@@ -129,7 +129,7 @@ class AutonomousSystem(Printable, Graphable, Configurable, Customizable):
         # this causes no redundant setting of the same options/defaults
         reg = emulator.getRegistry()
         all_nodes = [ obj for (scope,typ,name),obj  in reg.getAll( ).items()
-                      if scope==str(self.getAsn()) and typ in ['rnode','hnode','csnode','rsnode'] ]
+                      if scope==str(self.getAsn()) and typ in ['rnode','hnode','csnode','rsnode','rs'] ]
         for n in all_nodes:
             self.handDown(n)
 

--- a/seedemu/core/Binding.py
+++ b/seedemu/core/Binding.py
@@ -9,6 +9,7 @@ from typing import List
 from ipaddress import IPv4Network, IPv4Address
 from sys import stderr
 import re, random, string
+from .Scope import Scope, ScopeTier
 
 class Action(Enum):
     """!
@@ -175,6 +176,12 @@ class Binding(Printable):
 
         # create the host in as
         host = asObject.createHost(nodeName)
+        # inherit AS level option overrides...
+        asObject.handDown(host)
+        # 'host' didnt exist back when Base::configure() installed
+        #  the global default sysctl options on all nodes
+        for o in base.getAvailableOptions():
+            host.setOption(o, Scope(ScopeTier.Global))
 
         # set name servers
         host.setNameServers(asObject.getNameServers())
@@ -186,8 +193,8 @@ class Binding(Printable):
         reg.register(str(asn), 'hnode', nodeName, host)
 
         # configure - usually this is done by AS in configure stage, since we have passed that point, we need to do it ourself.
+        # >> here at the latest,  any relevant options must be set on the node or they wont be considered
         host.configure(emulator)
-
         return host
 
 

--- a/seedemu/core/Configurable.py
+++ b/seedemu/core/Configurable.py
@@ -60,10 +60,11 @@ class DynamicConfigurable(Configurable):
         # set options on nodes directly
         reg = emulator.getRegistry()
         all_nodes = [ obj for (scope,typ,name),obj  in reg.getAll( ).items() 
-                      if typ in ['rnode','hnode','csnode','rsnode'] ]
+                      if typ in ['rnode','hnode','csnode','rsnode', 'rs'] ] #FIXME: remove redundancy between rs & rsnode
         for n in all_nodes:
             for o in self.getAvailableOptions():
                 assert o, 'implementation error'
+                # TODO: if o has __prefix attribute add prefix  argument to setOption()
                 n.setOption(o, Scope(ScopeTier.Global))
         
     

--- a/seedemu/layers/Scion.py
+++ b/seedemu/layers/Scion.py
@@ -212,7 +212,7 @@ class ScionBuilder():
         But doesn't configure them ( /etc/scion config dir is untouched by it)
         The install is performed as instructed by the nodes SetupSpec option.
         """
-        spec = node.getOption('setup_spec')
+        spec = node.getOption('setup_spec', prefix='scion')
         assert spec != None, 'implementation error - all nodes are supposed to have a SetupSpecification set by ScionRoutingLayer'
 
         match s:=spec.value:
@@ -227,7 +227,7 @@ class ScionBuilder():
                 self._installFromDebPackage(node)
 
     def nameOfCmd(self, cmd, node: Node) -> str:
-        spec = node.getOption('setup_spec')
+        spec = node.getOption('setup_spec', prefix='scion')
         assert spec != None, 'implementation error - all nodes are supposed to have a SetupSpecification set by ScionRoutingLayer'
         assert cmd in ['router', 'control', 'dispatcher', 'daemon'], f'unknown SCION distributable {cmd}'
         match spec.value:
@@ -273,11 +273,11 @@ class ScionBuilder():
         #node.addSoftware("apt-transport-https")
         #node.addSoftware("ca-certificates") # by whom are these required exactly ?! only the deb-packages ?!
 
-        if node.getOption("rotate_logs").value == "true":
+        if node.getOption("rotate_logs", prefix='scion').value == "true":
             node.addSoftware("apache2-utils")  # for rotatelogs
         # TODO actually i had to check if there's any option on this node
         # which has OptionMode.RUN_TIME set
-        if node.getOption("use_envsubst").value == "true":  # for envsubst
+        if node.getOption("use_envsubst", prefix='scion').value == "true":  # for envsubst
             node.addSoftware("gettext")
 
 

--- a/seedemu/layers/ScionRouting.py
+++ b/seedemu/layers/ScionRouting.py
@@ -294,10 +294,10 @@ class ScionRouting(Routing):
         #TODO: maybe add toLowerTOML(default_val: str) -> str checks here
         # since user can input any garbage as input i.e. "'False'"(capitalized str) or "False" (bool)
         # when constructing the option, that is not valid toml expected by SCION distributables
-        if node.getOption('use_envsubst').value == 'true' and node.getOption(flag).mode == OptionMode.RUN_TIME:
-            return f'${{{node.getOption(flag).name.upper()}}}'
+        if node.getOption('use_envsubst', prefix='scion').value == 'true' and node.getOption(flag, prefix='scion').mode == OptionMode.RUN_TIME:
+            return f"${{{node.getOption(flag, prefix='scion').name.upper()}}}"
         else:
-            return node.getOption(flag).value
+            return node.getOption(flag, prefix='scion').value
 
     def _nameOfCmd(self, cmd: str, node: Node):
         """!
@@ -375,8 +375,8 @@ class ScionRouting(Routing):
         for ((scope, type, name), obj) in reg.getAll().items():
 
             if type not in ['hnode', 'csnode', 'brdnode']: continue
-            nologrotate = obj.getOption('rotate_logs').value == "false"
-            useenvsubst = obj.getOption('use_envsubst').value == 'true'
+            nologrotate = obj.getOption('rotate_logs', prefix='scion').value == "false"
+            useenvsubst = obj.getOption('use_envsubst', prefix='scion').value == 'true'
 
             # SCION inter-domain routing affects only border-routers
             if type == "brdnode":
@@ -442,8 +442,8 @@ class ScionRouting(Routing):
 
     def __append_scion_command(self, node: Node):
         """Append commands for starting the SCION host stack on the node."""
-        nologrotate = node.getOption('rotate_logs').value == "false"
-        useenvsubst = node.getOption('use_envsubst').value == 'true'
+        nologrotate = node.getOption('rotate_logs', prefix='scion').value == "false"
+        useenvsubst = node.getOption('use_envsubst', prefix='scion').value == 'true'
 
         disp_log = (">> /var/log/scion-dispatcher.log 2>&1"
                      if nologrotate
@@ -505,7 +505,7 @@ class ScionRouting(Routing):
                                          loglevel=lvl)
         +             _Templates["trust_db"].format(name="sd1")
         +             _Templates["path_db"].format(name="sd1"))
-        if node.getOption('serve_metrics').value=='true':
+        if node.getOption('serve_metrics', prefix='scion').value=='true':
             sciond_conf += _Templates["metrics"].format(node.getLocalIPAddress(), 30455)
         # No [features] for daemon
         handleScionConfFile(node, 'sciond.toml', sciond_conf)
@@ -531,7 +531,7 @@ class ScionRouting(Routing):
             raise ValueError(f"Node {node.getName()} has no interface in the control service network")
 
         dispatcher_conf = _Templates["dispatcher"].format(isd_as=isd_as, ip=ip)
-        if node.getOption('serve_metrics').value == 'true':
+        if node.getOption('serve_metrics', prefix='scion').value == 'true':
             dispatcher_conf += _Templates["metrics"].format(node.getLocalIPAddress(), 30441)
         handleScionConfFile(node, 'dispatcher.toml', dispatcher_conf)
 
@@ -552,7 +552,7 @@ class ScionRouting(Routing):
             config_content += _Templates['features'].format('\n'.join(_kvals_features) )
 
 
-        if router.getOption('serve_metrics').value == 'true' and (local_ip:=router.getLocalIPAddress()) != None:
+        if router.getOption('serve_metrics', prefix='scion').value == 'true' and (local_ip:=router.getLocalIPAddress()) != None:
             config_content += _Templates["metrics"].format(local_ip, 30442)
 
         handleScionConfFile(router, name + ".toml", config_content)
@@ -794,7 +794,7 @@ class ScionRouting(Routing):
         +  _Templates["path_db"].format(name=name)
         +  _Templates['features'].format('\n'.join(_features))
         )
-        if node.getOption('serve_metrics').value == 'true':
+        if node.getOption('serve_metrics', prefix='scion').value == 'true':
             cs_config += _Templates["metrics"].format(node.getLocalIPAddress(), 30452)
         cs_config += "\n".join(beaconing)
         handleScionConfFile(node, name + '.toml', cs_config)

--- a/seedemu/options/Sysctl.py
+++ b/seedemu/options/Sysctl.py
@@ -1,0 +1,93 @@
+from seedemu.core import BaseOptionGroup, Option, OptionMode
+
+
+class SysctlOpts(BaseOptionGroup):
+# NOTE: the classname is dynamically changed to just 'sysctl' so the
+# nested option names don't become too lengthy...
+
+    class NetIpv4(BaseOptionGroup):
+
+        class IP_FORWARD(Option):
+            """net.ipv4.ip_forward flag"""
+            value_type = bool
+            @classmethod
+            def supportedModes(cls) -> OptionMode:
+                """!@brief 'ip_forward' sysctl flag can be changed in the 'sysctl:' section 
+                    of the node's service definition in docker-compose.yml file.
+                    This does not require an image rebuild.
+                """
+                return OptionMode.BUILD_TIME|OptionMode.RUN_TIME
+            @classmethod
+            def default(cls):
+                return True
+            def __repr__(self):
+                return f"net.ipv4.{self.getName().lower()}={'1' if self._mutable_value else '0'}"
+            
+        class Conf(BaseOptionGroup):
+            """
+            net.ipv4.conf.* flags
+            @note the sequence is changed compared to linux sysctl.
+                Name of the flag preceedes the name of the interface:
+                    net.ipv4.conf.rp_filter.all = 1
+                            .conf.rp_filter.net0 = 1
+                                ...
+                Add all interface settings directlz here:
+                - log_martians
+                - mc_forwarding
+                - proxy_arp
+                - forwarding
+                .etc . . .
+                The actual value of the options/sysctl-flags is a map
+                 {interface_id(or 'all|default') -> option_value}
+
+            """
+
+            # /conf/[all|default|interface]/{rp_filter,log_martians, ..} 
+            # all..sets a value for all interfaces
+            # 'interface' .. changes special settings per interface 
+            # (where "interface" is the name of your network interface)
+
+            class RP_FILTER(Option):
+                value_type = dict
+
+                @classmethod
+                def supportedModes(cls) -> OptionMode:
+                    """@note values for 'all' & 'default' interfaces can be set in docker-compose.yml (RUNTIME).
+                            However flags for interfaces with custom names (i.e. 'net0')
+                            that are renamed by /interface_setup script on startup have to be set in /start.sh script(BUILD_TIME).
+
+                    """
+                    return OptionMode.BUILD_TIME|OptionMode.RUN_TIME
+                
+                def all(self) -> bool:
+                    return self._mutable_value.get('all', False)
+                
+                def default(self) -> bool:
+                    return self._mutable_value.get('default', False)
+                
+                @classmethod
+                def default(cls):
+                    return {'all': False, 'default': False}
+                
+                def __repr__(self):
+                    vals = []
+                    for _if, val in self._mutable_value.items():
+                      vals.append( f"net.ipv4.conf.{_if}.{self.getName().lower()}={'1' if  val else '0'}" )
+                    return '\n           '.join(vals)
+
+                def repr_build_time(self):
+                    vals = []
+                    for _if, val in self._mutable_value.items():
+                      if _if not in ['all', 'default']:
+                        vals.append( f"net.ipv4.conf.{_if}.{self.getName().lower()}={'1' if  val else '0'}" )
+                    return '\n           '.join(vals)
+                
+                def repr_runtime(self):
+                    vals = []
+                    for _if, val in self._mutable_value.items():
+                      if _if in ['all', 'default']:
+                        vals.append( f"net.ipv4.conf.{_if}.{self.getName().lower()}={'1' if  val else '0'}" )
+                    return '\n           '.join(vals)
+                
+            #value_type =  bool for some 'int' for others
+

--- a/seedemu/options/__init__.py
+++ b/seedemu/options/__init__.py
@@ -1,0 +1,1 @@
+from .Sysctl import *


### PR DESCRIPTION
make them options that can have  different values per container.
Not all [sysctl flags](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt) are supported yet. They can simply be added gradually to the sysctl option group as required.