### PR TITLE
Add workflow_dispatch and test flags for more control

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -4,6 +4,34 @@ on:
   pull_request:
     branches:
       - master
+    workflow_dispatch:
+      inputs:
+        run-quick-tests:
+          description: "Run quick tests"
+          type: boolean
+          required: false
+          default: "false"
+        run-basic-tests:
+          description: "Run basic tests"
+          type: boolean
+          required: false
+          default: "true"
+        run-internet-tests:
+          description: "Run internet tests"
+          type: boolean
+          required: false
+          default: "true"
+        run-blockchain-tests:
+          description: "Run blockchain tests"
+          type: boolean
+          required: false
+          default: "false"
+        run-scion-tests:
+          description: "Run SCION tests"
+          type: boolean
+          required: false
+          default: "true"
+
 
 jobs:
   compile-examples:
@@ -22,6 +50,7 @@ jobs:
           cache-dependency-path: "**/*requirements.txt"
       - run: pip install -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
       - name: Get scion-pki
+        if: ${{ github.event.inputs.run-scion-tests == 'true' }}
         run: |
           curl -fsSL -O https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz
           mkdir bin
@@ -30,7 +59,20 @@ jobs:
         run: |
           source development.env
           export PATH=$PATH:$PWD/bin
-          tests/compile-and-build-test/compile-test.py
+          CMD="tests/compile-and-build-test/compile-test.py"
+          if [ "${{ github.event.inputs.run-basic-tests }}" == "true" ]; then
+            CMD+=" --basic"
+          fi
+          if [ "${{ github.event.inputs.run-internet-tests }}" == "true" ]; then
+            CMD+=" --internet"
+          fi
+          if [ "${{ github.event.inputs.run-blockchain-tests }}" == "true" ]; then
+            CMD+=" --blockchain"
+          fi
+          if [ "${{ github.event.inputs.run-scion-tests }}" == "true" ]; then
+            CMD+=" --scion"
+          fi
+          python CMD
 
   run-tests:
     name: Run Tests
@@ -49,6 +91,7 @@ jobs:
           cache-dependency-path: "**/*requirements.txt"
       - run: pip install -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
       - name: Get scion-pki
+        if: ${{ github.event.inputs.run-scion-tests == 'true' }}
         run: |
           curl -fsSL -O https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz
           mkdir bin
@@ -57,7 +100,23 @@ jobs:
         run: |
           source development.env
           export PATH=$PATH:$PWD/bin
-          tests/run-tests.py --ci
+          CMD="tests/run-tests.py"
+          if [ "${{ github.event.inputs.run-quick-tests }}" == "true" ]; then
+            CMD+=" --ci"
+          fi
+          if [ "${{ github.event.inputs.run-basic-tests }}" == "true" ]; then
+            CMD+=" --basic"
+          fi
+          if [ "${{ github.event.inputs.run-internet-tests }}" == "true" ]; then
+            CMD+=" --internet"
+          fi
+          if [ "${{ github.event.inputs.run-blockchain-tests }}" == "true" ]; then
+            CMD+=" --blockchain"
+          fi
+          if [ "${{ github.event.inputs.run-scion-tests }}" == "true" ]; then
+            CMD+=" --scion"
+          fi
+          python CMD
       - name: Archive test results
         uses: actions/upload-artifact@v4
         with:
@@ -86,6 +145,7 @@ jobs:
           cache-dependency-path: "**/*requirements.txt"
       - run: pip install -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
       - name: Get scion-pki
+        if: ${{ github.event.inputs.run-scion-tests == 'true' }}
         run: |
           curl -fsSL -O https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz
           mkdir bin
@@ -95,7 +155,23 @@ jobs:
           source development.env
           export PATH=$PATH:$PWD/bin
           cd tests/compile-and-build-test
-          ./compile-and-build-test.py
+          CMD="tests/compile-and-build-test/build-test.py"
+          if [ "${{ github.event.inputs.run-quick-tests }}" == "true" ]; then
+            CMD+=" --quick"
+          fi
+          if [ "${{ github.event.inputs.run-basic-tests }}" == "true" ]; then
+            CMD+=" --basic"
+          fi
+          if [ "${{ github.event.inputs.run-internet-tests }}" == "true" ]; then
+            CMD+=" --internet"
+          fi
+          if [ "${{ github.event.inputs.run-blockchain-tests }}" == "true" ]; then
+            CMD+=" --blockchain"
+          fi
+          if [ "${{ github.event.inputs.run-scion-tests }}" == "true" ]; then
+            CMD+=" --scion"
+          fi
+          python CMD
       - name: Archive test results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -4,33 +4,33 @@ on:
   pull_request:
     branches:
       - master
-    workflow_dispatch:
-      inputs:
-        run-quick-tests:
-          description: "Run quick tests"
-          type: boolean
-          required: false
-          default: "false"
-        run-basic-tests:
-          description: "Run basic tests"
-          type: boolean
-          required: false
-          default: "true"
-        run-internet-tests:
-          description: "Run internet tests"
-          type: boolean
-          required: false
-          default: "true"
-        run-blockchain-tests:
-          description: "Run blockchain tests"
-          type: boolean
-          required: false
-          default: "false"
-        run-scion-tests:
-          description: "Run SCION tests"
-          type: boolean
-          required: false
-          default: "true"
+  workflow_dispatch:
+    inputs:
+      run-quick-tests:
+        description: "Run quick tests"
+        type: boolean
+        required: false
+        default: "false"
+      run-basic-tests:
+        description: "Run basic tests"
+        type: boolean
+        required: false
+        default: "true"
+      run-internet-tests:
+        description: "Run internet tests"
+        type: boolean
+        required: false
+        default: "true"
+      run-blockchain-tests:
+        description: "Run blockchain tests"
+        type: boolean
+        required: false
+        default: "false"
+      run-scion-tests:
+        description: "Run SCION tests"
+        type: boolean
+        required: false
+        default: "true"
 
 
 jobs:
@@ -72,7 +72,7 @@ jobs:
           if [ "${{ github.event.inputs.run-scion-tests }}" == "true" ]; then
             CMD+=" --scion"
           fi
-          python CMD
+          python $CMD
 
   run-tests:
     name: Run Tests
@@ -116,7 +116,7 @@ jobs:
           if [ "${{ github.event.inputs.run-scion-tests }}" == "true" ]; then
             CMD+=" --scion"
           fi
-          python CMD
+          python $CMD
       - name: Archive test results
         uses: actions/upload-artifact@v4
         with:
@@ -171,7 +171,7 @@ jobs:
           if [ "${{ github.event.inputs.run-scion-tests }}" == "true" ]; then
             CMD+=" --scion"
           fi
-          python CMD
+          python $CMD
       - name: Archive test results
         uses: actions/upload-artifact@v4
         with:

--- a/tests/compile-and-build-test/compile-and-build-test.py
+++ b/tests/compile-and-build-test/compile-and-build-test.py
@@ -5,9 +5,16 @@ import unittest as ut
 from seedemu import *
 import shutil
 import os, subprocess
+import argparse
 import getopt
 import sys
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--basic", action="store_true", help="Run basic tests")
+parser.add_argument("--internet", action="store_true", help="Run internet tests")
+parser.add_argument("--blockchain", action="store_true", help="Run blockchain tests")
+parser.add_argument("--scion", action="store_true", help="Run SCION tests")
+args = parser.parse_args()
 
 class CompileTest(ut.TestCase):
     @classmethod
@@ -24,7 +31,7 @@ class CompileTest(ut.TestCase):
             sys.exit(1)
 
         cls.platform
-        cls.test_list = {
+        basic_test_list = {
             "basic/A00_simple_as":                      (["simple_as.py"] , ["output"]),
             "basic/A01_transit_as" :                    (["transit_as.py"], ["output"]),
             "basic/A02_transit_as_mpls" :               (["transit_as_mpls.py"], ["output"]),
@@ -38,6 +45,8 @@ class CompileTest(ut.TestCase):
             "basic/A10_add_containers" :                (["add_containers.py"], ["output"]),
             #"basic/A20_nano_internet" :                 (["nano_internet.py"], ["output", "base_component.bin"]),
             "basic/A21_shadow_internet" :               (["shadow_internet.py"], ["output"]),
+        }
+        internet_test_list = {
             "internet/B00_mini_internet" :              (["mini_internet.py"], ["output"]),
             "internet/B01_dns_component" :              (["dns_component.py"], ["dns_component.bin"]),
             "internet/B02_mini_internet_with_dns" :     (["mini_internet_with_dns.py"], ["output", "base_internet.bin", "dns_component.bin"]),
@@ -58,19 +67,33 @@ class CompileTest(ut.TestCase):
             "internet/B28_traffic_generator/3-multi-traffic-generator": (["multi-traffic-generator.py"], ["output", "base_internet.bin"]),
             "internet/B50_bring_your_own_internet":     (["bring_your_own_internet.py", "bring_your_own_internet_client.py"], ["output", "output_0", "output_1", "output_2", "output_3", 'base_component.bin', 'base_hybrid_component.bin', 'hybrid_base_with_dns.bin', 'hybrid_dns_component.bin']),
             "internet/B51_bgp_prefix_hijacking":        (["bgp_prefix_hijacking.py"], ["output", 'base_internet.bin']),
-            #"blockchain/D00_ethereum_poa" :             (["ethereum_poa.py"], ["output", "component_base.bin", "component_poa.bin"]),
-            #"blockchain/D01_ethereum_pos" :             (["ethereum_pos.py"], ["output"]),
-            #"blockchain/D05_ethereum_small" :           (["ethereum_small.py"], ["output"]),
-            #"blockchain/D20_faucet" :                   (["faucet.py"], ["output", "component_base.bin", "component_poa.bin", "blockchain_poa.bin"]),
-            #"blockchain/D21_deploy_contract" :          (["deploy_contract.py"], ["output", "component_base.bin", "component_poa.bin", "blockchain_poa.bin"]),
-            #"blockchain/D22_oracle" :                   (["simple_oracle.py"], ["output", "ethereum-small.bin"]),
-            #"blockchain/D31_chainlink" :                (["chainlink.py"], ["output", "component_base.bin", "component_poa.bin", "blockchain_poa.bin"]),
-            #"blockchain/D50_blockchain" :               (["blockchain.py"], ["output", "blockchain_poa.bin"]),
+        }
+        blockchain_test_list = {
+            "blockchain/D00_ethereum_poa" :             (["ethereum_poa.py"], ["output", "component_base.bin", "component_poa.bin"]),
+            "blockchain/D01_ethereum_pos" :             (["ethereum_pos.py"], ["output"]),
+            "blockchain/D05_ethereum_small" :           (["ethereum_small.py"], ["output"]),
+            "blockchain/D20_faucet" :                   (["faucet.py"], ["output", "component_base.bin", "component_poa.bin", "blockchain_poa.bin"]),
+            "blockchain/D21_deploy_contract" :          (["deploy_contract.py"], ["output", "component_base.bin", "component_poa.bin", "blockchain_poa.bin"]),
+            "blockchain/D22_oracle" :                   (["simple_oracle.py"], ["output", "ethereum-small.bin"]),
+            "blockchain/D31_chainlink" :                (["chainlink.py"], ["output", "component_base.bin", "component_poa.bin", "blockchain_poa.bin"]),
+            "blockchain/D50_blockchain" :               (["blockchain.py"], ["output", "blockchain_poa.bin"]),
+        }
+        scion_test_list = {
             "scion/S01_scion":                          (["scion.py"], ["output"]),
             "scion/S02_scion_bgp_mixed":                (["scion_bgp_mixed.py"], ["output"]),
             "scion/S03_bandwidth_tester":               (["bandwidth_tester.py"], ["output"]),
             "scion/S04_docker_api":                     (["docker_api.py"], ["output"]),
         }
+        cls.test_list = {
+        }
+        if args.basic:
+            cls.test_list.update(basic_test_list)
+        if args.internet:
+            cls.test_list.update(internet_test_list)
+        if args.blockchain:
+            cls.test_list.update(blockchain_test_list)
+        if args.scion:
+            cls.test_list.update(scion_test_list)
         # This is my path
         cls.init_cwd = os.getcwd()
 

--- a/tests/compile-and-build-test/compile-test.py
+++ b/tests/compile-and-build-test/compile-test.py
@@ -5,19 +5,32 @@ import subprocess
 import sys
 import os
 import shutil
+import argparse
 from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--basic", action="store_true", help="Run basic tests")
+parser.add_argument("--internet", action="store_true", help="Run internet tests")
+parser.add_argument("--blockchain", action="store_true", help="Run blockchain tests")
+parser.add_argument("--scion", action="store_true", help="Run SCION tests")
+args = parser.parse_args()
 
 """
 Compiles examples in examples/ and outputs the number of examples that fail to
 compile.
 """
 
-examples_dirs = [
-    Path("examples/basic"),
-    Path("examples/blockchain"),
-    Path("examples/internet"),
-    Path("examples/scion"),
-]
+examples_dirs = []
+
+if args.basic:
+    examples_dirs.append(Path("examples/basic"))
+if args.internet:
+    examples_dirs.append(Path("examples/internet"))
+if args.blockchain:
+    examples_dirs.append(Path("examples/blockchain"))
+if args.scion:
+    examples_dirs.append(Path("examples/scion"))
+
 
 
 def glob_examples(dir: Path):

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -22,24 +22,45 @@ args = parser.parse_args()
 os.environ['platform'] = args.platform
 
 test_case_list = [
-    MiniInternetTestCase,
-    IPAnyCastTestCase,
-    HostMgmtTestCase,
+]
+
+blockchain_tests = [
     EthereumPOATestCase,
     EthereumPOSTestCase,
     EthereumPOWTestCase,
     ChainlinkPOATestCase,
-    EthUtilityPOATestCase,
+    EthUtilityPOATestCase
+]
+
+scion_tests = [
     ScionLargeASNTestCase,
     ScionBgpMixedTestCase,
-    ScionBwtesterTestCase,
+    ScionBwtesterTestCase
+]
+
+basic_tests = [
+    MiniInternetTestCase,
     SEEDEmuOptionSystemTestCase,
+        ]
+
+internet_tests = [
     KuboTestCase,
     KuboUtilFuncsTestCase,
-    DottedDictTestCase,
+    IPAnyCastTestCase,
+    HostMgmtTestCase,
     PKITestCase,
+    DottedDictTestCase,
     TrafficGeneratorTestCase
-]
+        ]
+
+if args.basic:
+    test_case_list.extend(basic_tests)
+if args.internet:
+    test_case_list.extend(internet_tests)
+if args.blockchain:
+    test_case_list.extend(blockchain_tests)
+if args.scion:
+    test_case_list.extend(scion_tests)
 
 if args.ci:
     test_case_list = [


### PR DESCRIPTION
Previously, all tests (basic, internet, and Scion) ran automatically on every push to the master branch, with no option for manual execution on other branches. 

This PR introduces:
- `workflow_dispatch` to allow manual triggering of the workflow on any branch.
- Flags to select which type(s) of tests to run.

Implementation details:
- Flags are added in the workflow_dispatch section of the GitHub Actions YAML.
- The workflow passes these flags to the Python test scripts.
- Python scripts use the flags to run only the selected tests.

This will allow developers to easily run specific test types on-demand, improving workflow flexibility and reducing unnecessary test runs.
