### PR TITLE
Fix ModuleNotFoundError: No module named 'urllib3.packages.six.moves' by updating requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ rpds-py==0.23.1
 six==1.17.0
 toolz==1.0.0
 typing_extensions==4.12.2
-urllib3==1.25.11
+urllib3==1.26.20
 varint==1.0.2
 web3==5.31.1
 websocket-client==1.8.0


### PR DESCRIPTION
Users are encountering the following error when running the project:

ModuleNotFoundError: No module named 'urllib3.packages.six.moves'


