### PR TITLE
Add rsAddress

### DIFF
--- a/seedemu/core/InternetExchange.py
+++ b/seedemu/core/InternetExchange.py
@@ -19,7 +19,7 @@ class InternetExchange(Printable, Configurable):
     __rs: Node
     __name: str
 
-    def __init__(self, id: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs = True):
+    def __init__(self, id: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs = True, rsAdress = None):
         """!
         @brief InternetExchange constructor.
 
@@ -29,7 +29,8 @@ class InternetExchange(Printable, Configurable):
         @param create_rs (optional) create route server node for the IX or not.
           ( route servers are only relevant for BGP, thus the default is True. But RSes can be disabled for SCION)
         """
-
+        if create_rs== True and id>254 :
+            assert rsAdress!=None, "rsAdress can't be None"
         self.__id = id
 
         assert prefix != "auto" or self.__id <= 255, "can't use auto: id > 255"
@@ -39,8 +40,11 @@ class InternetExchange(Printable, Configurable):
         self.__net = Network(self.__name, NetworkType.InternetExchange, network, aac, False)
 
         if create_rs:
-            self.__rs = Router(self.__name, NodeRole.RouteServer, self.__id)      
-            self.__rs.joinNetwork(self.__name)
+            self.__rs = Router(self.__name, NodeRole.RouteServer, self.__id) 
+            if rsAdress == None: 
+                self.__rs.joinNetwork(self.__name)
+            else:
+                self.__rs.joinNetwork(self.__name, rsAdress)
         else:
             self.__rs = None
 

--- a/seedemu/core/InternetExchange.py
+++ b/seedemu/core/InternetExchange.py
@@ -19,7 +19,7 @@ class InternetExchange(Printable, Configurable):
     __rs: Node
     __name: str
 
-    def __init__(self, id: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs = True, rsAdress = None):
+    def __init__(self, id: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs = True, rsAddress = None):
         """!
         @brief InternetExchange constructor.
 
@@ -28,9 +28,10 @@ class InternetExchange(Printable, Configurable):
         @param aac (option) AddressAssignmentConstraint to use.
         @param create_rs (optional) create route server node for the IX or not.
           ( route servers are only relevant for BGP, thus the default is True. But RSes can be disabled for SCION)
+        @param rsAddress (optional) specific address for the route server. (Required if id > 254)
         """
-        if create_rs== True and id>254 :
-            assert rsAdress!=None, "rsAdress can't be None"
+        if create_rs and id > 254: 
+            assert rsAddress != None, "rsAddress can't be None if id > 254"
         self.__id = id
 
         assert prefix != "auto" or self.__id <= 255, "can't use auto: id > 255"
@@ -41,10 +42,10 @@ class InternetExchange(Printable, Configurable):
 
         if create_rs:
             self.__rs = Router(self.__name, NodeRole.RouteServer, self.__id) 
-            if rsAdress == None: 
+            if rsAddress == None: 
                 self.__rs.joinNetwork(self.__name)
             else:
-                self.__rs.joinNetwork(self.__name, rsAdress)
+                self.__rs.joinNetwork(self.__name, rsAddress)
         else:
             self.__rs = None
 

--- a/seedemu/layers/Base.py
+++ b/seedemu/layers/Base.py
@@ -170,7 +170,7 @@ class Base(Layer, Graphable):
         asn = asObject.getAsn()
         self.__ases[asn] = asObject
 
-    def createInternetExchange(self, asn: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs=True) -> InternetExchange:
+    def createInternetExchange(self, asn: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs=True, rsAdress = None) -> InternetExchange:
         """!
         @brief Create a new InternetExchange.
 
@@ -181,7 +181,7 @@ class Base(Layer, Graphable):
         @throws AssertionError if IX exists.
         """
         assert asn not in self.__ixes, "ix{} already exist.".format(asn)
-        self.__ixes[asn] = InternetExchange(asn, prefix, aac, create_rs)
+        self.__ixes[asn] = InternetExchange(asn, prefix, aac, create_rs, rsAdress)
         return self.__ixes[asn]
 
     def getInternetExchange(self, asn: int) -> InternetExchange:

--- a/seedemu/layers/Base.py
+++ b/seedemu/layers/Base.py
@@ -170,18 +170,20 @@ class Base(Layer, Graphable):
         asn = asObject.getAsn()
         self.__ases[asn] = asObject
 
-    def createInternetExchange(self, asn: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs=True, rsAdress = None) -> InternetExchange:
+    def createInternetExchange(self, asn: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs=True, rsAddress = None) -> InternetExchange:
         """!
         @brief Create a new InternetExchange.
 
         @param asn ASN of the new IX.
         @param prefix (optional) prefix of the IX peering LAN.
         @param aac (optional) Address assignment constraint.
+        @param create_rs (optional) create route server node for the IX or not.
+        @param rsAddress (optional) specific address for the route server.
         @returns created IX.
         @throws AssertionError if IX exists.
         """
         assert asn not in self.__ixes, "ix{} already exist.".format(asn)
-        self.__ixes[asn] = InternetExchange(asn, prefix, aac, create_rs, rsAdress)
+        self.__ixes[asn] = InternetExchange(asn, prefix, aac, create_rs, rsAddress)
         return self.__ixes[asn]
 
     def getInternetExchange(self, asn: int) -> InternetExchange:


### PR DESCRIPTION
Previously, the createInternetExchange function and InternetExchange class lacked the ability to specify rsAddress, which would cause an error when calling base.createInternetExchange(asn = 33108, prefix = '206.81.80.0/23'). These two have now been modified to add support for specifying the RS IP address.