### PR TITLE
feat(seedops): add OPS control-plane reliability suite (capabilities, retries/on_error, chunked artifacts, pcap) and docs alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ project-words.txt
 **/.obsidian/**
 test_result.txt
 .env
+.seedops/
 Gmail
 QQ
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ including Blockchain, Botnet, and many other useful elements of the Internet.
 
 -  [Getting Started](#getting-started)
 -  [User Manuals](#user-manuals)
+-  [MCP Ops Control Plane (SeedOps)](#mcp-ops-control-plane-seedops)
 -  [Contributing](#contributing)
 -  [License](#license)
 
@@ -82,6 +83,13 @@ To run an example, do the following:
 ## User Manuals
 
 User manuals are provided inside the [docs/user_manual/](./docs/user_manual) folder.
+
+## MCP Ops Control Plane (SeedOps)
+
+This repository includes an MCP server for operating **already-running** Docker/Compose simulations
+(workspace attachment, inventory/selector, batch exec/logs, BGP summary, and YAML playbooks/jobs).
+
+See [SeedOps user manual](./docs/user_manual/mcp_seedops.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ High-level agent and Codex integration live in:
 
 - `../seed-agent/README.md`
 
+Recommended closed-loop launcher from `seed-agent`:
+
+- `../seed-agent/scripts/seed-codex up`
+- `../seed-agent/scripts/seed-codex ui`
+
 ---
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,100 +1,121 @@
-Internet Emulator
----
+# SEED Emulator (`seed-email-service`)
 
-The objective of the SEED-Emulator project is to help create emulators of 
-the Internet. These emulators are for educational uses, and they can be
-used as the platform for designing hands-on lab exercises for various subjects,
-including cybersecurity, networking, etc.
+`seed-email-service` is the core SEED Emulator repository. It provides:
 
-The project provides essential elements of the Internet (as Python classes), including 
-Internet exchanges, autonomous systems, BGP routers, DNS infrastructure, 
-a variety of services. Users can use these elements as the building blocks
-to build their emulation programmatically. The output of the program 
-is a set of docker container folders/files. When these containers are built and 
-started, they form a small-size Internet. New building blocks are being added,
-including Blockchain, Botnet, and many other useful elements of the Internet. 
+- programmable Internet emulation (AS/IX/BGP/DNS/services)
+- compiler outputs to Docker/Compose runtimes
+- a modern MCP operations control plane (`SeedOps`) for running labs
+
+This repo now supports two complementary workflows:
+
+1. **BUILD path**: define topology -> compile -> run containers
+2. **OPS path**: attach to running output -> observe/operate via MCP tools
 
 ![The Web UI](./docs/assets/web-ui.png)
 
-## Table of Contents
+---
 
--  [Getting Started](#getting-started)
--  [User Manuals](#user-manuals)
--  [MCP Ops Control Plane (SeedOps)](#mcp-ops-control-plane-seedops)
--  [Contributing](#contributing)
--  [License](#license)
+## Quick Start (BUILD path)
 
+### Prerequisites
 
-## Getting Started
+- `python3`
+- `docker`
+- `docker-compose` (or compose plugin)
 
-### Install the necessary software
+### Environment
 
-To run the emulator, you need to install `docker`, `docker-compose`, 
-and `python3`.
+```bash
+source development.env
+```
 
+For persistent usage, add repo root to `PYTHONPATH` in your shell profile.
 
-### Set up the project
+### Run a minimal example
 
-To run the emulator code, we can add this folder to the `PYTHONPATH` environment variable. Running `source development.env` 
-inside the project's root directory can temporarily run our code but will lose its effect when you restart your shell. We do recommend to permanently add the project's root directory to the `PYTHONPATH` environment variable.
+```bash
+cd examples/basic/A00_simple_as
+python3 simple_as.py
+cd output
+docker-compose build && docker-compose up
+```
 
-### Set up the proxy (not needed if you don't have an issue)
+After startup, routers need time to converge.
 
-The emulator needs to fetch docker images from the Docker Hub. 
-If you are in Mainland China, you may not be able to directly get the 
-docker images. However, there are many docker hub proxies that 
-you can use. Please follow [these instructions](./docs/user_manual/dockerhub_proxy.md)
-to set up the docker hub proxies.
+---
 
-However, sometimes the docker hub proxies are not working or working incredibly slow. In this case, we recommend you to build the docker images locally in your docker hub. 
+## Quick Start (OPS path / SeedOps MCP)
 
-Please follow [these instructions](./docker_images/README.md) to build the docker images locally.
+Start SeedOps MCP server:
 
-If you do not have such an issue, please skip this step. 
+```bash
+cd mcp-server
+export SEED_MCP_TOKEN=your-bearer-token
+export FASTMCP_HOST=127.0.0.1 FASTMCP_PORT=8000 FASTMCP_STREAMABLE_HTTP_PATH=/mcp
+python serve_http.py
+```
 
+Then use a client (for example `seed-agent`) to call SeedOps tools:
 
-### Run Examples
+- workspace attach (`workspace_attach_compose` / `workspace_attach_labels`)
+- inventory + selectors (`inventory_list_nodes`)
+- batch ops (`ops_exec`, `ops_logs`, `routing_bgp_summary`)
+- async jobs/artifacts (`playbook_run`, `job_get`, `artifacts_list`)
 
-We have provided many examples in the [examples/](./examples/) folder. 
-Detailed explanations are provided the README file in each example folder.
-To run an example, do the following:
+SeedOps manual:
 
-1. Pick an example, for example, `A00-simple-as`. 
+- `docs/user_manual/mcp_seedops.md`
 
-2. Build the emulation. For this example, go to `examples/A00-simple-as/`, and
-   run `python3 ./simple-as.py`. The container files will be created inside the
-  `output/` folder. For some examples, such as `B02-mini-internet-with-dns`,
-   they depend on other examples, so you need to run those examples first. 
+---
 
-3. Build and run the generated containers. First `cd output/`, then do `docker-compose
-   build && docker-compose up`. The emulator will start running. Give it a
-   minute or two (or longer if your emulator is large) to let the routers do
-   their jobs.
+## Repository map
 
-4. Some examples already include the visualization container (called Internet
-   Map).  Point your browser to `http://127.0.0.1:8080/map.html`, and you will
-   see the visualization. More instructions on how to use the visualization app
-   is given in [this manual](./docs/user_manual/internet_map.md).  If the map
-   is not included, you can open a new terminal window, navigate to the project
-   root directory, cd to `client/`, and run `docker-compose build &&
-   docker-compose up`. This will bring up the Internet Map container. 
+```text
+seed-email-service/
+├── examples/                 # Topology and scenario examples
+├── mcp-server/               # SeedOps MCP server implementation
+├── docs/user_manual/         # User manuals and feature guides
+├── library/, seedemu/        # Emulator core packages
+├── docker_images/            # Container image build assets
+└── client/                   # Visualization/client components
+```
 
+---
 
-## User Manuals
+## Documentation entrypoints
 
-User manuals are provided inside the [docs/user_manual/](./docs/user_manual) folder.
+- Main user manual index: `docs/user_manual/README.md`
+- Build flow overview: `docs/user_manual/overall_flow.md`
+- SeedOps MCP operations: `docs/user_manual/mcp_seedops.md`
+- Example catalogs:
+  - `examples/basic/README.md`
+  - `examples/internet/README.md`
+  - `examples/blockchain/README.md`
+  - `examples/scion/README.md`
 
-## MCP Ops Control Plane (SeedOps)
+---
 
-This repository includes an MCP server for operating **already-running** Docker/Compose simulations
-(workspace attachment, inventory/selector, batch exec/logs, BGP summary, and YAML playbooks/jobs).
+## Notes for constrained network environments
 
-See [SeedOps user manual](./docs/user_manual/mcp_seedops.md).
+If Docker Hub access is unstable:
+
+- configure proxy: `docs/user_manual/dockerhub_proxy.md`
+- or build local images: `docker_images/README.md`
+
+---
+
+## Related repository
+
+High-level agent and Codex integration live in:
+
+- `../seed-agent/README.md`
+
+---
 
 ## Contributing
 
-Contributions to SEED-Emulator are always welcome. For contribution guidelines, please see [CONTRIBUTING](./CONTRIBUTING.md).
+See `CONTRIBUTING.md`.
 
 ## License
 
-The software is licensed under the GNU General Public License v3.0 license, with copyright by The SEED-Emulator Developers (see [LICENSE](./LICENSE.txt)).
+GNU GPL v3.0, see `LICENSE.txt`.

--- a/docs/user_manual/README.md
+++ b/docs/user_manual/README.md
@@ -19,6 +19,10 @@ This document provides a portal to those examples.
   - [Docker image](./docker.md): generate images for AMD and ARM platforms, 
            use custom images 
 
+## MCP Operational Control Plane
+
+  - [SeedOps (operate already-running networks)](./mcp_seedops.md)
+
 ## [Internet Emulator: Components and Advanced Features](./internet/README.md)
 
 ## [Blockchain Emulator](./blockchain/README.md)

--- a/docs/user_manual/README.md
+++ b/docs/user_manual/README.md
@@ -1,30 +1,57 @@
-# User Manual for the SEED Emulator
+# SEED Emulator User Manual Index
 
-We have plenty of examples to demonstrate the usages of the SEED emulator.
-This document provides a portal to those examples.
+This is the primary manual hub for `seed-email-service`.
 
-## Internet Emulator: Basic elements
+---
 
-  - [Create an emulator: the overall flow](./overall_flow.md)
-  - [Autonomous system](./as.md)
-  - [Internet exchange](./internet_exchange.md)
-  - [BGP routers and Peering](./bgp.md) 
-  - [Routing](./routing.md) 
-  - [Node customization](./node.md): install software, add startup command, 
-           assign hostname, etc.
-  - [Component and Binding](./component.md): bind virtual nodes in component 
-           to physical nodes, filters  
-  - [Compilation](./compiler.md): generate emulation files (docker files)
-  - [Visualization](./visualization.md): visualize the emulated Internet
-  - [Docker image](./docker.md): generate images for AMD and ARM platforms, 
-           use custom images 
+## Recommended reading paths
 
-## MCP Operational Control Plane
+### Path A: Build and run a lab (first-time users)
 
-  - [SeedOps (operate already-running networks)](./mcp_seedops.md)
+1. [Overall flow](./overall_flow.md)
+2. [Autonomous system](./as.md)
+3. [BGP and peering](./bgp.md)
+4. [Compilation](./compiler.md)
+5. [Visualization](./visualization.md)
 
-## [Internet Emulator: Components and Advanced Features](./internet/README.md)
+### Path B: Operate an existing running lab (OPS)
 
-## [Blockchain Emulator](./blockchain/README.md)
+1. [SeedOps MCP guide](./mcp_seedops.md)
+2. [Selectors and inventory](./mcp_seedops.md#phase-1-workspaces--inventory)
+3. [Playbooks/jobs/artifacts](./mcp_seedops.md#phase-2-jobs--yaml-playbooks)
 
-## Frequently Asked Questions (FAQ)
+---
+
+## Core emulator manuals
+
+- [Create an emulator: overall flow](./overall_flow.md)
+- [Autonomous system](./as.md)
+- [Internet exchange](./internet_exchange.md)
+- [BGP routers and peering](./bgp.md)
+- [Routing](./routing.md)
+- [Node customization](./node.md)
+- [Component and binding](./component.md)
+- [Compilation](./compiler.md)
+- [Visualization](./visualization.md)
+- [Docker images](./docker.md)
+
+---
+
+## MCP operations control plane
+
+- [SeedOps: operate already-running networks](./mcp_seedops.md)
+
+---
+
+## Domain-specific manuals
+
+- [Internet advanced features](./internet/README.md)
+- [Blockchain emulator](./blockchain/README.md)
+
+---
+
+## Notes and troubleshooting
+
+- [General notes](./00_notes.md)
+- [Docker Hub proxy](./dockerhub_proxy.md)
+- [Misc manual topics](./misc.md)

--- a/docs/user_manual/index.md
+++ b/docs/user_manual/index.md
@@ -11,3 +11,4 @@ High-frequency links:
 - [Compilation](./compiler.md)
 - [Visualization](./visualization.md)
 - [SeedOps MCP operations](./mcp_seedops.md)
+- [SeedAgent/Codex one-command launcher](../../../seed-agent/README.md#quick-start)

--- a/docs/user_manual/index.md
+++ b/docs/user_manual/index.md
@@ -1,10 +1,13 @@
-# Manual of the SEED Internet Emulator
+# SEED Emulator Manual (Quick Index)
 
+Use `README.md` in this directory for the full navigation portal.
 
-## [BGP Peering](./bgp_peering.md) 
+High-frequency links:
 
-## [Component and Binding](./component.md) 
-
-## [Compilation](./compiler.md) 
-
-## [Visualization](./visualization.md)
+- [Overall flow](./overall_flow.md)
+- [Autonomous system](./as.md)
+- [BGP and peering](./bgp.md)
+- [Component and binding](./component.md)
+- [Compilation](./compiler.md)
+- [Visualization](./visualization.md)
+- [SeedOps MCP operations](./mcp_seedops.md)

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -187,16 +187,41 @@ Supported actions:
 - `ops_exec`
 - `ops_logs`
 - `routing_bgp_summary`
+- `ping`
+- `traceroute`
+- `inject_fault`
+- `capture_evidence`
 - `sleep`
+
+### Playbook templating (vars + step references)
+
+SeedOps playbooks support a **safe** templating syntax inside step args (and `save_as`):
+
+- Inline: `echo asn={{ vars.asn }}` → string interpolation
+- Full value: `selector: "{{ vars.selector }}"` → returns a **typed** object (dict/list/int/...)
+
+Expressions are **path-only** (no code execution): `a.b[0]['k']`.
+
+Template context keys:
+
+- `vars`: from `playbook.vars` (defaults to `{}`)
+- `workspace_id`, `job_id`
+- `steps.<step_id>` after a step runs:
+  - success: `{action, ok=true, summary, artifact_id, attempts}`
+  - failure (with `on_error: continue`): `{action, ok=false, error, attempts}`
 
 Example:
 
 ```yaml
 version: 1
 name: bgp_check
-defaults:
-  selector:
+vars:
+  routers:
     role: ["BorderRouter", "Router"]
+  dst: 1.1.1.1
+defaults:
+  # Full-template returns a dict (typed), so this works for selectors.
+  selector: "{{ vars.routers }}"
   timeout_seconds: 20
   parallelism: 30
   max_output_chars: 6000
@@ -214,10 +239,16 @@ steps:
     # selector can be omitted to use defaults.selector
     save_as: bgp_summary
 
+  - action: ping
+    id: ping_dst
+    dst: "{{ vars.dst }}"
+    count: 2
+    save_as: "ping_{{ vars.dst }}"
+
   - action: ops_exec
     id: routes
     selector: { asn: [150, 151] }
-    command: "ip route"
+    command: "echo parsed={{ steps.refresh.summary.counts.nodes_parsed }} && ip route"
     on_error: continue
     retries: 0
     save_as: routes_as150_151
@@ -230,9 +261,22 @@ Notes:
 
 - For `ops_exec/ops_logs/routing_bgp_summary/inventory_list_nodes`, selector is taken from `step.selector` or `defaults.selector`.
 - To select everything, explicitly pass `{}` (do not use `[]`).
+- `ping/traceroute/inject_fault/capture_evidence` also require a selector via `step.selector` or `defaults.selector` (use `{}` to select all).
 - `retries` is the number of retries after the first attempt (total attempts = `1 + retries`).
 - `on_error: continue` keeps the job running and the final job status becomes `succeeded_with_errors`.
 - `retry_delay_seconds` controls the delay between retries.
+
+### Diagnostic / forensics actions
+
+These actions are wrappers around `ops_exec` and share `timeout_seconds`, `parallelism`, and `max_output_chars` behavior:
+
+- `ping`: `{selector?, dst, count?}` → runs `ping -c <count> <dst>`
+- `traceroute`: `{selector?, dst}` → runs `traceroute -n <dst> || tracepath -n <dst>`
+- `inject_fault`: `{selector?, fault_type, params?, interface?}`:
+  - `packet_loss` (params=`10`), `latency` (params=`100`), `bandwidth` (params=`1mbit`)
+  - `kill_process` (params=`bird`), `disconnect` (params=`eth0`), `reset`
+- `capture_evidence`: `{selector?, evidence_type}`:
+  - `routing_snapshot`, `network_state`, `process_list`, `logs`, `full`
 
 ---
 

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -200,6 +200,9 @@ defaults:
   timeout_seconds: 20
   parallelism: 30
   max_output_chars: 6000
+  on_error: stop
+  retries: 1
+  retry_delay_seconds: 1
 
 steps:
   - action: workspace_refresh
@@ -215,6 +218,8 @@ steps:
     id: routes
     selector: { asn: [150, 151] }
     command: "ip route"
+    on_error: continue
+    retries: 0
     save_as: routes_as150_151
 
   - action: sleep
@@ -225,6 +230,9 @@ Notes:
 
 - For `ops_exec/ops_logs/routing_bgp_summary/inventory_list_nodes`, selector is taken from `step.selector` or `defaults.selector`.
 - To select everything, explicitly pass `{}` (do not use `[]`).
+- `retries` is the number of retries after the first attempt (total attempts = `1 + retries`).
+- `on_error: continue` keeps the job running and the final job status becomes `succeeded_with_errors`.
+- `retry_delay_seconds` controls the delay between retries.
 
 ---
 

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -84,6 +84,9 @@ Attach by Compose output directory (recommended):
 
 - Tool: `workspace_attach_compose(workspace_id, output_dir)`
 - It reads `output_dir/docker-compose.yml` and records `services.*.container_name`
+- Notes:
+  - `output_dir` must exist and contain `docker-compose.yml`
+  - If `services.*.container_name` are missing (empty list), the tool returns an error; use `workspace_attach_labels` instead
 
 Or attach by label scan:
 

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -160,11 +160,23 @@ Then poll:
 
 - `job_get(job_id)`
 - `job_steps_list(job_id, since_step_id=0, limit=200)`
-- `artifacts_list(job_id)` + `artifact_read(artifact_id)`
+- `artifacts_list(job_id)` then:
+  - `artifact_read(artifact_id)` (small text)
+  - `artifact_read_chunk(artifact_id, offset=0, max_bytes=65536)` (large/binary, remote-friendly)
 
 Cancel a running job:
 
 - `job_cancel(job_id)`
+
+### Artifacts (remote-friendly)
+
+Artifact `path` values are **server-local filesystem paths**. Remote clients should use `artifact_read` or `artifact_read_chunk`.
+
+To download an artifact in chunks:
+
+1. Call `artifacts_list(job_id)` to find `artifact_id`
+2. Repeatedly call `artifact_read_chunk(artifact_id, offset, max_bytes)` until `eof=true`
+3. Base64-decode `content_b64` and append bytes locally
 
 ### Playbook YAML schema (v1)
 
@@ -234,4 +246,3 @@ Snapshot types (current):
 
 - `inventory_summary`
 - `bgp_summary_counts`
-

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -1,0 +1,237 @@
+# MCP Ops Control Plane (SeedOps)
+
+SeedOps turns the `mcp-server` into an **operational control plane** for **already-running** SEED Emulator Docker/Compose networks.
+
+It is designed for:
+
+- Attaching to an existing `docker compose up -d` output (no rebuild needed)
+- Building a runtime **inventory** from SEED container labels
+- Selecting nodes via **selectors**
+- Running **batch operations** (`exec`, `logs`, `BGP` summary)
+- Running deterministic **YAML playbooks** as **async jobs** (with artifacts + snapshots)
+
+This guide covers both Phase 1 (workspace/inventory/ops) and Phase 2 (jobs/playbooks/collector).
+
+---
+
+## Security model (HTTP)
+
+- Transport: **MCP Streamable-HTTP**
+- Auth: **Bearer Token** (static shared secret)
+- No OAuth flow (Phase 1/2)
+- `server.py` (stdio) remains local/no-auth for backwards compatibility
+- `serve_http.py` enforces `SEED_MCP_TOKEN`
+
+---
+
+## Run the MCP HTTP server
+
+From the repo root:
+
+```bash
+cd mcp-server
+python3 -m pip install -r requirements.txt
+
+export SEED_MCP_TOKEN='change-me'
+export FASTMCP_HOST=0.0.0.0
+export FASTMCP_PORT=8000
+export FASTMCP_STREAMABLE_HTTP_PATH=/mcp
+export SEED_MCP_PUBLIC_URL=http://127.0.0.1:8000
+
+python3 serve_http.py
+```
+
+If you run with `FASTMCP_HOST=0.0.0.0` and clients connect remotely, set a reachable `SEED_MCP_PUBLIC_URL`.
+
+### DNS rebinding protection (important for remote clients)
+
+The server enables Host/Origin allowlists by default. If clients get `421 Invalid Host` or `403 Invalid Origin`:
+
+- Ensure `SEED_MCP_PUBLIC_URL` matches what clients use
+- Or explicitly extend allowlists:
+
+```bash
+export SEED_MCP_ALLOWED_HOSTS='seed-mcp.example.com:*,10.0.0.5:*'
+export SEED_MCP_ALLOWED_ORIGINS='http://seed-mcp.example.com:*,http://10.0.0.5:*'
+```
+
+You can disable this protection (not recommended on untrusted networks):
+
+```bash
+export SEED_MCP_DNS_REBINDING_PROTECTION=0
+```
+
+---
+
+## Data locations
+
+By default, SeedOps stores state under `mcp-server/.seedops/`:
+
+- DB: `mcp-server/.seedops/seedops.db` (override with `SEEDOPS_DB_PATH`)
+- Workspace data/artifacts: `mcp-server/.seedops/workspaces/` (override with `SEEDOPS_DATA_DIR`)
+
+---
+
+## Phase 1: Workspaces + Inventory
+
+### 1) Create a workspace
+
+Tool: `workspace_create(name)`
+
+### 2) Attach to an already-running network
+
+Attach by Compose output directory (recommended):
+
+- Tool: `workspace_attach_compose(workspace_id, output_dir)`
+- It reads `output_dir/docker-compose.yml` and records `services.*.container_name`
+
+Or attach by label scan:
+
+- Tool: `workspace_attach_labels(workspace_id, name_regex, label_prefix=...)`
+- Safer than scanning all containers because it filters by name + label prefix
+
+### 3) Refresh inventory
+
+Tool: `workspace_refresh(workspace_id)`
+
+### 4) List nodes (selector)
+
+Tool: `inventory_list_nodes(workspace_id, selector={})`
+
+Selector semantics:
+
+- AND across provided keys
+- OR inside list values
+- `labels` is AND across k/v
+- **Empty list matches nothing** (safer than matching everything)
+
+Common keys:
+
+- `asn`, `role`, `node_name`, `class`, `network`, `container_name`, `labels`
+
+---
+
+## Phase 1: Ops (batch)
+
+### Batch exec
+
+Tool: `ops_exec(workspace_id, selector, command, timeout_seconds=30, parallelism=20, max_output_chars=8000)`
+
+Exec backend:
+
+- `SEEDOPS_EXEC_BACKEND=auto` (default)
+- `cli` uses host-side timeout/output limits via `docker exec`
+- `sdk` uses Docker SDK (may be less robust for timeouts)
+
+Recommended for large scenarios:
+
+```bash
+export SEEDOPS_EXEC_BACKEND=cli
+```
+
+### Batch logs
+
+Tool: `ops_logs(workspace_id, selector, tail=200, since_seconds=0, ...)`
+
+### BGP summary (BIRD)
+
+Tool: `routing_bgp_summary(workspace_id, selector)`
+
+It runs `birdc show protocols` inside selected containers and aggregates BGP status.
+
+---
+
+## Phase 2: Jobs + YAML playbooks
+
+Playbooks run **asynchronously** and produce:
+
+- `job_steps` (progress + step events)
+- artifacts (optional JSON outputs saved to disk)
+
+### Validate a playbook
+
+Tool: `playbook_validate(playbook_yaml)`
+
+### Run a playbook
+
+Tool: `playbook_run(workspace_id, playbook_yaml)` → returns `job_id`
+
+Then poll:
+
+- `job_get(job_id)`
+- `job_steps_list(job_id, since_step_id=0, limit=200)`
+- `artifacts_list(job_id)` + `artifact_read(artifact_id)`
+
+Cancel a running job:
+
+- `job_cancel(job_id)`
+
+### Playbook YAML schema (v1)
+
+Supported actions:
+
+- `workspace_refresh`
+- `inventory_list_nodes`
+- `ops_exec`
+- `ops_logs`
+- `routing_bgp_summary`
+- `sleep`
+
+Example:
+
+```yaml
+version: 1
+name: bgp_check
+defaults:
+  selector:
+    role: ["BorderRouter", "Router"]
+  timeout_seconds: 20
+  parallelism: 30
+  max_output_chars: 6000
+
+steps:
+  - action: workspace_refresh
+    id: refresh
+    save_as: refresh
+
+  - action: routing_bgp_summary
+    id: bgp
+    # selector can be omitted to use defaults.selector
+    save_as: bgp_summary
+
+  - action: ops_exec
+    id: routes
+    selector: { asn: [150, 151] }
+    command: "ip route"
+    save_as: routes_as150_151
+
+  - action: sleep
+    seconds: 2
+```
+
+Notes:
+
+- For `ops_exec/ops_logs/routing_bgp_summary/inventory_list_nodes`, selector is taken from `step.selector` or `defaults.selector`.
+- To select everything, explicitly pass `{}` (do not use `[]`).
+
+---
+
+## Phase 2: Collector + snapshots
+
+Start a periodic collector job:
+
+- Tool: `collector_start(workspace_id, interval_seconds=30, selector={}, include_bgp_summary=true)`
+
+Stop it:
+
+- Tool: `job_cancel(job_id)`
+
+List snapshots:
+
+- Tool: `snapshots_list(workspace_id, snapshot_type="", since_ts=0, limit=200)`
+
+Snapshot types (current):
+
+- `inventory_summary`
+- `bgp_summary_counts`
+

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -191,6 +191,7 @@ Supported actions:
 - `traceroute`
 - `inject_fault`
 - `capture_evidence`
+- `pcap_capture`
 - `sleep`
 
 ### Playbook templating (vars + step references)
@@ -277,6 +278,9 @@ These actions are wrappers around `ops_exec` and share `timeout_seconds`, `paral
   - `kill_process` (params=`bird`), `disconnect` (params=`eth0`), `reset`
 - `capture_evidence`: `{selector?, evidence_type}`:
   - `routing_snapshot`, `network_state`, `process_list`, `logs`, `full`
+- `pcap_capture`: `{selector?, interface?, duration_seconds?, filter?, max_bytes?, parallelism?}`
+  - Captures a `.pcap` **artifact per selected node** and returns `artifact_id` values for download via `artifact_read_chunk`.
+  - Requires `tcpdump` in the container and `docker` CLI on the server host.
 
 ---
 

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -2,6 +2,50 @@
 
 SeedOps turns the `mcp-server` into an **operational control plane** for **already-running** SEED Emulator Docker/Compose networks.
 
+---
+
+## Quick start (10 minutes)
+
+1) Start server:
+
+```bash
+cd mcp-server
+python3 -m pip install -r requirements.txt
+export SEED_MCP_TOKEN='change-me'
+export FASTMCP_HOST=127.0.0.1 FASTMCP_PORT=8000 FASTMCP_STREAMABLE_HTTP_PATH=/mcp
+python3 serve_http.py
+```
+
+2) Attach and inspect (via client such as `seed-agent`):
+
+- `workspace_create(name)`
+- `workspace_attach_compose(workspace_id, output_dir)`
+- `workspace_refresh(workspace_id)`
+- `routing_bgp_summary(workspace_id, selector)`
+
+3) Run deterministic playbook:
+
+- `playbook_validate(playbook_yaml)`
+- `playbook_run(workspace_id, playbook_yaml)`
+- `job_get(job_id)` + `artifacts_list(job_id)`
+
+4) Optional capability introspection:
+
+- `seedops_capabilities()`
+
+---
+
+## Typical closed-loop workflow
+
+For production-like operations, use this order:
+
+1. attach workspace
+2. refresh inventory
+3. selector-scoped observation (`ops_logs` / `routing_bgp_summary`)
+4. run bounded playbook job
+5. download/parse artifacts
+6. summarize + decide next action
+
 It is designed for:
 
 - Attaching to an existing `docker compose up -d` output (no rebuild needed)
@@ -69,6 +113,23 @@ By default, SeedOps stores state under `mcp-server/.seedops/`:
 
 - DB: `mcp-server/.seedops/seedops.db` (override with `SEEDOPS_DB_PATH`)
 - Workspace data/artifacts: `mcp-server/.seedops/workspaces/` (override with `SEEDOPS_DATA_DIR`)
+
+---
+
+## Capability discovery
+
+Tool: `seedops_capabilities()`
+
+This is a lightweight introspection endpoint intended for higher-level planners
+(for example SeedAgent MCP) and automation clients. It returns:
+
+- `playbook_version`
+- `supported_actions`
+- `default_limits` (`timeout_seconds`, `parallelism`, `max_output_chars`, `artifact_chunk_bytes`)
+- `tool_names`
+
+Use this to keep planner prompts and policy checks aligned with the server's
+actual supported tool/action surface.
 
 ---
 

--- a/docs/user_manual/mcp_seedops.md
+++ b/docs/user_manual/mcp_seedops.md
@@ -254,3 +254,17 @@ Snapshot types (current):
 
 - `inventory_summary`
 - `bgp_summary_counts`
+
+---
+
+## Maintenance: pruning
+
+Long-running control planes accumulate events, snapshots, jobs, and artifacts. Use:
+
+- `maintenance_prune_workspace(workspace_id, keep_events=5000, keep_snapshots=5000, keep_terminal_jobs=200)`
+
+This deletes:
+
+- old `events` and `snapshots` beyond keep limits
+- terminal jobs beyond keep limit (and their job steps)
+- artifact files on disk for pruned jobs

--- a/mcp-server/PHASE2_DESIGN.md
+++ b/mcp-server/PHASE2_DESIGN.md
@@ -1,5 +1,12 @@
 # MCP Server Tools - Phase 2 Design
 
+> Note (2026-02-10): The SeedOps "Phase 2" implemented in this repository focuses on
+> **jobs / YAML playbooks / artifacts / snapshots / collector** for operating already-running networks.
+> See `docs/user_manual/mcp_seedops.md` for the up-to-date user-facing guide.
+>
+> The sections below describe an additional roadmap for extending build-time/service tools, which is
+> orthogonal to SeedOps automation.
+
 ## 已完成的工具 (Phase 1)
 
 ### 基础设施层 (5个)

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,4 +1,5 @@
-mcp>=0.1.0
+mcp>=1.0.0
 click
 docker>=7.0.0
 python-dotenv
+PyYAML>=6.0.2

--- a/mcp-server/seedops/__init__.py
+++ b/mcp-server/seedops/__init__.py
@@ -516,3 +516,33 @@ def register_tools(mcp: FastMCP, services: SeedOpsServices | None = None) -> Non
             )
         except Exception as e:
             return _json({"error": str(e)})
+
+    @mcp.tool()
+    def artifact_read_chunk(artifact_id: str, offset: int = 0, max_bytes: int = 65536) -> str:
+        """Read an artifact chunk as base64 (Phase 2, remote-friendly)."""
+        try:
+            res = svcs.artifacts.read_chunk_base64(artifact_id, offset=offset, max_bytes=max_bytes)
+            if res is None:
+                return _json({"error": "not found"})
+            return _json(
+                {
+                    "artifact": {
+                        "artifact_id": res.artifact.artifact_id,
+                        "job_id": res.artifact.job_id,
+                        "workspace_id": res.artifact.workspace_id,
+                        "name": res.artifact.name,
+                        "kind": res.artifact.kind,
+                        "path": res.artifact.path,
+                        "size_bytes": res.artifact.size_bytes,
+                        "created_at": res.artifact.created_at,
+                    },
+                    "encoding": "base64",
+                    "offset": res.offset,
+                    "bytes_read": res.bytes_read,
+                    "file_size": res.file_size,
+                    "eof": res.eof,
+                    "content_b64": res.content_b64,
+                }
+            )
+        except Exception as e:
+            return _json({"error": str(e)})

--- a/mcp-server/seedops/__init__.py
+++ b/mcp-server/seedops/__init__.py
@@ -556,3 +556,52 @@ def register_tools(mcp: FastMCP, services: SeedOpsServices | None = None) -> Non
             )
         except Exception as e:
             return _json({"error": str(e)})
+
+    @mcp.tool()
+    def maintenance_prune_workspace(
+        workspace_id: str,
+        keep_events: int = 5000,
+        keep_snapshots: int = 5000,
+        keep_terminal_jobs: int = 200,
+    ) -> str:
+        """Prune old events/snapshots/jobs/artifacts to control disk usage (Phase 2)."""
+        try:
+            if svcs.workspaces.get(workspace_id) is None:
+                return _json({"error": "workspace not found"})
+
+            job_ids = svcs.store.list_terminal_job_ids_to_prune(workspace_id, keep_last=keep_terminal_jobs)
+            artifacts = svcs.store.list_artifacts_for_job_ids(job_ids)
+            file_counts = svcs.artifacts.delete_files(artifacts)
+            db_counts = svcs.store.delete_jobs_and_related(job_ids)
+
+            events_deleted = svcs.store.prune_events(workspace_id, keep_last=keep_events)
+            snapshots_deleted = svcs.store.prune_snapshots(workspace_id, keep_last=keep_snapshots)
+
+            payload = {
+                "workspace_id": workspace_id,
+                "keep": {
+                    "events": int(keep_events),
+                    "snapshots": int(keep_snapshots),
+                    "terminal_jobs": int(keep_terminal_jobs),
+                },
+                "deleted": {
+                    "events": int(events_deleted),
+                    "snapshots": int(snapshots_deleted),
+                    "jobs": int(db_counts.get("jobs_deleted", 0)),
+                    "job_steps": int(db_counts.get("job_steps_deleted", 0)),
+                    "artifacts": int(db_counts.get("artifacts_deleted", 0)),
+                    "artifact_files": file_counts,
+                },
+            }
+
+            svcs.store.insert_event(
+                workspace_id,
+                level="info",
+                event_type="maintenance.prune",
+                message="Workspace pruned",
+                data=payload,
+            )
+            return _json(payload)
+        except Exception as e:
+            _audit_error(workspace_id, tool="maintenance_prune_workspace", error=e)
+            return _json({"error": str(e)})

--- a/mcp-server/seedops/__init__.py
+++ b/mcp-server/seedops/__init__.py
@@ -9,7 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from .config import load_config
 from .artifacts import ArtifactManager
 from .jobs import JobManager
-from .playbooks import parse_playbook_yaml
+from .playbooks import SUPPORTED_ACTIONS, SUPPORTED_PLAYBOOK_VERSION, parse_playbook_yaml
 from .store import SeedOpsStore
 from .workspaces import WorkspaceManager
 from .ops import OpsService
@@ -45,6 +45,34 @@ def register_tools(mcp: FastMCP, services: SeedOpsServices | None = None) -> Non
     """Register SeedOps Phase 1 tools on a FastMCP instance."""
     svcs = services or get_services()
 
+    tool_names = [
+        "seedops_capabilities",
+        "workspace_create",
+        "workspace_list",
+        "workspace_get",
+        "workspace_attach_compose",
+        "workspace_attach_labels",
+        "workspace_refresh",
+        "events_list",
+        "inventory_list_nodes",
+        "inventory_get_node",
+        "ops_exec",
+        "ops_logs",
+        "routing_bgp_summary",
+        "playbook_validate",
+        "playbook_run",
+        "jobs_list",
+        "job_get",
+        "job_steps_list",
+        "job_cancel",
+        "collector_start",
+        "snapshots_list",
+        "artifacts_list",
+        "artifact_read",
+        "artifact_read_chunk",
+        "maintenance_prune_workspace",
+    ]
+
     def _audit_error(workspace_id: str, *, tool: str, error: Exception, data: dict[str, Any] | None = None) -> None:
         try:
             # Only write an audit event if the workspace exists.
@@ -60,6 +88,25 @@ def register_tools(mcp: FastMCP, services: SeedOpsServices | None = None) -> Non
         except Exception:
             # Never let audit logging break tool execution.
             return
+
+    @mcp.tool()
+    def seedops_capabilities() -> str:
+        """Return capability metadata for SeedOps clients and planners."""
+
+        return _json(
+            {
+                "seedops_version": "phase2",
+                "playbook_version": SUPPORTED_PLAYBOOK_VERSION,
+                "supported_actions": sorted(SUPPORTED_ACTIONS),
+                "default_limits": {
+                    "timeout_seconds": 30,
+                    "parallelism": 20,
+                    "max_output_chars": 8000,
+                    "artifact_chunk_bytes": 65536,
+                },
+                "tool_names": tool_names,
+            }
+        )
 
     @mcp.tool()
     def workspace_create(name: str) -> str:

--- a/mcp-server/seedops/__init__.py
+++ b/mcp-server/seedops/__init__.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from .config import load_config
+from .artifacts import ArtifactManager
+from .jobs import JobManager
+from .playbooks import parse_playbook_yaml
+from .store import SeedOpsStore
+from .workspaces import WorkspaceManager
+from .ops import OpsService
+
+
+class SeedOpsServices:
+    def __init__(self):
+        cfg = load_config(require_token=False)
+        self.config = cfg
+        os.makedirs(cfg.data_dir, exist_ok=True)
+        self.store = SeedOpsStore(cfg.db_path)
+        self.workspaces = WorkspaceManager(store=self.store)
+        self.ops = OpsService(store=self.store, workspaces=self.workspaces)
+        self.artifacts = ArtifactManager(base_dir=cfg.data_dir, store=self.store)
+        self.jobs = JobManager(store=self.store, workspaces=self.workspaces, ops=self.ops, artifacts=self.artifacts)
+
+
+_services: SeedOpsServices | None = None
+
+
+def get_services() -> SeedOpsServices:
+    global _services
+    if _services is None:
+        _services = SeedOpsServices()
+    return _services
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def register_tools(mcp: FastMCP, services: SeedOpsServices | None = None) -> None:
+    """Register SeedOps Phase 1 tools on a FastMCP instance."""
+    svcs = services or get_services()
+
+    def _audit_error(workspace_id: str, *, tool: str, error: Exception, data: dict[str, Any] | None = None) -> None:
+        try:
+            # Only write an audit event if the workspace exists.
+            if svcs.workspaces.get(workspace_id) is None:
+                return
+            svcs.store.insert_event(
+                workspace_id,
+                level="error",
+                event_type="error",
+                message=f"{tool} failed: {error}",
+                data={"tool": tool, "error": str(error), **(data or {})},
+            )
+        except Exception:
+            # Never let audit logging break tool execution.
+            return
+
+    @mcp.tool()
+    def workspace_create(name: str) -> str:
+        """Create a persistent workspace for operating an existing running simulation."""
+        try:
+            ws = svcs.workspaces.create(name)
+            return _json({"workspace_id": ws.workspace_id, "name": ws.name, "created_at": ws.created_at})
+        except Exception as e:
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def workspace_list() -> str:
+        """List all workspaces."""
+        try:
+            items = svcs.workspaces.list()
+            return _json(
+                {
+                    "workspaces": [
+                        {
+                            "workspace_id": w.workspace_id,
+                            "name": w.name,
+                            "attach_type": w.attach_type,
+                            "updated_at": w.updated_at,
+                        }
+                        for w in items
+                    ]
+                }
+            )
+        except Exception as e:
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def workspace_get(workspace_id: str) -> str:
+        """Get workspace metadata including attach configuration."""
+        try:
+            ws = svcs.workspaces.get(workspace_id)
+            if not ws:
+                return _json({"error": "not found"})
+            return _json(
+                {
+                    "workspace": {
+                        "workspace_id": ws.workspace_id,
+                        "name": ws.name,
+                        "attach_type": ws.attach_type,
+                        "created_at": ws.created_at,
+                        "updated_at": ws.updated_at,
+                    },
+                    "attach_config": ws.attach_config,
+                }
+            )
+        except Exception as e:
+            _audit_error(workspace_id, tool="workspace_get", error=e)
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def workspace_attach_compose(workspace_id: str, output_dir: str) -> str:
+        """Attach a workspace to a running SEED simulation compiled to docker-compose output_dir."""
+        try:
+            summary = svcs.workspaces.attach_compose(workspace_id, output_dir)
+            return _json({"attached": True, "workspace_id": workspace_id, "inventory_summary": summary})
+        except Exception as e:
+            _audit_error(workspace_id, tool="workspace_attach_compose", error=e, data={"output_dir": output_dir})
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def workspace_attach_labels(
+        workspace_id: str,
+        name_regex: str,
+        label_prefix: str = "org.seedsecuritylabs.seedemu.meta.",
+    ) -> str:
+        """Attach a workspace by scanning running Docker containers with a name regex and SEED meta labels."""
+        try:
+            summary = svcs.workspaces.attach_labels(workspace_id, name_regex=name_regex, label_prefix=label_prefix)
+            return _json({"attached": True, "workspace_id": workspace_id, "inventory_summary": summary})
+        except Exception as e:
+            _audit_error(
+                workspace_id,
+                tool="workspace_attach_labels",
+                error=e,
+                data={"name_regex": name_regex, "label_prefix": label_prefix},
+            )
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def workspace_refresh(workspace_id: str) -> str:
+        """Refresh inventory cache for a workspace by re-scanning the runtime backend."""
+        try:
+            summary = svcs.workspaces.refresh(workspace_id)
+            return _json(summary)
+        except Exception as e:
+            _audit_error(workspace_id, tool="workspace_refresh", error=e)
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def events_list(workspace_id: str, since_ts: int = 0, limit: int = 200) -> str:
+        """List audit events for a workspace."""
+        try:
+            rows = svcs.workspaces.list_events(workspace_id, since_ts=since_ts, limit=limit)
+            return _json(
+                {
+                    "events": [
+                        {
+                            "event_id": ev.event_id,
+                            "ts": ev.ts,
+                            "level": ev.level,
+                            "event_type": ev.event_type,
+                            "message": ev.message,
+                            "data": ev.data,
+                        }
+                        for ev in rows
+                    ]
+                }
+            )
+        except Exception as e:
+            _audit_error(workspace_id, tool="events_list", error=e, data={"since_ts": since_ts, "limit": limit})
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def inventory_list_nodes(workspace_id: str, selector: dict = {}) -> str:
+        """List nodes in the workspace inventory, optionally filtered by selector."""
+        try:
+            nodes = svcs.workspaces.list_nodes(workspace_id, selector=selector)
+            return _json({"nodes": nodes})
+        except Exception as e:
+            _audit_error(workspace_id, tool="inventory_list_nodes", error=e, data={"selector": selector})
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def inventory_get_node(workspace_id: str, node_id: str) -> str:
+        """Get a single node by node_id (e.g., 'as150/router0')."""
+        try:
+            node = svcs.workspaces.get_node(workspace_id, node_id)
+            if not node:
+                return _json({"error": "not found"})
+            return _json({"node": node})
+        except Exception as e:
+            _audit_error(workspace_id, tool="inventory_get_node", error=e, data={"node_id": node_id})
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def ops_exec(
+        workspace_id: str,
+        selector: dict,
+        command: str,
+        timeout_seconds: int = 30,
+        parallelism: int = 20,
+        max_output_chars: int = 8000,
+    ) -> str:
+        """Execute a shell command across multiple containers selected from inventory."""
+        try:
+            result = svcs.ops.exec(
+                workspace_id,
+                selector=selector,
+                command=command,
+                timeout_seconds=timeout_seconds,
+                parallelism=parallelism,
+                max_output_chars=max_output_chars,
+            )
+            return _json(result)
+        except Exception as e:
+            _audit_error(
+                workspace_id,
+                tool="ops_exec",
+                error=e,
+                data={
+                    "selector": selector,
+                    "command": command,
+                    "timeout_seconds": timeout_seconds,
+                    "parallelism": parallelism,
+                },
+            )
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def ops_logs(
+        workspace_id: str,
+        selector: dict,
+        tail: int = 200,
+        since_seconds: int = 0,
+        parallelism: int = 20,
+        max_output_chars: int = 8000,
+    ) -> str:
+        """Fetch docker logs across multiple containers selected from inventory."""
+        try:
+            result = svcs.ops.logs(
+                workspace_id,
+                selector=selector,
+                tail=tail,
+                since_seconds=since_seconds,
+                parallelism=parallelism,
+                max_output_chars=max_output_chars,
+            )
+            return _json(result)
+        except Exception as e:
+            _audit_error(
+                workspace_id,
+                tool="ops_logs",
+                error=e,
+                data={
+                    "selector": selector,
+                    "tail": tail,
+                    "since_seconds": since_seconds,
+                    "parallelism": parallelism,
+                },
+            )
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def routing_bgp_summary(workspace_id: str, selector: dict) -> str:
+        """Summarize BGP protocol status for selected router containers (BIRD)."""
+        try:
+            result = svcs.ops.bgp_summary(workspace_id, selector=selector)
+            return _json(result)
+        except Exception as e:
+            _audit_error(workspace_id, tool="routing_bgp_summary", error=e, data={"selector": selector})
+            return _json({"error": str(e)})
+
+    # --------------------------------------------------------------------------
+    # Phase 2: Jobs / Playbooks / Collector / Snapshots / Artifacts
+    # --------------------------------------------------------------------------
+
+    @mcp.tool()
+    def playbook_validate(playbook_yaml: str) -> str:
+        """Validate a YAML playbook (Phase 2)."""
+        try:
+            pb = parse_playbook_yaml(playbook_yaml)
+            return _json(
+                {
+                    "valid": True,
+                    "playbook": {
+                        "version": pb.version,
+                        "name": pb.name,
+                        "defaults": pb.defaults,
+                        "steps": [{"id": s.step_id, "action": s.action, "save_as": s.save_as} for s in pb.steps],
+                    },
+                }
+            )
+        except Exception as e:
+            return _json({"valid": False, "error": str(e)})
+
+    @mcp.tool()
+    def playbook_run(workspace_id: str, playbook_yaml: str) -> str:
+        """Run a YAML playbook as an async job (Phase 2)."""
+        try:
+            job = svcs.jobs.start_playbook(workspace_id, playbook_yaml=playbook_yaml)
+            return _json(
+                {
+                    "job_id": job.job_id,
+                    "workspace_id": job.workspace_id,
+                    "kind": job.kind,
+                    "name": job.name,
+                    "status": job.status,
+                    "progress": {"current": job.progress_current, "total": job.progress_total},
+                    "created_at": job.created_at,
+                }
+            )
+        except Exception as e:
+            _audit_error(workspace_id, tool="playbook_run", error=e)
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def jobs_list(workspace_id: str, status: str = "", limit: int = 50) -> str:
+        """List jobs for a workspace (Phase 2)."""
+        try:
+            rows = svcs.store.list_jobs(workspace_id, status=(status or None), limit=limit)
+            return _json(
+                {
+                    "jobs": [
+                        {
+                            "job_id": j.job_id,
+                            "workspace_id": j.workspace_id,
+                            "kind": j.kind,
+                            "name": j.name,
+                            "status": j.status,
+                            "created_at": j.created_at,
+                            "started_at": j.started_at,
+                            "finished_at": j.finished_at,
+                            "progress": {"current": j.progress_current, "total": j.progress_total},
+                            "message": j.message,
+                            "data": j.data,
+                        }
+                        for j in rows
+                    ]
+                }
+            )
+        except Exception as e:
+            _audit_error(workspace_id, tool="jobs_list", error=e, data={"status": status, "limit": limit})
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def job_get(job_id: str) -> str:
+        """Get a job by job_id (Phase 2)."""
+        try:
+            j = svcs.store.get_job(job_id)
+            if not j:
+                return _json({"error": "not found"})
+            return _json(
+                {
+                    "job": {
+                        "job_id": j.job_id,
+                        "workspace_id": j.workspace_id,
+                        "kind": j.kind,
+                        "name": j.name,
+                        "status": j.status,
+                        "created_at": j.created_at,
+                        "started_at": j.started_at,
+                        "finished_at": j.finished_at,
+                        "progress": {"current": j.progress_current, "total": j.progress_total},
+                        "message": j.message,
+                        "data": j.data,
+                    }
+                }
+            )
+        except Exception as e:
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def job_steps_list(job_id: str, since_step_id: int = 0, limit: int = 200) -> str:
+        """List job step events (Phase 2)."""
+        try:
+            rows = svcs.store.list_job_steps(job_id, since_step_id=since_step_id, limit=limit)
+            return _json(
+                {
+                    "steps": [
+                        {
+                            "step_id": s.step_id,
+                            "ts": s.ts,
+                            "level": s.level,
+                            "step_index": s.step_index,
+                            "step_name": s.step_name,
+                            "event_type": s.event_type,
+                            "message": s.message,
+                            "data": s.data,
+                        }
+                        for s in rows
+                    ]
+                }
+            )
+        except Exception as e:
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def job_cancel(job_id: str) -> str:
+        """Cancel a running job (Phase 2)."""
+        try:
+            ok = svcs.jobs.cancel_job(job_id)
+            return _json({"canceled": bool(ok), "job_id": job_id})
+        except Exception as e:
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def collector_start(
+        workspace_id: str,
+        interval_seconds: int = 30,
+        selector: dict = {},
+        include_bgp_summary: bool = True,
+    ) -> str:
+        """Start a periodic collector that writes snapshots (Phase 2)."""
+        try:
+            job = svcs.jobs.start_collector(
+                workspace_id,
+                interval_seconds=interval_seconds,
+                selector=selector,
+                include_bgp_summary=include_bgp_summary,
+            )
+            return _json(
+                {
+                    "job_id": job.job_id,
+                    "workspace_id": job.workspace_id,
+                    "kind": job.kind,
+                    "status": job.status,
+                    "created_at": job.created_at,
+                    "interval_seconds": int(interval_seconds),
+                }
+            )
+        except Exception as e:
+            _audit_error(workspace_id, tool="collector_start", error=e)
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def snapshots_list(workspace_id: str, snapshot_type: str = "", since_ts: int = 0, limit: int = 200) -> str:
+        """List snapshots captured by collectors (Phase 2)."""
+        try:
+            rows = svcs.store.list_snapshots(
+                workspace_id,
+                snapshot_type=(snapshot_type or None),
+                since_ts=since_ts,
+                limit=limit,
+            )
+            return _json(
+                {
+                    "snapshots": [
+                        {
+                            "snapshot_id": s.snapshot_id,
+                            "ts": s.ts,
+                            "snapshot_type": s.snapshot_type,
+                            "data": s.data,
+                        }
+                        for s in rows
+                    ]
+                }
+            )
+        except Exception as e:
+            _audit_error(workspace_id, tool="snapshots_list", error=e)
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def artifacts_list(job_id: str, limit: int = 200) -> str:
+        """List artifacts produced by a job (Phase 2)."""
+        try:
+            rows = svcs.store.list_artifacts(job_id, limit=limit)
+            return _json(
+                {
+                    "artifacts": [
+                        {
+                            "artifact_id": a.artifact_id,
+                            "job_id": a.job_id,
+                            "workspace_id": a.workspace_id,
+                            "name": a.name,
+                            "kind": a.kind,
+                            "path": a.path,
+                            "size_bytes": a.size_bytes,
+                            "created_at": a.created_at,
+                        }
+                        for a in rows
+                    ]
+                }
+            )
+        except Exception as e:
+            return _json({"error": str(e)})
+
+    @mcp.tool()
+    def artifact_read(artifact_id: str, max_chars: int = 8000) -> str:
+        """Read an artifact content (Phase 2)."""
+        try:
+            res = svcs.artifacts.read(artifact_id, max_chars=max_chars)
+            if res is None:
+                return _json({"error": "not found"})
+            return _json(
+                {
+                    "artifact": {
+                        "artifact_id": res.artifact.artifact_id,
+                        "job_id": res.artifact.job_id,
+                        "workspace_id": res.artifact.workspace_id,
+                        "name": res.artifact.name,
+                        "kind": res.artifact.kind,
+                        "path": res.artifact.path,
+                        "size_bytes": res.artifact.size_bytes,
+                        "created_at": res.artifact.created_at,
+                    },
+                    "content": res.content,
+                    "truncated": res.truncated,
+                }
+            )
+        except Exception as e:
+            return _json({"error": str(e)})

--- a/mcp-server/seedops/__init__.py
+++ b/mcp-server/seedops/__init__.py
@@ -293,7 +293,17 @@ def register_tools(mcp: FastMCP, services: SeedOpsServices | None = None) -> Non
                         "version": pb.version,
                         "name": pb.name,
                         "defaults": pb.defaults,
-                        "steps": [{"id": s.step_id, "action": s.action, "save_as": s.save_as} for s in pb.steps],
+                        "steps": [
+                            {
+                                "id": s.step_id,
+                                "action": s.action,
+                                "save_as": s.save_as,
+                                "on_error": s.on_error,
+                                "retries": s.retries,
+                                "retry_delay_seconds": s.retry_delay_seconds,
+                            }
+                            for s in pb.steps
+                        ],
                     },
                 }
             )

--- a/mcp-server/seedops/artifacts.py
+++ b/mcp-server/seedops/artifacts.py
@@ -185,3 +185,23 @@ class ArtifactManager:
             eof=eof,
             content_b64=b64,
         )
+
+    def delete_files(self, artifacts: list[ArtifactRow]) -> dict[str, int]:
+        """Delete artifact files from disk.
+
+        Returns counts: {deleted, missing, errors}.
+        """
+        deleted = 0
+        missing = 0
+        errors = 0
+        for a in artifacts:
+            try:
+                p = self._resolve_artifact_path(a.path)
+                if p.exists():
+                    p.unlink()
+                    deleted += 1
+                else:
+                    missing += 1
+            except Exception:
+                errors += 1
+        return {"deleted": deleted, "missing": missing, "errors": errors}

--- a/mcp-server/seedops/artifacts.py
+++ b/mcp-server/seedops/artifacts.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .store import ArtifactRow, SeedOpsStore
+
+
+_SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def _safe_name(name: str) -> str:
+    name = (name or "").strip()
+    if not name:
+        return "artifact"
+    name = name.replace(os.sep, "_")
+    name = name.replace("/", "_")
+    name = _SAFE_NAME_RE.sub("_", name)
+    return name[:120] or "artifact"
+
+
+@dataclass(frozen=True)
+class ArtifactReadResult:
+    artifact: ArtifactRow
+    content: str
+    truncated: bool
+
+
+class ArtifactManager:
+    """Manage on-disk artifacts with metadata in SQLite."""
+
+    def __init__(self, *, base_dir: str, store: SeedOpsStore):
+        self._base_dir = Path(base_dir)
+        self._store = store
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _workspace_dir(self, workspace_id: str) -> Path:
+        return self._base_dir / workspace_id
+
+    def _job_artifacts_dir(self, workspace_id: str, job_id: str) -> Path:
+        return self._workspace_dir(workspace_id) / "artifacts" / job_id
+
+    def write_json(self, *, workspace_id: str, job_id: str, name: str, data: Any) -> ArtifactRow:
+        safe = _safe_name(name)
+        out_dir = self._job_artifacts_dir(workspace_id, job_id)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        path = out_dir / f"{safe}.json"
+
+        tmp = path.with_suffix(".json.tmp")
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+
+        size = path.stat().st_size
+        artifact_id = str(uuid.uuid4())
+        self._store.insert_artifact(
+            artifact_id=artifact_id,
+            job_id=job_id,
+            workspace_id=workspace_id,
+            name=safe,
+            kind="json",
+            path=str(path),
+            size_bytes=int(size),
+        )
+
+        row = self._store.get_artifact(artifact_id)
+        assert row is not None
+        return row
+
+    def read(self, artifact_id: str, *, max_chars: int = 8000) -> ArtifactReadResult | None:
+        row = self._store.get_artifact(artifact_id)
+        if row is None:
+            return None
+
+        p = Path(row.path)
+        if not p.exists():
+            return ArtifactReadResult(artifact=row, content="[missing artifact file]", truncated=False)
+
+        if max_chars <= 0:
+            return ArtifactReadResult(artifact=row, content="", truncated=False)
+
+        raw = p.read_text(encoding="utf-8", errors="replace")
+        if len(raw) <= max_chars:
+            return ArtifactReadResult(artifact=row, content=raw, truncated=False)
+        return ArtifactReadResult(artifact=row, content=raw[:max_chars] + "\n...[truncated]", truncated=True)
+

--- a/mcp-server/seedops/artifacts.py
+++ b/mcp-server/seedops/artifacts.py
@@ -52,6 +52,48 @@ class ArtifactManager:
         self._store = store
         self._base_dir.mkdir(parents=True, exist_ok=True)
 
+    def allocate_path(self, *, workspace_id: str, job_id: str, name: str, suffix: str) -> Path:
+        safe = _safe_name(name)
+        suf = str(suffix or "").strip()
+        if suf and not suf.startswith("."):
+            suf = f".{suf}"
+
+        out_dir = self._job_artifacts_dir(workspace_id, job_id)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return out_dir / f"{safe}{suf}"
+
+    def register_file(
+        self,
+        *,
+        workspace_id: str,
+        job_id: str,
+        name: str,
+        kind: str,
+        path: str,
+    ) -> ArtifactRow:
+        safe = _safe_name(name)
+        if not safe:
+            raise ValueError("Artifact name cannot be empty.")
+
+        p = self._resolve_artifact_path(path)
+        if not p.exists():
+            raise ValueError("Artifact file does not exist.")
+
+        size = int(p.stat().st_size)
+        artifact_id = str(uuid.uuid4())
+        self._store.insert_artifact(
+            artifact_id=artifact_id,
+            job_id=job_id,
+            workspace_id=workspace_id,
+            name=safe,
+            kind=str(kind or "bin"),
+            path=str(p),
+            size_bytes=size,
+        )
+        row = self._store.get_artifact(artifact_id)
+        assert row is not None
+        return row
+
     def _resolve_artifact_path(self, raw_path: str) -> Path:
         base = self._base_dir.resolve()
         p = Path(raw_path)
@@ -71,6 +113,49 @@ class ArtifactManager:
 
     def _job_artifacts_dir(self, workspace_id: str, job_id: str) -> Path:
         return self._workspace_dir(workspace_id) / "artifacts" / job_id
+
+    def write_bytes(
+        self,
+        *,
+        workspace_id: str,
+        job_id: str,
+        name: str,
+        data: bytes,
+        kind: str = "bin",
+        suffix: str = ".bin",
+    ) -> ArtifactRow:
+        path = self.allocate_path(workspace_id=workspace_id, job_id=job_id, name=name, suffix=suffix)
+        tmp = Path(str(path) + ".tmp")
+        with open(tmp, "wb") as f:
+            f.write(bytes(data))
+        os.replace(tmp, path)
+        return self.register_file(
+            workspace_id=workspace_id,
+            job_id=job_id,
+            name=name,
+            kind=kind,
+            path=str(path),
+        )
+
+    def write_text(
+        self,
+        *,
+        workspace_id: str,
+        job_id: str,
+        name: str,
+        text: str,
+        kind: str = "text",
+        suffix: str = ".txt",
+        encoding: str = "utf-8",
+    ) -> ArtifactRow:
+        return self.write_bytes(
+            workspace_id=workspace_id,
+            job_id=job_id,
+            name=name,
+            data=(text or "").encode(encoding, errors="replace"),
+            kind=kind,
+            suffix=suffix,
+        )
 
     def write_json(self, *, workspace_id: str, job_id: str, name: str, data: Any) -> ArtifactRow:
         safe = _safe_name(name)

--- a/mcp-server/seedops/artifacts.py
+++ b/mcp-server/seedops/artifacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
@@ -12,6 +13,8 @@ from .store import ArtifactRow, SeedOpsStore
 
 
 _SAFE_NAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+_TRUNCATED_SUFFIX = "\n...[truncated]"
+_MAX_CHUNK_BYTES = 256 * 1024
 
 
 def _safe_name(name: str) -> str:
@@ -31,6 +34,16 @@ class ArtifactReadResult:
     truncated: bool
 
 
+@dataclass(frozen=True)
+class ArtifactChunkResult:
+    artifact: ArtifactRow
+    offset: int
+    bytes_read: int
+    file_size: int
+    eof: bool
+    content_b64: str
+
+
 class ArtifactManager:
     """Manage on-disk artifacts with metadata in SQLite."""
 
@@ -38,6 +51,20 @@ class ArtifactManager:
         self._base_dir = Path(base_dir)
         self._store = store
         self._base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _resolve_artifact_path(self, raw_path: str) -> Path:
+        base = self._base_dir.resolve()
+        p = Path(raw_path)
+        # Resolve symlinks where possible. If the file does not exist, return the raw path.
+        try:
+            p_resolved = p.resolve()
+        except FileNotFoundError:
+            p_resolved = p.absolute()
+
+        # Enforce that artifacts live under base_dir to avoid path traversal if DB is tampered.
+        if base == p_resolved or base in p_resolved.parents:
+            return p_resolved
+        raise ValueError("Artifact path is outside of configured data directory.")
 
     def _workspace_dir(self, workspace_id: str) -> Path:
         return self._base_dir / workspace_id
@@ -78,15 +105,83 @@ class ArtifactManager:
         if row is None:
             return None
 
-        p = Path(row.path)
+        p = self._resolve_artifact_path(row.path)
         if not p.exists():
             return ArtifactReadResult(artifact=row, content="[missing artifact file]", truncated=False)
 
         if max_chars <= 0:
             return ArtifactReadResult(artifact=row, content="", truncated=False)
 
-        raw = p.read_text(encoding="utf-8", errors="replace")
-        if len(raw) <= max_chars:
-            return ArtifactReadResult(artifact=row, content=raw, truncated=False)
-        return ArtifactReadResult(artifact=row, content=raw[:max_chars] + "\n...[truncated]", truncated=True)
+        # Avoid reading entire file: cap bytes and decode as UTF-8 (replacement for invalid sequences).
+        max_bytes = int(max_chars) * 4
+        try:
+            with open(p, "rb") as f:
+                data = f.read(max_bytes + 1)
+        except Exception:
+            return ArtifactReadResult(artifact=row, content="[failed to read artifact file]", truncated=False)
 
+        truncated = len(data) > max_bytes
+        if truncated:
+            data = data[:max_bytes]
+        text = data.decode("utf-8", errors="replace")
+        if len(text) > max_chars:
+            text = text[:max_chars]
+            truncated = True
+        if truncated:
+            text += _TRUNCATED_SUFFIX
+        return ArtifactReadResult(artifact=row, content=text, truncated=truncated)
+
+    def read_chunk_base64(
+        self,
+        artifact_id: str,
+        *,
+        offset: int = 0,
+        max_bytes: int = 65536,
+    ) -> ArtifactChunkResult | None:
+        row = self._store.get_artifact(artifact_id)
+        if row is None:
+            return None
+
+        if offset < 0:
+            raise ValueError("offset must be >= 0")
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be > 0")
+        max_bytes_i = min(int(max_bytes), _MAX_CHUNK_BYTES)
+
+        p = self._resolve_artifact_path(row.path)
+        if not p.exists():
+            return ArtifactChunkResult(
+                artifact=row,
+                offset=int(offset),
+                bytes_read=0,
+                file_size=0,
+                eof=True,
+                content_b64="",
+            )
+
+        file_size = int(p.stat().st_size)
+        if int(offset) >= file_size:
+            return ArtifactChunkResult(
+                artifact=row,
+                offset=int(offset),
+                bytes_read=0,
+                file_size=file_size,
+                eof=True,
+                content_b64="",
+            )
+
+        with open(p, "rb") as f:
+            f.seek(int(offset))
+            chunk = f.read(max_bytes_i)
+
+        b64 = base64.b64encode(chunk).decode("ascii")
+        bytes_read = len(chunk)
+        eof = (int(offset) + bytes_read) >= file_size
+        return ArtifactChunkResult(
+            artifact=row,
+            offset=int(offset),
+            bytes_read=bytes_read,
+            file_size=file_size,
+            eof=eof,
+            content_b64=b64,
+        )

--- a/mcp-server/seedops/auth.py
+++ b/mcp-server/seedops/auth.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+
+
+class StaticTokenVerifier(TokenVerifier):
+    """A minimal TokenVerifier for Bearer auth using a static shared secret."""
+
+    def __init__(self, expected_token: str):
+        self._expected_token = expected_token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if token != self._expected_token:
+            return None
+        return AccessToken(
+            token=token,
+            client_id="seedops-static-token",
+            scopes=[],
+            expires_at=None,
+            resource=None,
+        )
+
+
+def build_auth_settings(public_url: str) -> AuthSettings:
+    """Build minimal AuthSettings required for FastMCP to enforce Bearer auth.
+
+    Note: We are not enabling OAuth flows in Phase 1. This is only used to
+    activate the built-in auth middleware and produce standards-compliant
+    WWW-Authenticate headers.
+    """
+    return AuthSettings(
+        issuer_url=public_url,
+        resource_server_url=public_url,
+        required_scopes=[],
+    )
+

--- a/mcp-server/seedops/config.py
+++ b/mcp-server/seedops/config.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _env_int(name: str, default: int) -> int:
+    val = os.environ.get(name)
+    if val is None or val == "":
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    val = os.environ.get(name)
+    if val is None or val == "":
+        return default
+    v = val.strip().lower()
+    if v in {"1", "true", "yes", "y", "on"}:
+        return True
+    if v in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _env_csv(name: str) -> list[str]:
+    raw = os.environ.get(name) or ""
+    if not raw.strip():
+        return []
+    return [x.strip() for x in raw.split(",") if x.strip()]
+
+
+def _ensure_leading_slash(path: str) -> str:
+    if not path:
+        return "/"
+    return path if path.startswith("/") else f"/{path}"
+
+
+def get_mcp_server_dir() -> Path:
+    # .../mcp-server/seedops/config.py -> .../mcp-server
+    return Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class SeedOpsConfig:
+    token: str | None
+    db_path: str
+    data_dir: str
+    public_url: str
+    host: str
+    port: int
+    streamable_http_path: str
+    dns_rebinding_protection: bool
+    allowed_hosts: list[str]
+    allowed_origins: list[str]
+
+
+def load_config(*, require_token: bool = False) -> SeedOpsConfig:
+    """Load SeedOps configuration from environment variables.
+
+    Environment variables:
+      - SEED_MCP_TOKEN
+      - SEEDOPS_DB_PATH
+      - SEEDOPS_DATA_DIR
+      - SEED_MCP_PUBLIC_URL
+      - SEED_MCP_DNS_REBINDING_PROTECTION
+      - SEED_MCP_ALLOWED_HOSTS (comma-separated, e.g. "seed-mcp.example.com:*,10.0.0.5:*")
+      - SEED_MCP_ALLOWED_ORIGINS (comma-separated, e.g. "http://seed-mcp.example.com:*,http://10.0.0.5:*")
+      - FASTMCP_HOST
+      - FASTMCP_PORT
+      - FASTMCP_STREAMABLE_HTTP_PATH
+    """
+    mcp_server_dir = get_mcp_server_dir()
+    seedops_dir = mcp_server_dir / ".seedops"
+
+    host = os.environ.get("FASTMCP_HOST", "127.0.0.1")
+    port = _env_int("FASTMCP_PORT", 8000)
+    streamable_http_path = _ensure_leading_slash(os.environ.get("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp"))
+
+    token = os.environ.get("SEED_MCP_TOKEN") or None
+    if require_token and not token:
+        raise ValueError("SEED_MCP_TOKEN is required to run the HTTP MCP server.")
+
+    db_path = os.environ.get("SEEDOPS_DB_PATH") or str(seedops_dir / "seedops.db")
+    data_dir = os.environ.get("SEEDOPS_DATA_DIR") or str(seedops_dir / "workspaces")
+
+    public_url = os.environ.get("SEED_MCP_PUBLIC_URL") or f"http://127.0.0.1:{port}"
+
+    dns_rebinding_protection = _env_bool("SEED_MCP_DNS_REBINDING_PROTECTION", True)
+    extra_allowed_hosts = _env_csv("SEED_MCP_ALLOWED_HOSTS")
+    extra_allowed_origins = _env_csv("SEED_MCP_ALLOWED_ORIGINS")
+
+    # Transport security allowlists:
+    # - Always include localhost defaults
+    # - Also include the hostname from public_url so remote clients can connect
+    allowed_hosts: set[str] = {"127.0.0.1:*", "localhost:*", "[::1]:*"}
+    allowed_origins: set[str] = {"http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"}
+    try:
+        parsed = urlparse(public_url)
+        hostname = parsed.hostname
+        scheme = parsed.scheme or "http"
+        if hostname:
+            host_for_header = f"[{hostname}]" if ":" in hostname else hostname
+            allowed_hosts.add(f"{host_for_header}:*")
+            allowed_origins.add(f"{scheme}://{host_for_header}:*")
+    except Exception:
+        # If public_url is malformed, keep safe localhost defaults and rely on explicit env overrides.
+        pass
+
+    allowed_hosts.update(extra_allowed_hosts)
+    allowed_origins.update(extra_allowed_origins)
+
+    return SeedOpsConfig(
+        token=token,
+        db_path=db_path,
+        data_dir=data_dir,
+        public_url=public_url,
+        host=host,
+        port=port,
+        streamable_http_path=streamable_http_path,
+        dns_rebinding_protection=dns_rebinding_protection,
+        allowed_hosts=sorted(allowed_hosts),
+        allowed_origins=sorted(allowed_origins),
+    )

--- a/mcp-server/seedops/inventory.py
+++ b/mcp-server/seedops/inventory.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_LABEL_PREFIX = "org.seedsecuritylabs.seedemu.meta."
+
+
+def _get_labels(container: Any) -> dict[str, str]:
+    labels = getattr(container, "labels", None)
+    if isinstance(labels, dict):
+        return labels
+    # Fallback: docker SDK containers often have attrs
+    attrs = getattr(container, "attrs", None)
+    if isinstance(attrs, dict):
+        cfg = attrs.get("Config", {})
+        if isinstance(cfg, dict):
+            raw = cfg.get("Labels", {})
+            if isinstance(raw, dict):
+                return raw
+    return {}
+
+
+def parse_node_from_labels(
+    *,
+    container_name: str,
+    labels: dict[str, str],
+    label_prefix: str = DEFAULT_LABEL_PREFIX,
+) -> dict[str, Any] | None:
+    """Parse a NodeRef from SEED Emulator docker labels.
+
+    Returns None if required labels are missing.
+    """
+    asn_raw = labels.get(f"{label_prefix}asn")
+    node_name = labels.get(f"{label_prefix}nodename")
+    role = labels.get(f"{label_prefix}role")
+    if not asn_raw or not node_name or not role:
+        return None
+
+    try:
+        asn = int(asn_raw)
+    except ValueError:
+        return None
+
+    classes: list[str] = []
+    classes_raw = labels.get(f"{label_prefix}class")
+    if classes_raw:
+        try:
+            parsed = json.loads(classes_raw)
+            if isinstance(parsed, list):
+                classes = [str(x) for x in parsed]
+        except Exception:
+            classes = []
+
+    loopback = labels.get(f"{label_prefix}loopback_addr") or None
+
+    # Interfaces: meta.net.{i}.name / meta.net.{i}.address
+    iface_pat = re.compile(rf"^{re.escape(label_prefix)}net\.(\d+)\.(name|address)$")
+    iface_map: dict[int, dict[str, str]] = {}
+    for k, v in labels.items():
+        m = iface_pat.match(k)
+        if not m:
+            continue
+        idx = int(m.group(1))
+        field = m.group(2)
+        iface_map.setdefault(idx, {})[field] = v
+
+    interfaces: list[dict[str, str]] = []
+    for idx in sorted(iface_map.keys()):
+        entry = iface_map[idx]
+        name = entry.get("name")
+        address = entry.get("address")
+        if not name or not address:
+            continue
+        interfaces.append({"name": name, "address": address})
+
+    return {
+        "node_id": f"as{asn}/{node_name}",
+        "asn": asn,
+        "node_name": node_name,
+        "role": role,
+        "classes": classes,
+        "container_name": container_name,
+        "interfaces": interfaces,
+        "loopback": loopback,
+        "labels": labels,
+    }
+
+
+@dataclass(frozen=True)
+class Inventory:
+    nodes: list[dict[str, Any]]
+    by_node_id: dict[str, dict[str, Any]]
+    updated_at: int
+
+
+class InventoryBuilder:
+    def build(self, containers: list[Any], *, label_prefix: str = DEFAULT_LABEL_PREFIX) -> Inventory:
+        nodes: list[dict[str, Any]] = []
+        for c in containers:
+            name = getattr(c, "name", "") or getattr(c, "Name", "")
+            labels = _get_labels(c)
+            node = parse_node_from_labels(container_name=name, labels=labels, label_prefix=label_prefix)
+            if node:
+                nodes.append(node)
+
+        nodes.sort(key=lambda n: n.get("node_id", ""))
+        by_id = {n["node_id"]: n for n in nodes}
+        return Inventory(nodes=nodes, by_node_id=by_id, updated_at=int(time.time()))
+

--- a/mcp-server/seedops/jobs.py
+++ b/mcp-server/seedops/jobs.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import os
 import shlex
+import shutil
+import subprocess
+import selectors as _selectors
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any
 
 from .artifacts import ArtifactManager
@@ -22,6 +28,158 @@ def _sleep_interruptible(cancel: threading.Event, seconds: float) -> None:
         if remaining <= 0:
             return
         time.sleep(min(0.2, remaining))
+
+
+def _capture_pcap_to_file(
+    *,
+    container_name: str,
+    interface: str,
+    duration_seconds: int,
+    filter_expr: str,
+    out_path: str,
+    max_bytes: int,
+) -> dict[str, Any]:
+    """Capture a PCAP from a container to a local file via `docker exec`.
+
+    This uses tcpdump with `-w -` to write PCAP bytes to stdout, then streams stdout to `out_path`.
+    """
+    if not shutil.which("docker"):
+        raise RuntimeError("docker CLI not found; pcap_capture requires docker CLI.")
+
+    dur = max(1, int(duration_seconds))
+    iface = str(interface or "any").strip() or "any"
+    filt = str(filter_expr or "").strip()
+    max_bytes_i = max(0, int(max_bytes))
+
+    tcpdump_cmd = f"tcpdump -i {shlex.quote(iface)} -U -w -"
+    if filt:
+        tcpdump_cmd += f" {filt}"
+    shell_script = f"command -v timeout >/dev/null 2>&1 && timeout {dur}s {tcpdump_cmd} || {tcpdump_cmd}"
+
+    cmd = ["docker", "exec", str(container_name), "sh", "-lc", shell_script]
+
+    start = time.monotonic()
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+
+    sel = _selectors.DefaultSelector()
+    sel.register(proc.stdout, _selectors.EVENT_READ)
+    sel.register(proc.stderr, _selectors.EVENT_READ)
+
+    bytes_written = 0
+    truncated = False
+    timed_out = False
+    stderr_buf = bytearray()
+    stderr_max = 8192
+
+    def read_chunk(f) -> bytes:
+        try:
+            return f.read1(4096)  # type: ignore[attr-defined]
+        except Exception:
+            return f.read(4096)
+
+    with open(out_path, "wb") as out_f:
+        try:
+            while sel.get_map():
+                if (time.monotonic() - start) > float(dur + 10):
+                    timed_out = True
+                    break
+
+                events = sel.select(timeout=0.1)
+                if not events:
+                    if proc.poll() is not None:
+                        # Drain remaining quickly.
+                        for key in list(sel.get_map().values()):
+                            chunk = read_chunk(key.fileobj)
+                            if not chunk:
+                                try:
+                                    sel.unregister(key.fileobj)
+                                except Exception:
+                                    pass
+                                continue
+                            if key.fileobj is proc.stdout:
+                                if max_bytes_i > 0 and bytes_written < max_bytes_i:
+                                    remaining = max_bytes_i - bytes_written
+                                    out_f.write(chunk[:remaining])
+                                    bytes_written += min(len(chunk), remaining)
+                                    if len(chunk) > remaining:
+                                        truncated = True
+                                else:
+                                    truncated = True
+                            else:
+                                if len(stderr_buf) < stderr_max:
+                                    remaining = stderr_max - len(stderr_buf)
+                                    stderr_buf.extend(chunk[:remaining])
+                        continue
+                    continue
+
+                for key, _mask in events:
+                    chunk = read_chunk(key.fileobj)
+                    if not chunk:
+                        try:
+                            sel.unregister(key.fileobj)
+                        except Exception:
+                            pass
+                        continue
+
+                    if key.fileobj is proc.stdout:
+                        if truncated:
+                            # Stop reading stdout once we hit the cap; terminate below.
+                            continue
+                        if max_bytes_i > 0 and bytes_written < max_bytes_i:
+                            remaining = max_bytes_i - bytes_written
+                            out_f.write(chunk[:remaining])
+                            bytes_written += min(len(chunk), remaining)
+                            if len(chunk) > remaining:
+                                truncated = True
+                        else:
+                            truncated = True
+
+                        if truncated:
+                            break
+                    else:
+                        if len(stderr_buf) < stderr_max:
+                            remaining = stderr_max - len(stderr_buf)
+                            stderr_buf.extend(chunk[:remaining])
+
+                if truncated:
+                    break
+        finally:
+            try:
+                sel.close()
+            except Exception:
+                pass
+
+    if timed_out or truncated:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    exit_code = proc.wait() if proc.poll() is None else int(proc.returncode)
+    if timed_out and exit_code == 0:
+        exit_code = -1
+
+    return {
+        "exit_code": int(exit_code),
+        "bytes_written": int(bytes_written),
+        "truncated": bool(truncated),
+        "timed_out": bool(timed_out),
+        "stderr_head": stderr_buf.decode("utf-8", errors="replace").strip(),
+    }
 
 
 class JobManager:
@@ -212,6 +370,14 @@ class JobManager:
             if action == "capture_evidence":
                 summary["evidence_type"] = result.get("evidence_type")
             return summary
+        if action == "pcap_capture" and isinstance(result, dict):
+            arts = result.get("artifacts") or []
+            sample = []
+            if isinstance(arts, list):
+                for a in arts[:10]:
+                    if isinstance(a, dict) and a.get("ok"):
+                        sample.append({"node_id": a.get("node_id"), "artifact_id": a.get("artifact_id")})
+            return {"counts": result.get("counts"), "sample": sample}
         if action == "ops_logs" and isinstance(result, dict):
             return {"counts": result.get("counts"), "fail_reasons": result.get("fail_reasons")}
         if action == "routing_bgp_summary" and isinstance(result, dict):
@@ -270,6 +436,7 @@ class JobManager:
             "traceroute",
             "inject_fault",
             "capture_evidence",
+            "pcap_capture",
         }:
             sel, explicit = self._effective_selector(playbook, step_args=step_args, context=context)
             if sel is None and not explicit:
@@ -457,6 +624,111 @@ class JobManager:
                     max_output_chars=max_output_chars,
                 )
                 return {"evidence_type": evidence_type, **res}
+
+            if action == "pcap_capture":
+                job_id = str(context.get("job_id") or "").strip()
+                if not job_id:
+                    raise RuntimeError("job_id missing from context")
+
+                interface = str(step_args.get("interface") or "any").strip() or "any"
+                duration_seconds = int(step_args.get("duration_seconds") or 10)
+                filter_expr = str(step_args.get("filter") or "").strip()
+                max_bytes = int(step_args.get("max_bytes") or (20 * 1024 * 1024))
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 5)
+
+                nodes = self._workspaces.list_nodes(workspace_id, selector=selector)
+
+                def worker(node: dict[str, Any]) -> dict[str, Any]:
+                    node_id = str(node.get("node_id") or "")
+                    cname = str(node.get("container_name") or "")
+                    name = f"{step.step_id}_{node_id}"
+                    path = self._artifacts.allocate_path(
+                        workspace_id=workspace_id,
+                        job_id=job_id,
+                        name=name,
+                        suffix=".pcap",
+                    )
+                    tmp = Path(str(path) + ".tmp")
+                    try:
+                        meta = _capture_pcap_to_file(
+                            container_name=cname,
+                            interface=interface,
+                            duration_seconds=int(duration_seconds),
+                            filter_expr=filter_expr,
+                            out_path=str(tmp),
+                            max_bytes=int(max_bytes),
+                        )
+                        if int(meta.get("bytes_written") or 0) <= 0:
+                            try:
+                                if tmp.exists():
+                                    tmp.unlink()
+                            except Exception:
+                                pass
+                            err = meta.get("stderr_head") or "no data captured"
+                            return {
+                                "node_id": node_id,
+                                "container_name": cname,
+                                "ok": False,
+                                "error": str(err),
+                                "meta": meta,
+                            }
+
+                        os.replace(tmp, path)
+                        artifact = self._artifacts.register_file(
+                            workspace_id=workspace_id,
+                            job_id=job_id,
+                            name=name,
+                            kind="pcap",
+                            path=str(path),
+                        )
+                        return {
+                            "node_id": node_id,
+                            "container_name": cname,
+                            "ok": True,
+                            "artifact_id": artifact.artifact_id,
+                            "size_bytes": artifact.size_bytes,
+                            "name": artifact.name,
+                            "meta": meta,
+                        }
+                    except Exception as e:
+                        try:
+                            if tmp.exists():
+                                tmp.unlink()
+                        except Exception:
+                            pass
+                        try:
+                            if path.exists():
+                                path.unlink()
+                        except Exception:
+                            pass
+                        return {"node_id": node_id, "container_name": cname, "ok": False, "error": str(e)}
+
+                results: list[dict[str, Any]] = []
+                with ThreadPoolExecutor(max_workers=max(1, int(parallelism))) as pool:
+                    futs = [pool.submit(worker, n) for n in nodes]
+                    for fut in as_completed(futs):
+                        results.append(fut.result())
+
+                results.sort(key=lambda r: str(r.get("node_id", "")))
+                ok = sum(1 for r in results if r.get("ok"))
+                fail = len(results) - ok
+
+                payload = {
+                    "interface": interface,
+                    "duration_seconds": int(duration_seconds),
+                    "filter": filter_expr,
+                    "max_bytes": int(max_bytes),
+                    "counts": {"total": len(results), "ok": ok, "fail": fail},
+                    "artifacts": results,
+                }
+                self._store.insert_event(
+                    workspace_id,
+                    level="info",
+                    event_type="ops.pcap_capture",
+                    message=f"pcap_capture ({step.step_id})",
+                    data={**payload["counts"], "interface": interface, "duration_seconds": int(duration_seconds), "filter": filter_expr},
+                )
+                return payload
 
         raise ValueError(f"Unsupported step action: {action}")
 

--- a/mcp-server/seedops/jobs.py
+++ b/mcp-server/seedops/jobs.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from .artifacts import ArtifactManager
 from .ops import OpsService
-from .playbooks import Playbook, PlaybookStep, parse_playbook_yaml
+from .playbooks import Playbook, PlaybookStep, SUPPORTED_ON_ERROR, parse_playbook_yaml
 from .store import JobRow, SeedOpsStore
 from .workspaces import WorkspaceManager
 
@@ -143,6 +143,34 @@ class JobManager:
             return defaults_sel, False
         return None, False
 
+    def _effective_on_error(self, playbook: Playbook, step: PlaybookStep) -> str:
+        if step.on_error:
+            return step.on_error
+        val = playbook.defaults.get("on_error")
+        if isinstance(val, str) and val.strip() in SUPPORTED_ON_ERROR:
+            return val.strip()
+        return "stop"
+
+    def _effective_retries(self, playbook: Playbook, step: PlaybookStep) -> int:
+        if step.retries is not None:
+            return int(step.retries)
+        val = playbook.defaults.get("retries")
+        try:
+            retries = int(val) if val is not None else 0
+        except Exception:
+            retries = 0
+        return max(0, retries)
+
+    def _effective_retry_delay_seconds(self, playbook: Playbook, step: PlaybookStep) -> float:
+        if step.retry_delay_seconds is not None:
+            return float(step.retry_delay_seconds)
+        val = playbook.defaults.get("retry_delay_seconds")
+        try:
+            delay = float(val) if val is not None else 1.0
+        except Exception:
+            delay = 1.0
+        return max(0.0, delay)
+
     def _summarize_result(self, action: str, result: Any) -> dict[str, Any]:
         if action == "inventory_list_nodes" and isinstance(result, list):
             sample = []
@@ -242,6 +270,7 @@ class JobManager:
         )
 
         try:
+            had_errors = False
             for idx, step in enumerate(playbook.steps, start=1):
                 if cancel.is_set():
                     self._store.insert_job_step(
@@ -273,7 +302,60 @@ class JobManager:
                     data={"action": step.action},
                 )
 
-                result = self._execute_step(workspace_id, playbook, step, cancel)
+                retries = self._effective_retries(playbook, step)
+                delay = self._effective_retry_delay_seconds(playbook, step)
+                on_error = self._effective_on_error(playbook, step)
+
+                attempt = 0
+                last_error: Exception | None = None
+                result: Any | None = None
+                while True:
+                    if cancel.is_set():
+                        raise RuntimeError("canceled")
+                    attempt += 1
+                    try:
+                        result = self._execute_step(workspace_id, playbook, step, cancel)
+                        break
+                    except Exception as e:
+                        last_error = e
+                        max_attempts = 1 + int(retries)
+                        if attempt >= max_attempts:
+                            break
+                        self._store.insert_job_step(
+                            job_id,
+                            level="warn",
+                            step_index=idx,
+                            step_name=step.step_id,
+                            event_type="step.retry",
+                            message=str(e),
+                            data={"action": step.action, "attempt": attempt, "max_attempts": max_attempts, "delay_seconds": delay},
+                        )
+                        _sleep_interruptible(cancel, delay)
+
+                if result is None and last_error is not None:
+                    had_errors = True
+                    self._store.insert_job_step(
+                        job_id,
+                        level="error",
+                        step_index=idx,
+                        step_name=step.step_id,
+                        event_type="step.failed",
+                        message=str(last_error),
+                        data={"action": step.action, "attempts": attempt, "retries": retries, "on_error": on_error},
+                    )
+
+                    if on_error != "continue":
+                        raise last_error
+
+                    # Continue to next step, but still update job progress.
+                    self._store.update_job(
+                        job_id,
+                        progress_current=idx,
+                        message=f"{step.step_id} failed (continuing) ({idx}/{total})",
+                    )
+                    continue
+
+                assert result is not None
                 summary = self._summarize_result(step.action, result)
 
                 artifact_id = None
@@ -303,12 +385,13 @@ class JobManager:
                 )
 
             finished_at = int(time.time())
-            self._store.update_job(job_id, status="succeeded", finished_at=finished_at, message="succeeded")
+            final_status = "succeeded_with_errors" if had_errors else "succeeded"
+            self._store.update_job(job_id, status=final_status, finished_at=finished_at, message=final_status)
             self._store.insert_event(
                 workspace_id,
                 level="info",
-                event_type="job.succeeded",
-                message=f"Job succeeded: {playbook.name}",
+                event_type="job.succeeded" if final_status == "succeeded" else "job.succeeded_with_errors",
+                message=f"Job {final_status}: {playbook.name}",
                 data={"job_id": job_id},
             )
         except Exception as e:
@@ -411,4 +494,3 @@ class JobManager:
             )
         finally:
             self._cleanup_thread(job_id)
-

--- a/mcp-server/seedops/jobs.py
+++ b/mcp-server/seedops/jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import threading
 import time
 from typing import Any
@@ -8,6 +9,7 @@ from .artifacts import ArtifactManager
 from .ops import OpsService
 from .playbooks import Playbook, PlaybookStep, SUPPORTED_ON_ERROR, parse_playbook_yaml
 from .store import JobRow, SeedOpsStore
+from .template import TemplateError, render_value
 from .workspaces import WorkspaceManager
 
 
@@ -133,15 +135,34 @@ class JobManager:
         thread.start()
         return job
 
-    def _effective_selector(self, playbook: Playbook, step: PlaybookStep) -> tuple[dict[str, Any] | None, bool]:
+    def _render_default(self, playbook: Playbook, key: str, context: dict[str, Any]) -> Any:
+        if key not in playbook.defaults:
+            return None
+        try:
+            return render_value(playbook.defaults.get(key), context)
+        except TemplateError as e:
+            raise ValueError(f"Template error in defaults.{key}: {e}") from None
+
+    def _effective_selector(
+        self,
+        playbook: Playbook,
+        *,
+        step_args: dict[str, Any],
+        context: dict[str, Any],
+    ) -> tuple[dict[str, Any] | None, bool]:
         # Return (selector, explicitly_provided)
-        if "selector" in step.args:
-            sel = step.args.get("selector")
+        if "selector" in step_args:
+            sel = step_args.get("selector")
             return (sel if isinstance(sel, dict) else None), True
-        defaults_sel = playbook.defaults.get("selector")
-        if isinstance(defaults_sel, dict):
-            return defaults_sel, False
-        return None, False
+
+        defaults_sel_raw = playbook.defaults.get("selector")
+        if defaults_sel_raw is None:
+            return None, False
+        try:
+            defaults_sel = render_value(defaults_sel_raw, context)
+        except TemplateError as e:
+            raise ValueError(f"Template error in defaults.selector: {e}") from None
+        return (defaults_sel if isinstance(defaults_sel, dict) else None), False
 
     def _effective_on_error(self, playbook: Playbook, step: PlaybookStep) -> str:
         if step.on_error:
@@ -178,14 +199,19 @@ class JobManager:
                 if isinstance(n, dict) and "node_id" in n:
                     sample.append(str(n["node_id"]))
             return {"count": len(result), "sample_node_ids": sample}
-        if action == "ops_exec" and isinstance(result, dict):
-            return {
-                "command": result.get("command"),
-                "command_hash": result.get("command_hash"),
-                "backend": result.get("backend"),
-                "counts": result.get("counts"),
-                "fail_reasons": result.get("fail_reasons"),
-            }
+        if action in {"ops_exec", "ping", "traceroute", "inject_fault", "capture_evidence"} and isinstance(result, dict):
+            summary = self._summarize_exec_like(result)
+            if action in {"ping", "traceroute"}:
+                summary["dst"] = result.get("dst")
+            if action == "ping":
+                summary["count"] = result.get("count")
+            if action == "inject_fault":
+                summary["fault_type"] = result.get("fault_type")
+                summary["params"] = result.get("params")
+                summary["interface"] = result.get("interface")
+            if action == "capture_evidence":
+                summary["evidence_type"] = result.get("evidence_type")
+            return summary
         if action == "ops_logs" and isinstance(result, dict):
             return {"counts": result.get("counts"), "fail_reasons": result.get("fail_reasons")}
         if action == "routing_bgp_summary" and isinstance(result, dict):
@@ -197,11 +223,29 @@ class JobManager:
             return result
         return {"result_type": type(result).__name__}
 
-    def _execute_step(self, workspace_id: str, playbook: Playbook, step: PlaybookStep, cancel: threading.Event) -> Any:
+    def _summarize_exec_like(self, result: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "command": result.get("command"),
+            "command_hash": result.get("command_hash"),
+            "backend": result.get("backend"),
+            "counts": result.get("counts"),
+            "fail_reasons": result.get("fail_reasons"),
+        }
+
+    def _execute_step(
+        self,
+        workspace_id: str,
+        playbook: Playbook,
+        step: PlaybookStep,
+        *,
+        step_args: dict[str, Any],
+        cancel: threading.Event,
+        context: dict[str, Any],
+    ) -> Any:
         action = step.action
 
         if action == "sleep":
-            seconds = float(step.args.get("seconds", 0))
+            seconds = float(step_args.get("seconds", 0))
             _sleep_interruptible(cancel, seconds)
             return {"slept_seconds": seconds}
 
@@ -212,23 +256,35 @@ class JobManager:
             return self._workspaces.refresh(workspace_id)
 
         if action == "inventory_list_nodes":
-            sel, _explicit = self._effective_selector(playbook, step)
+            sel, explicit = self._effective_selector(playbook, step_args=step_args, context=context)
+            if explicit and sel is None:
+                raise ValueError("selector must be a dict (use {} to select all).")
             selector = sel or {}
             return self._workspaces.list_nodes(workspace_id, selector=selector)
 
-        if action in {"ops_exec", "ops_logs", "routing_bgp_summary"}:
-            sel, explicit = self._effective_selector(playbook, step)
+        if action in {
+            "ops_exec",
+            "ops_logs",
+            "routing_bgp_summary",
+            "ping",
+            "traceroute",
+            "inject_fault",
+            "capture_evidence",
+        }:
+            sel, explicit = self._effective_selector(playbook, step_args=step_args, context=context)
             if sel is None and not explicit:
                 raise ValueError(f"{action} requires selector via step.selector or defaults.selector (use {{}} to select all).")
+            if explicit and sel is None:
+                raise ValueError("selector must be a dict (use {} to select all).")
             selector = sel if isinstance(sel, dict) else {}
 
             if action == "ops_exec":
-                command = str(step.args.get("command") or "").strip()
+                command = str(step_args.get("command") or "").strip()
                 if not command:
                     raise ValueError("ops_exec requires non-empty command.")
-                timeout_seconds = int(step.args.get("timeout_seconds") or playbook.defaults.get("timeout_seconds") or 30)
-                parallelism = int(step.args.get("parallelism") or playbook.defaults.get("parallelism") or 20)
-                max_output_chars = int(step.args.get("max_output_chars") or playbook.defaults.get("max_output_chars") or 8000)
+                timeout_seconds = int(step_args.get("timeout_seconds") or self._render_default(playbook, "timeout_seconds", context) or 30)
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 20)
+                max_output_chars = int(step_args.get("max_output_chars") or self._render_default(playbook, "max_output_chars", context) or 8000)
                 return self._ops.exec(
                     workspace_id,
                     selector=selector,
@@ -239,10 +295,10 @@ class JobManager:
                 )
 
             if action == "ops_logs":
-                tail = int(step.args.get("tail") or playbook.defaults.get("tail") or 200)
-                since_seconds = int(step.args.get("since_seconds") or playbook.defaults.get("since_seconds") or 0)
-                parallelism = int(step.args.get("parallelism") or playbook.defaults.get("parallelism") or 20)
-                max_output_chars = int(step.args.get("max_output_chars") or playbook.defaults.get("max_output_chars") or 8000)
+                tail = int(step_args.get("tail") or self._render_default(playbook, "tail", context) or 200)
+                since_seconds = int(step_args.get("since_seconds") or self._render_default(playbook, "since_seconds", context) or 0)
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 20)
+                max_output_chars = int(step_args.get("max_output_chars") or self._render_default(playbook, "max_output_chars", context) or 8000)
                 return self._ops.logs(
                     workspace_id,
                     selector=selector,
@@ -254,6 +310,153 @@ class JobManager:
 
             if action == "routing_bgp_summary":
                 return self._ops.bgp_summary(workspace_id, selector=selector)
+
+            if action == "ping":
+                dst = str(step_args.get("dst") or "").strip()
+                if not dst:
+                    raise ValueError("ping requires non-empty dst.")
+                count = int(step_args.get("count") or 4)
+                timeout_seconds = int(step_args.get("timeout_seconds") or self._render_default(playbook, "timeout_seconds", context) or 30)
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 20)
+                max_output_chars = int(step_args.get("max_output_chars") or self._render_default(playbook, "max_output_chars", context) or 8000)
+
+                cmd = f"ping -c {count} {shlex.quote(dst)}"
+                res = self._ops.exec(
+                    workspace_id,
+                    selector=selector,
+                    command=cmd,
+                    timeout_seconds=timeout_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+                return {"dst": dst, "count": count, **res}
+
+            if action == "traceroute":
+                dst = str(step_args.get("dst") or "").strip()
+                if not dst:
+                    raise ValueError("traceroute requires non-empty dst.")
+                timeout_seconds = int(step_args.get("timeout_seconds") or self._render_default(playbook, "timeout_seconds", context) or 30)
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 20)
+                max_output_chars = int(step_args.get("max_output_chars") or self._render_default(playbook, "max_output_chars", context) or 8000)
+
+                script = f"traceroute -n {shlex.quote(dst)} || tracepath -n {shlex.quote(dst)}"
+                cmd = f"sh -lc {shlex.quote(script)}"
+                res = self._ops.exec(
+                    workspace_id,
+                    selector=selector,
+                    command=cmd,
+                    timeout_seconds=timeout_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+                return {"dst": dst, **res}
+
+            if action == "inject_fault":
+                fault_type = str(step_args.get("fault_type") or "").strip().lower()
+                if not fault_type:
+                    raise ValueError("inject_fault requires non-empty fault_type.")
+                params = str(step_args.get("params") or "").strip()
+                interface = str(step_args.get("interface") or "eth0").strip() or "eth0"
+
+                if fault_type == "packet_loss":
+                    percent = params or "10"
+                    cmd = f"tc qdisc add dev {shlex.quote(interface)} root netem loss {shlex.quote(percent)}%"
+                elif fault_type == "latency":
+                    ms = params or "100"
+                    cmd = f"tc qdisc add dev {shlex.quote(interface)} root netem delay {shlex.quote(ms)}ms"
+                elif fault_type == "bandwidth":
+                    rate = params or "1mbit"
+                    cmd = (
+                        f"tc qdisc add dev {shlex.quote(interface)} root tbf rate {shlex.quote(rate)}"
+                        " burst 32kbit latency 400ms"
+                    )
+                elif fault_type == "kill_process":
+                    process = params or "bird"
+                    cmd = f"pkill -9 {shlex.quote(process)} 2>/dev/null || echo 'Process not found'"
+                elif fault_type == "disconnect":
+                    iface = params or interface
+                    cmd = f"ip link set {shlex.quote(iface)} down"
+                elif fault_type == "reset":
+                    cmd = f"tc qdisc del dev {shlex.quote(interface)} root 2>/dev/null || true"
+                else:
+                    raise ValueError(
+                        "Unknown fault_type. Valid: packet_loss, latency, bandwidth, kill_process, disconnect, reset"
+                    )
+
+                timeout_seconds = int(step_args.get("timeout_seconds") or self._render_default(playbook, "timeout_seconds", context) or 30)
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 20)
+                max_output_chars = int(step_args.get("max_output_chars") or self._render_default(playbook, "max_output_chars", context) or 8000)
+
+                res = self._ops.exec(
+                    workspace_id,
+                    selector=selector,
+                    command=cmd,
+                    timeout_seconds=timeout_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+                return {"fault_type": fault_type, "params": params, "interface": interface, **res}
+
+            if action == "capture_evidence":
+                evidence_type = str(step_args.get("evidence_type") or "").strip().lower()
+                if not evidence_type:
+                    raise ValueError("capture_evidence requires non-empty evidence_type.")
+
+                parts: list[str] = []
+
+                if evidence_type in {"routing_snapshot", "full"}:
+                    parts.append("echo '=== ROUTING TABLE ==='")
+                    parts.append("ip route || true")
+                    parts.append("echo ''")
+                    parts.append("echo '=== BGP STATUS ==='")
+                    parts.append("birdc show protocol 2>/dev/null || echo 'No BIRD'")
+                    parts.append("echo ''")
+                    parts.append("echo '=== BGP ROUTES ==='")
+                    parts.append("birdc 'show route' 2>/dev/null || echo 'No BIRD'")
+
+                if evidence_type in {"network_state", "full"}:
+                    parts.append("echo ''")
+                    parts.append("echo '=== INTERFACES ==='")
+                    parts.append("ip addr || true")
+                    parts.append("echo ''")
+                    parts.append("echo '=== ARP TABLE ==='")
+                    parts.append("ip neigh || true")
+                    parts.append("echo ''")
+                    parts.append("echo '=== ACTIVE CONNECTIONS ==='")
+                    parts.append("ss -tuln 2>/dev/null || netstat -tuln || true")
+
+                if evidence_type in {"process_list", "full"}:
+                    parts.append("echo ''")
+                    parts.append("echo '=== PROCESSES ==='")
+                    parts.append("ps aux || true")
+
+                if evidence_type in {"logs", "full"}:
+                    parts.append("echo ''")
+                    parts.append("echo '=== SYSLOG (last 50 lines) ==='")
+                    parts.append("tail -50 /var/log/syslog 2>/dev/null || echo 'No syslog'")
+                    parts.append("echo ''")
+                    parts.append("echo '=== DMESG (last 20 lines) ==='")
+                    parts.append("dmesg | tail -20 2>/dev/null || echo 'No dmesg'")
+
+                if not parts:
+                    raise ValueError(
+                        "Unknown evidence_type. Valid: routing_snapshot, network_state, process_list, logs, full"
+                    )
+
+                script = "\n".join(parts)
+                cmd = f"sh -lc {shlex.quote(script)}"
+                timeout_seconds = int(step_args.get("timeout_seconds") or self._render_default(playbook, "timeout_seconds", context) or 30)
+                parallelism = int(step_args.get("parallelism") or self._render_default(playbook, "parallelism", context) or 20)
+                max_output_chars = int(step_args.get("max_output_chars") or self._render_default(playbook, "max_output_chars", context) or 8000)
+                res = self._ops.exec(
+                    workspace_id,
+                    selector=selector,
+                    command=cmd,
+                    timeout_seconds=timeout_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+                return {"evidence_type": evidence_type, **res}
 
         raise ValueError(f"Unsupported step action: {action}")
 
@@ -271,6 +474,13 @@ class JobManager:
 
         try:
             had_errors = False
+            context: dict[str, Any] = {
+                "workspace_id": workspace_id,
+                "job_id": job_id,
+                "vars": playbook.vars,
+                "playbook": {"version": playbook.version, "name": playbook.name, "defaults": playbook.defaults},
+                "steps": {},
+            }
             for idx, step in enumerate(playbook.steps, start=1):
                 if cancel.is_set():
                     self._store.insert_job_step(
@@ -314,7 +524,22 @@ class JobManager:
                         raise RuntimeError("canceled")
                     attempt += 1
                     try:
-                        result = self._execute_step(workspace_id, playbook, step, cancel)
+                        context["now_ts"] = int(time.time())
+                        context["step"] = {"id": step.step_id, "action": step.action, "index": idx, "attempt": attempt}
+                        try:
+                            rendered = render_value(step.args, context)
+                        except TemplateError as e:
+                            raise ValueError(f"Template error in step {step.step_id}: {e}") from None
+                        if not isinstance(rendered, dict):
+                            raise ValueError(f"Step args must be a dict after templating (step {step.step_id}).")
+                        result = self._execute_step(
+                            workspace_id,
+                            playbook,
+                            step,
+                            step_args=rendered,
+                            cancel=cancel,
+                            context=context,
+                        )
                         break
                     except Exception as e:
                         last_error = e
@@ -334,6 +559,12 @@ class JobManager:
 
                 if result is None and last_error is not None:
                     had_errors = True
+                    context["steps"][step.step_id] = {
+                        "action": step.action,
+                        "ok": False,
+                        "error": str(last_error),
+                        "attempts": attempt,
+                    }
                     self._store.insert_job_step(
                         job_id,
                         level="error",
@@ -360,14 +591,28 @@ class JobManager:
 
                 artifact_id = None
                 if step.save_as:
+                    try:
+                        rendered_name = render_value(step.save_as, context)
+                    except TemplateError as e:
+                        raise ValueError(f"Template error in save_as for step {step.step_id}: {e}") from None
+                    name_s = str(rendered_name).strip()
+                    if not name_s:
+                        raise ValueError(f"save_as resolved to empty name for step {step.step_id}.")
                     artifact = self._artifacts.write_json(
                         workspace_id=workspace_id,
                         job_id=job_id,
-                        name=step.save_as,
+                        name=name_s,
                         data=result,
                     )
                     artifact_id = artifact.artifact_id
 
+                context["steps"][step.step_id] = {
+                    "action": step.action,
+                    "ok": True,
+                    "summary": summary,
+                    "artifact_id": artifact_id,
+                    "attempts": attempt,
+                }
                 self._store.insert_job_step(
                     job_id,
                     level="info",

--- a/mcp-server/seedops/jobs.py
+++ b/mcp-server/seedops/jobs.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from .artifacts import ArtifactManager
+from .ops import OpsService
+from .playbooks import Playbook, PlaybookStep, parse_playbook_yaml
+from .store import JobRow, SeedOpsStore
+from .workspaces import WorkspaceManager
+
+
+def _sleep_interruptible(cancel: threading.Event, seconds: float) -> None:
+    deadline = time.monotonic() + float(seconds)
+    while True:
+        if cancel.is_set():
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(0.2, remaining))
+
+
+class JobManager:
+    """Background jobs for long-running operations (playbooks, collectors)."""
+
+    def __init__(
+        self,
+        *,
+        store: SeedOpsStore,
+        workspaces: WorkspaceManager,
+        ops: OpsService,
+        artifacts: ArtifactManager,
+    ):
+        self._store = store
+        self._workspaces = workspaces
+        self._ops = ops
+        self._artifacts = artifacts
+
+        self._lock = threading.RLock()
+        self._cancel: dict[str, threading.Event] = {}
+        self._threads: dict[str, threading.Thread] = {}
+
+        # Any in-flight jobs are no longer running after a restart.
+        self._store.mark_running_jobs_interrupted()
+
+    def _register_thread(self, job_id: str, cancel: threading.Event, thread: threading.Thread) -> None:
+        with self._lock:
+            self._cancel[job_id] = cancel
+            self._threads[job_id] = thread
+
+    def _cleanup_thread(self, job_id: str) -> None:
+        with self._lock:
+            self._cancel.pop(job_id, None)
+            self._threads.pop(job_id, None)
+
+    def cancel_job(self, job_id: str) -> bool:
+        with self._lock:
+            ev = self._cancel.get(job_id)
+        if ev is None:
+            job = self._store.get_job(job_id)
+            if job and job.status in {"queued"}:
+                self._store.update_job(job_id, status="canceled", finished_at=int(time.time()), message="canceled")
+                return True
+            return False
+        ev.set()
+        self._store.update_job(job_id, status="cancel_requested", message="cancel requested")
+        return True
+
+    def start_playbook(self, workspace_id: str, *, playbook_yaml: str) -> JobRow:
+        playbook = parse_playbook_yaml(playbook_yaml)
+        job = self._store.create_job(
+            workspace_id,
+            kind="playbook",
+            name=playbook.name,
+            status="queued",
+            message="queued",
+            data={"version": playbook.version, "name": playbook.name},
+            progress_total=len(playbook.steps),
+        )
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="job.created",
+            message=f"Job created: {playbook.name}",
+            data={"job_id": job.job_id, "kind": "playbook", "name": playbook.name},
+        )
+
+        cancel = threading.Event()
+        thread = threading.Thread(
+            target=self._run_playbook_job,
+            args=(job.job_id, workspace_id, playbook, cancel),
+            daemon=True,
+        )
+        self._register_thread(job.job_id, cancel, thread)
+        thread.start()
+        return job
+
+    def start_collector(
+        self,
+        workspace_id: str,
+        *,
+        interval_seconds: int = 30,
+        selector: dict[str, Any] | None = None,
+        include_bgp_summary: bool = True,
+    ) -> JobRow:
+        sel = selector or {}
+        job = self._store.create_job(
+            workspace_id,
+            kind="collector",
+            name="collector",
+            status="queued",
+            message="queued",
+            data={"interval_seconds": int(interval_seconds), "selector": sel, "include_bgp_summary": bool(include_bgp_summary)},
+            progress_total=0,
+        )
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="collector.created",
+            message="Collector created",
+            data={"job_id": job.job_id, "interval_seconds": int(interval_seconds), "include_bgp_summary": bool(include_bgp_summary)},
+        )
+
+        cancel = threading.Event()
+        thread = threading.Thread(
+            target=self._run_collector_job,
+            args=(job.job_id, workspace_id, int(interval_seconds), sel, bool(include_bgp_summary), cancel),
+            daemon=True,
+        )
+        self._register_thread(job.job_id, cancel, thread)
+        thread.start()
+        return job
+
+    def _effective_selector(self, playbook: Playbook, step: PlaybookStep) -> tuple[dict[str, Any] | None, bool]:
+        # Return (selector, explicitly_provided)
+        if "selector" in step.args:
+            sel = step.args.get("selector")
+            return (sel if isinstance(sel, dict) else None), True
+        defaults_sel = playbook.defaults.get("selector")
+        if isinstance(defaults_sel, dict):
+            return defaults_sel, False
+        return None, False
+
+    def _summarize_result(self, action: str, result: Any) -> dict[str, Any]:
+        if action == "inventory_list_nodes" and isinstance(result, list):
+            sample = []
+            for n in result[:10]:
+                if isinstance(n, dict) and "node_id" in n:
+                    sample.append(str(n["node_id"]))
+            return {"count": len(result), "sample_node_ids": sample}
+        if action == "ops_exec" and isinstance(result, dict):
+            return {
+                "command": result.get("command"),
+                "command_hash": result.get("command_hash"),
+                "backend": result.get("backend"),
+                "counts": result.get("counts"),
+                "fail_reasons": result.get("fail_reasons"),
+            }
+        if action == "ops_logs" and isinstance(result, dict):
+            return {"counts": result.get("counts"), "fail_reasons": result.get("fail_reasons")}
+        if action == "routing_bgp_summary" and isinstance(result, dict):
+            return {"backend": result.get("backend"), "counts": result.get("counts")}
+        if action == "sleep" and isinstance(result, dict):
+            return result
+        if isinstance(result, dict):
+            # workspace_refresh is already a compact summary
+            return result
+        return {"result_type": type(result).__name__}
+
+    def _execute_step(self, workspace_id: str, playbook: Playbook, step: PlaybookStep, cancel: threading.Event) -> Any:
+        action = step.action
+
+        if action == "sleep":
+            seconds = float(step.args.get("seconds", 0))
+            _sleep_interruptible(cancel, seconds)
+            return {"slept_seconds": seconds}
+
+        if cancel.is_set():
+            raise RuntimeError("canceled")
+
+        if action == "workspace_refresh":
+            return self._workspaces.refresh(workspace_id)
+
+        if action == "inventory_list_nodes":
+            sel, _explicit = self._effective_selector(playbook, step)
+            selector = sel or {}
+            return self._workspaces.list_nodes(workspace_id, selector=selector)
+
+        if action in {"ops_exec", "ops_logs", "routing_bgp_summary"}:
+            sel, explicit = self._effective_selector(playbook, step)
+            if sel is None and not explicit:
+                raise ValueError(f"{action} requires selector via step.selector or defaults.selector (use {{}} to select all).")
+            selector = sel if isinstance(sel, dict) else {}
+
+            if action == "ops_exec":
+                command = str(step.args.get("command") or "").strip()
+                if not command:
+                    raise ValueError("ops_exec requires non-empty command.")
+                timeout_seconds = int(step.args.get("timeout_seconds") or playbook.defaults.get("timeout_seconds") or 30)
+                parallelism = int(step.args.get("parallelism") or playbook.defaults.get("parallelism") or 20)
+                max_output_chars = int(step.args.get("max_output_chars") or playbook.defaults.get("max_output_chars") or 8000)
+                return self._ops.exec(
+                    workspace_id,
+                    selector=selector,
+                    command=command,
+                    timeout_seconds=timeout_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+
+            if action == "ops_logs":
+                tail = int(step.args.get("tail") or playbook.defaults.get("tail") or 200)
+                since_seconds = int(step.args.get("since_seconds") or playbook.defaults.get("since_seconds") or 0)
+                parallelism = int(step.args.get("parallelism") or playbook.defaults.get("parallelism") or 20)
+                max_output_chars = int(step.args.get("max_output_chars") or playbook.defaults.get("max_output_chars") or 8000)
+                return self._ops.logs(
+                    workspace_id,
+                    selector=selector,
+                    tail=tail,
+                    since_seconds=since_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+
+            if action == "routing_bgp_summary":
+                return self._ops.bgp_summary(workspace_id, selector=selector)
+
+        raise ValueError(f"Unsupported step action: {action}")
+
+    def _run_playbook_job(self, job_id: str, workspace_id: str, playbook: Playbook, cancel: threading.Event) -> None:
+        started_at = int(time.time())
+        total = len(playbook.steps)
+        self._store.update_job(job_id, status="running", started_at=started_at, progress_total=total, message="running")
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="job.started",
+            message=f"Job started: {playbook.name}",
+            data={"job_id": job_id, "kind": "playbook", "name": playbook.name},
+        )
+
+        try:
+            for idx, step in enumerate(playbook.steps, start=1):
+                if cancel.is_set():
+                    self._store.insert_job_step(
+                        job_id,
+                        level="warn",
+                        step_index=idx,
+                        step_name=step.step_id,
+                        event_type="job.canceled",
+                        message="Canceled",
+                        data={},
+                    )
+                    self._store.update_job(job_id, status="canceled", finished_at=int(time.time()), message="canceled")
+                    self._store.insert_event(
+                        workspace_id,
+                        level="warn",
+                        event_type="job.canceled",
+                        message=f"Job canceled: {playbook.name}",
+                        data={"job_id": job_id},
+                    )
+                    return
+
+                self._store.insert_job_step(
+                    job_id,
+                    level="info",
+                    step_index=idx,
+                    step_name=step.step_id,
+                    event_type="step.started",
+                    message=f"{step.action} started",
+                    data={"action": step.action},
+                )
+
+                result = self._execute_step(workspace_id, playbook, step, cancel)
+                summary = self._summarize_result(step.action, result)
+
+                artifact_id = None
+                if step.save_as:
+                    artifact = self._artifacts.write_json(
+                        workspace_id=workspace_id,
+                        job_id=job_id,
+                        name=step.save_as,
+                        data=result,
+                    )
+                    artifact_id = artifact.artifact_id
+
+                self._store.insert_job_step(
+                    job_id,
+                    level="info",
+                    step_index=idx,
+                    step_name=step.step_id,
+                    event_type="step.finished",
+                    message=f"{step.action} finished",
+                    data={"action": step.action, "summary": summary, "artifact_id": artifact_id},
+                )
+
+                self._store.update_job(
+                    job_id,
+                    progress_current=idx,
+                    message=f"{step.step_id} ({idx}/{total})",
+                )
+
+            finished_at = int(time.time())
+            self._store.update_job(job_id, status="succeeded", finished_at=finished_at, message="succeeded")
+            self._store.insert_event(
+                workspace_id,
+                level="info",
+                event_type="job.succeeded",
+                message=f"Job succeeded: {playbook.name}",
+                data={"job_id": job_id},
+            )
+        except Exception as e:
+            self._store.insert_job_step(
+                job_id,
+                level="error",
+                step_index=int(self._store.get_job(job_id).progress_current if self._store.get_job(job_id) else 0),
+                step_name="error",
+                event_type="job.failed",
+                message=str(e),
+                data={"error": str(e)},
+            )
+            self._store.update_job(job_id, status="failed", finished_at=int(time.time()), message=str(e))
+            self._store.insert_event(
+                workspace_id,
+                level="error",
+                event_type="job.failed",
+                message=f"Job failed: {playbook.name}",
+                data={"job_id": job_id, "error": str(e)},
+            )
+        finally:
+            self._cleanup_thread(job_id)
+
+    def _run_collector_job(
+        self,
+        job_id: str,
+        workspace_id: str,
+        interval_seconds: int,
+        selector: dict[str, Any],
+        include_bgp_summary: bool,
+        cancel: threading.Event,
+    ) -> None:
+        started_at = int(time.time())
+        self._store.update_job(job_id, status="running", started_at=started_at, message="running")
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="collector.started",
+            message="Collector started",
+            data={"job_id": job_id, "interval_seconds": int(interval_seconds)},
+        )
+
+        tick = 0
+        try:
+            while not cancel.is_set():
+                tick += 1
+                inv_summary = self._workspaces.refresh(workspace_id)
+                inv_snapshot_id = self._store.insert_snapshot(
+                    workspace_id,
+                    snapshot_type="inventory_summary",
+                    data={"job_id": job_id, "tick": tick, **inv_summary},
+                )
+
+                bgp_snapshot_id = None
+                if include_bgp_summary:
+                    bgp = self._ops.bgp_summary(workspace_id, selector=selector)
+                    bgp_snapshot_id = self._store.insert_snapshot(
+                        workspace_id,
+                        snapshot_type="bgp_summary_counts",
+                        data={"job_id": job_id, "tick": tick, **(bgp.get("counts") or {}), "backend": bgp.get("backend")},
+                    )
+
+                self._store.insert_job_step(
+                    job_id,
+                    level="info",
+                    step_index=tick,
+                    step_name="tick",
+                    event_type="collector.tick",
+                    message="collector tick",
+                    data={"inventory_snapshot_id": inv_snapshot_id, "bgp_snapshot_id": bgp_snapshot_id},
+                )
+                self._store.update_job(job_id, message=f"tick {tick}")
+                _sleep_interruptible(cancel, float(interval_seconds))
+
+            self._store.update_job(job_id, status="canceled", finished_at=int(time.time()), message="stopped")
+            self._store.insert_event(
+                workspace_id,
+                level="info",
+                event_type="collector.stopped",
+                message="Collector stopped",
+                data={"job_id": job_id},
+            )
+        except Exception as e:
+            self._store.insert_job_step(
+                job_id,
+                level="error",
+                step_index=tick,
+                step_name="tick",
+                event_type="collector.error",
+                message=str(e),
+                data={"error": str(e)},
+            )
+            self._store.update_job(job_id, status="failed", finished_at=int(time.time()), message=str(e))
+            self._store.insert_event(
+                workspace_id,
+                level="error",
+                event_type="collector.failed",
+                message="Collector failed",
+                data={"job_id": job_id, "error": str(e)},
+            )
+        finally:
+            self._cleanup_thread(job_id)
+

--- a/mcp-server/seedops/ops.py
+++ b/mcp-server/seedops/ops.py
@@ -326,6 +326,110 @@ class OpsService:
         )
         return payload
 
+    def exec_cli(
+        self,
+        workspace_id: str,
+        *,
+        selector: dict[str, Any],
+        command: str,
+        timeout_seconds: int = 30,
+        parallelism: int = 20,
+        max_output_chars: int = 8000,
+    ) -> dict[str, Any]:
+        """Execute a shell command across containers using the docker CLI backend.
+
+        This is safer for long-running commands because it enforces a host-side timeout.
+        """
+        if not shutil.which("docker"):
+            raise RuntimeError("docker CLI not found; cannot use exec_cli backend.")
+
+        nodes = self._workspaces.list_nodes(workspace_id, selector=selector)
+        backend = "cli"
+
+        script = f"command -v timeout >/dev/null 2>&1 && timeout {int(timeout_seconds)}s {command} || {command}"
+
+        def worker(node: dict[str, Any]) -> dict[str, Any]:
+            node_id = node.get("node_id")
+            cname = node.get("container_name")
+            try:
+                run = self._run_shell(
+                    docker_client=None,
+                    backend="cli",
+                    container_name=str(cname),
+                    shell_script=script,
+                    timeout_seconds=int(timeout_seconds),
+                    max_output_chars=int(max_output_chars),
+                )
+                exit_code = int(run["exit_code"])
+                out = str(run["output"])
+                timed_out = bool(run["timed_out"])
+                ok = exit_code == 0 and not timed_out
+                item: dict[str, Any] = {
+                    "node_id": node_id,
+                    "container_name": cname,
+                    "ok": ok,
+                    "exit_code": exit_code,
+                    "output": out,
+                }
+                if not ok:
+                    if timed_out:
+                        item["error"] = f"timeout after {int(timeout_seconds)}s"
+                    else:
+                        head = (out or "").strip().splitlines()[:1]
+                        item["error"] = head[0][:200] if head else f"exit_code {exit_code}"
+                return item
+            except Exception as e:
+                return {
+                    "node_id": node_id,
+                    "container_name": cname,
+                    "ok": False,
+                    "exit_code": -1,
+                    "error": str(e),
+                    "output": "",
+                }
+
+        results: list[dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=max(1, int(parallelism))) as pool:
+            futs = [pool.submit(worker, n) for n in nodes]
+            for fut in as_completed(futs):
+                results.append(fut.result())
+
+        results.sort(key=lambda r: str(r.get("node_id", "")))
+        ok = sum(1 for r in results if r.get("ok"))
+        fail = len(results) - ok
+        cmd_hash = hashlib.sha256(command.encode("utf-8")).hexdigest()[:12]
+
+        fail_reasons: dict[str, int] = {}
+        for r in results:
+            if r.get("ok"):
+                continue
+            reason = str(r.get("error") or f"exit_code {r.get('exit_code')}")
+            fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+
+        payload = {
+            "command": command,
+            "command_hash": cmd_hash,
+            "counts": {"total": len(results), "ok": ok, "fail": fail},
+            "results": results,
+            "backend": backend,
+            "fail_reasons": fail_reasons,
+        }
+
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="ops.exec",
+            message=f"Batch exec (cli): {cmd_hash}",
+            data={
+                "command": command,
+                "command_hash": cmd_hash,
+                "counts": payload["counts"],
+                "backend": backend,
+                "fail_reasons": fail_reasons,
+            },
+        )
+        return payload
+
     def logs(
         self,
         workspace_id: str,

--- a/mcp-server/seedops/ops.py
+++ b/mcp-server/seedops/ops.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import selectors
+import shutil
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+from .store import SeedOpsStore
+from .workspaces import WorkspaceManager
+
+
+_TRUNCATED_SUFFIX = "\n...[truncated]"
+
+
+def _truncate(text: str, max_chars: int, *, truncated: bool = False) -> str:
+    if max_chars <= 0:
+        return ""
+    if len(text) <= max_chars:
+        return text + (_TRUNCATED_SUFFIX if truncated else "")
+    return text[:max_chars] + _TRUNCATED_SUFFIX
+
+
+def _max_output_bytes(max_output_chars: int) -> int:
+    # Bound memory usage even if the output contains multibyte UTF-8.
+    # We intentionally over-approximate (worst case is 4 bytes/char).
+    if max_output_chars <= 0:
+        return 0
+    return int(max_output_chars) * 4
+
+
+def _read_stream_limited(stream: Any, *, max_bytes: int) -> tuple[bytes, bool]:
+    """Read bytes from an iterable stream up to max_bytes, returning (data, truncated)."""
+    if max_bytes <= 0:
+        return b"", False
+    buf = bytearray()
+    for chunk in stream:
+        if chunk is None:
+            continue
+        if isinstance(chunk, str):
+            chunk_b = chunk.encode("utf-8", errors="replace")
+        else:
+            chunk_b = bytes(chunk)
+        remaining = max_bytes - len(buf)
+        if remaining <= 0:
+            return bytes(buf), True
+        if len(chunk_b) <= remaining:
+            buf.extend(chunk_b)
+        else:
+            buf.extend(chunk_b[:remaining])
+            return bytes(buf), True
+    return bytes(buf), False
+
+
+def _exec_run(container: Any, cmd: list[str] | str) -> tuple[int, bytes]:
+    res = container.exec_run(cmd, demux=False)
+    exit_code = getattr(res, "exit_code", None)
+    output = getattr(res, "output", None)
+    if exit_code is None and isinstance(res, (tuple, list)) and len(res) >= 2:
+        exit_code = res[0]
+        output = res[1]
+    if exit_code is None:
+        exit_code = 0
+    if output is None:
+        output = b""
+    return int(exit_code), bytes(output)
+
+
+def _docker_exec_cli(
+    container_name: str,
+    *,
+    shell_script: str,
+    timeout_seconds: int,
+    max_bytes: int,
+) -> tuple[int, bytes, bool, bool]:
+    """Run `docker exec <container> sh -lc <script>` with host-side timeout and output limit.
+
+    Returns (exit_code, output_bytes_limited, output_truncated, timed_out).
+    """
+    cmd = ["docker", "exec", container_name, "sh", "-lc", shell_script]
+    start = time.monotonic()
+    proc = subprocess.Popen(  # noqa: S603
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+
+    sel = selectors.DefaultSelector()
+    sel.register(proc.stdout, selectors.EVENT_READ)
+    sel.register(proc.stderr, selectors.EVENT_READ)
+
+    buf = bytearray()
+    truncated = False
+    timed_out = False
+
+    def read_chunk(f) -> bytes:
+        try:
+            return f.read1(4096)  # type: ignore[attr-defined]
+        except Exception:
+            return f.read(4096)
+
+    try:
+        while sel.get_map():
+            if timeout_seconds and (time.monotonic() - start) > float(timeout_seconds):
+                timed_out = True
+                break
+
+            events = sel.select(timeout=0.1)
+            if not events:
+                if proc.poll() is not None:
+                    # Process ended; drain any remaining data quickly.
+                    for key in list(sel.get_map().values()):
+                        chunk = read_chunk(key.fileobj)
+                        if not chunk:
+                            try:
+                                sel.unregister(key.fileobj)
+                            except Exception:
+                                pass
+                            continue
+                        if max_bytes > 0 and len(buf) < max_bytes:
+                            remaining = max_bytes - len(buf)
+                            buf.extend(chunk[:remaining])
+                            if len(chunk) > remaining:
+                                truncated = True
+                        else:
+                            truncated = True
+                    continue
+                continue
+
+            for key, _mask in events:
+                chunk = read_chunk(key.fileobj)
+                if not chunk:
+                    try:
+                        sel.unregister(key.fileobj)
+                    except Exception:
+                        pass
+                    continue
+                if max_bytes > 0 and len(buf) < max_bytes:
+                    remaining = max_bytes - len(buf)
+                    buf.extend(chunk[:remaining])
+                    if len(chunk) > remaining:
+                        truncated = True
+                else:
+                    truncated = True
+    finally:
+        try:
+            sel.close()
+        except Exception:
+            pass
+
+    if timed_out:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        return -1, bytes(buf), True if max_bytes > 0 else False, True
+
+    exit_code = proc.wait()
+    return int(exit_code), bytes(buf), truncated, False
+
+
+class OpsService:
+    def __init__(self, *, store: SeedOpsStore, workspaces: WorkspaceManager):
+        self._store = store
+        self._workspaces = workspaces
+
+    def _pick_exec_backend(self, docker_client: Any) -> str:
+        """Pick an exec backend for ops_exec/routing checks.
+
+        - `SEEDOPS_EXEC_BACKEND=sdk|cli|auto` (default auto)
+        - In auto mode, prefer CLI when the docker client appears to be real and `docker` is available.
+        """
+        mode = (os.environ.get("SEEDOPS_EXEC_BACKEND") or "auto").strip().lower()
+        if mode == "sdk":
+            return "sdk"
+        if mode == "cli":
+            return "cli" if shutil.which("docker") else "sdk"
+
+        if shutil.which("docker") and getattr(docker_client, "__class__", type("x", (), {})).__module__.startswith("docker."):
+            return "cli"
+        return "sdk"
+
+    def _run_shell(
+        self,
+        *,
+        docker_client: Any,
+        backend: str,
+        container_name: str,
+        shell_script: str,
+        timeout_seconds: int,
+        max_output_chars: int,
+    ) -> dict[str, Any]:
+        max_bytes = _max_output_bytes(max_output_chars)
+        if backend == "cli":
+            exit_code, out_b, truncated_b, timed_out = _docker_exec_cli(
+                container_name,
+                shell_script=shell_script,
+                timeout_seconds=int(timeout_seconds),
+                max_bytes=max_bytes,
+            )
+        else:
+            timed_out = False
+            c = docker_client.containers.get(container_name)
+            exit_code, full_b = _exec_run(c, ["sh", "-lc", shell_script])
+            truncated_b = max_bytes > 0 and len(full_b) > max_bytes
+            out_b = full_b[:max_bytes] if truncated_b else full_b
+
+        out_s = out_b.decode("utf-8", errors="replace")
+        out_s = _truncate(out_s, int(max_output_chars), truncated=truncated_b)
+
+        return {
+            "exit_code": int(exit_code),
+            "output": out_s,
+            "output_truncated": bool(truncated_b),
+            "timed_out": bool(timed_out),
+        }
+
+    def exec(
+        self,
+        workspace_id: str,
+        *,
+        selector: dict[str, Any],
+        command: str,
+        timeout_seconds: int = 30,
+        parallelism: int = 20,
+        max_output_chars: int = 8000,
+    ) -> dict[str, Any]:
+        nodes = self._workspaces.list_nodes(workspace_id, selector=selector)
+        docker_client = self._workspaces.get_docker_client()
+        backend = self._pick_exec_backend(docker_client)
+
+        script = f"command -v timeout >/dev/null 2>&1 && timeout {int(timeout_seconds)}s {command} || {command}"
+
+        def worker(node: dict[str, Any]) -> dict[str, Any]:
+            node_id = node.get("node_id")
+            cname = node.get("container_name")
+            try:
+                run = self._run_shell(
+                    docker_client=docker_client,
+                    backend=backend,
+                    container_name=str(cname),
+                    shell_script=script,
+                    timeout_seconds=int(timeout_seconds),
+                    max_output_chars=int(max_output_chars),
+                )
+                exit_code = int(run["exit_code"])
+                out = str(run["output"])
+                timed_out = bool(run["timed_out"])
+                ok = exit_code == 0 and not timed_out
+                item: dict[str, Any] = {
+                    "node_id": node_id,
+                    "container_name": cname,
+                    "ok": ok,
+                    "exit_code": exit_code,
+                    "output": out,
+                }
+                if not ok:
+                    if timed_out:
+                        item["error"] = f"timeout after {int(timeout_seconds)}s"
+                    else:
+                        head = (out or "").strip().splitlines()[:1]
+                        item["error"] = head[0][:200] if head else f"exit_code {exit_code}"
+                return item
+            except Exception as e:
+                return {
+                    "node_id": node_id,
+                    "container_name": cname,
+                    "ok": False,
+                    "exit_code": -1,
+                    "error": str(e),
+                    "output": "",
+                }
+
+        results: list[dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=max(1, int(parallelism))) as pool:
+            futs = [pool.submit(worker, n) for n in nodes]
+            for fut in as_completed(futs):
+                results.append(fut.result())
+
+        results.sort(key=lambda r: str(r.get("node_id", "")))
+        ok = sum(1 for r in results if r.get("ok"))
+        fail = len(results) - ok
+        cmd_hash = hashlib.sha256(command.encode("utf-8")).hexdigest()[:12]
+
+        fail_reasons: dict[str, int] = {}
+        for r in results:
+            if r.get("ok"):
+                continue
+            reason = str(r.get("error") or f"exit_code {r.get('exit_code')}")
+            fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+
+        payload = {
+            "command": command,
+            "command_hash": cmd_hash,
+            "counts": {"total": len(results), "ok": ok, "fail": fail},
+            "results": results,
+            "backend": backend,
+            "fail_reasons": fail_reasons,
+        }
+
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="ops.exec",
+            message=f"Batch exec: {cmd_hash}",
+            data={
+                "command": command,
+                "command_hash": cmd_hash,
+                "counts": payload["counts"],
+                "backend": backend,
+                "fail_reasons": fail_reasons,
+            },
+        )
+        return payload
+
+    def logs(
+        self,
+        workspace_id: str,
+        *,
+        selector: dict[str, Any],
+        tail: int = 200,
+        since_seconds: int = 0,
+        parallelism: int = 20,
+        max_output_chars: int = 8000,
+    ) -> dict[str, Any]:
+        nodes = self._workspaces.list_nodes(workspace_id, selector=selector)
+        docker_client = self._workspaces.get_docker_client()
+
+        since = None
+        if since_seconds and int(since_seconds) > 0:
+            since = int(time.time()) - int(since_seconds)
+
+        def worker(node: dict[str, Any]) -> dict[str, Any]:
+            node_id = node.get("node_id")
+            cname = node.get("container_name")
+            try:
+                c = docker_client.containers.get(cname)
+                max_bytes = _max_output_bytes(int(max_output_chars))
+                try:
+                    stream = (
+                        c.logs(tail=int(tail), since=since, stream=True)
+                        if since is not None
+                        else c.logs(tail=int(tail), stream=True)
+                    )
+                    raw_b, truncated_b = _read_stream_limited(stream, max_bytes=max_bytes)
+                except TypeError:
+                    raw = c.logs(tail=int(tail), since=since) if since is not None else c.logs(tail=int(tail))
+                    raw_b = bytes(raw)
+                    truncated_b = max_bytes > 0 and len(raw_b) > max_bytes
+                    raw_b = raw_b[:max_bytes] if truncated_b else raw_b
+
+                out = raw_b.decode("utf-8", errors="replace")
+                out = _truncate(out, int(max_output_chars), truncated=truncated_b)
+                return {"node_id": node_id, "container_name": cname, "ok": True, "log": out}
+            except Exception as e:
+                return {"node_id": node_id, "container_name": cname, "ok": False, "error": str(e), "log": ""}
+
+        results: list[dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=max(1, int(parallelism))) as pool:
+            futs = [pool.submit(worker, n) for n in nodes]
+            for fut in as_completed(futs):
+                results.append(fut.result())
+
+        results.sort(key=lambda r: str(r.get("node_id", "")))
+        ok = sum(1 for r in results if r.get("ok"))
+        fail = len(results) - ok
+
+        fail_reasons: dict[str, int] = {}
+        for r in results:
+            if r.get("ok"):
+                continue
+            reason = str(r.get("error") or "error")
+            fail_reasons[reason] = fail_reasons.get(reason, 0) + 1
+
+        payload = {
+            "counts": {"total": len(results), "ok": ok, "fail": fail},
+            "logs": results,
+            "fail_reasons": fail_reasons,
+        }
+
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="ops.logs",
+            message="Batch logs",
+            data={
+                "counts": payload["counts"],
+                "tail": int(tail),
+                "since_seconds": int(since_seconds),
+                "fail_reasons": fail_reasons,
+            },
+        )
+        return payload
+
+    def bgp_summary(self, workspace_id: str, *, selector: dict[str, Any]) -> dict[str, Any]:
+        nodes = self._workspaces.list_nodes(workspace_id, selector=selector)
+        docker_client = self._workspaces.get_docker_client()
+        backend = self._pick_exec_backend(docker_client)
+
+        def parse_bird_protocols(output: str) -> dict[str, int]:
+            up = 0
+            down = 0
+            for line in output.splitlines():
+                parts = line.split()
+                if len(parts) < 4:
+                    continue
+                if parts[1].upper() != "BGP":
+                    continue
+                state = parts[3].lower()
+                if state == "up":
+                    up += 1
+                else:
+                    down += 1
+            return {"up": up, "down": down}
+
+        def worker(node: dict[str, Any]) -> dict[str, Any]:
+            node_id = node.get("node_id")
+            cname = node.get("container_name")
+            try:
+                run = self._run_shell(
+                    docker_client=docker_client,
+                    backend=backend,
+                    container_name=str(cname),
+                    shell_script="birdc show protocols",
+                    timeout_seconds=20,
+                    max_output_chars=8000,
+                )
+                exit_code = int(run["exit_code"])
+                out = str(run["output"])
+                if exit_code != 0 or run["timed_out"]:
+                    err = "timeout" if run["timed_out"] else (out.strip()[:200] or f"exit_code {exit_code}")
+                    return {"node_id": node_id, "container_name": cname, "ok": False, "error": err}
+                bgp = parse_bird_protocols(out)
+                return {
+                    "node_id": node_id,
+                    "container_name": cname,
+                    "ok": True,
+                    "bgp": bgp,
+                    "raw_head": out[:200],
+                }
+            except Exception as e:
+                return {"node_id": node_id, "container_name": cname, "ok": False, "error": str(e)}
+
+        results: list[dict[str, Any]] = []
+        with ThreadPoolExecutor(max_workers=max(1, int(min(50, max(1, len(nodes)))))) as pool:
+            futs = [pool.submit(worker, n) for n in nodes]
+            for fut in as_completed(futs):
+                results.append(fut.result())
+
+        results.sort(key=lambda r: str(r.get("node_id", "")))
+        nodes_ok = sum(1 for r in results if r.get("ok"))
+        nodes_error = len(results) - nodes_ok
+        bgp_up = 0
+        bgp_down = 0
+        for r in results:
+            if r.get("ok") and isinstance(r.get("bgp"), dict):
+                bgp_up += int(r["bgp"].get("up", 0))
+                bgp_down += int(r["bgp"].get("down", 0))
+
+        payload = {
+            "counts": {
+                "nodes": len(results),
+                "nodes_ok": nodes_ok,
+                "nodes_error": nodes_error,
+                "bgp_up": bgp_up,
+                "bgp_down": bgp_down,
+            },
+            "nodes": results,
+            "backend": backend,
+        }
+
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="routing.bgp_summary",
+            message="BGP summary",
+            data={**payload["counts"], "backend": backend},
+        )
+        return payload

--- a/mcp-server/seedops/playbooks.py
+++ b/mcp-server/seedops/playbooks.py
@@ -14,6 +14,10 @@ SUPPORTED_ACTIONS = {
     "ops_exec",
     "ops_logs",
     "routing_bgp_summary",
+    "ping",
+    "traceroute",
+    "inject_fault",
+    "capture_evidence",
     "sleep",
 }
 
@@ -35,6 +39,7 @@ class PlaybookStep:
 class Playbook:
     version: int
     name: str
+    vars: dict[str, Any]
     defaults: dict[str, Any]
     steps: list[PlaybookStep]
 
@@ -45,6 +50,7 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
     YAML schema (v1):
       version: 1
       name: <str>
+      vars: <optional dict>
       defaults:
         selector: {...}
         timeout_seconds: 30
@@ -54,7 +60,7 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
         retries: 0
         retry_delay_seconds: 1
       steps:
-        - action: workspace_refresh|inventory_list_nodes|ops_exec|ops_logs|routing_bgp_summary|sleep
+        - action: workspace_refresh|inventory_list_nodes|ops_exec|ops_logs|routing_bgp_summary|ping|traceroute|inject_fault|capture_evidence|sleep
           id: <optional str>
           save_as: <optional str>
           on_error: <optional stop|continue>
@@ -75,6 +81,11 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
         raise ValueError(f"Unsupported playbook version: {version_i} (supported: {SUPPORTED_PLAYBOOK_VERSION})")
 
     name = str(data.get("name") or "playbook").strip() or "playbook"
+
+    vars_raw = data.get("vars") or {}
+    if not isinstance(vars_raw, dict):
+        raise ValueError("playbook.vars must be a dict.")
+    vars_v: dict[str, Any] = vars_raw
 
     defaults = data.get("defaults") or {}
     if not isinstance(defaults, dict):
@@ -149,13 +160,33 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
         if action == "ops_exec":
             if "command" not in args:
                 raise ValueError(f"playbook.steps[{i}] ops_exec requires 'command'.")
-        if action in {"ops_exec", "ops_logs", "routing_bgp_summary", "inventory_list_nodes"}:
+        if action in {
+            "ops_exec",
+            "ops_logs",
+            "routing_bgp_summary",
+            "inventory_list_nodes",
+            "ping",
+            "traceroute",
+            "inject_fault",
+            "capture_evidence",
+        }:
             sel = args.get("selector")
             if sel is not None and not isinstance(sel, dict):
-                raise ValueError(f"playbook.steps[{i}] selector must be a dict.")
+                # Allow selector templating via full-template strings like "{{ vars.selector }}".
+                if not (isinstance(sel, str) and "{{" in sel and "}}" in sel):
+                    raise ValueError(f"playbook.steps[{i}] selector must be a dict (or a template string).")
         if action == "sleep":
             if "seconds" not in args:
                 raise ValueError(f"playbook.steps[{i}] sleep requires 'seconds'.")
+        if action in {"ping", "traceroute"}:
+            if "dst" not in args:
+                raise ValueError(f"playbook.steps[{i}] {action} requires 'dst'.")
+        if action == "inject_fault":
+            if "fault_type" not in args:
+                raise ValueError(f"playbook.steps[{i}] inject_fault requires 'fault_type'.")
+        if action == "capture_evidence":
+            if "evidence_type" not in args:
+                raise ValueError(f"playbook.steps[{i}] capture_evidence requires 'evidence_type'.")
 
         steps.append(
             PlaybookStep(
@@ -169,4 +200,4 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
             )
         )
 
-    return Playbook(version=version_i, name=name, defaults=defaults, steps=steps)
+    return Playbook(version=version_i, name=name, vars=vars_v, defaults=defaults, steps=steps)

--- a/mcp-server/seedops/playbooks.py
+++ b/mcp-server/seedops/playbooks.py
@@ -17,6 +17,8 @@ SUPPORTED_ACTIONS = {
     "sleep",
 }
 
+SUPPORTED_ON_ERROR = {"stop", "continue"}
+
 
 @dataclass(frozen=True)
 class PlaybookStep:
@@ -24,6 +26,9 @@ class PlaybookStep:
     step_id: str
     args: dict[str, Any]
     save_as: str | None
+    retries: int | None
+    retry_delay_seconds: float | None
+    on_error: str | None
 
 
 @dataclass(frozen=True)
@@ -40,11 +45,21 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
     YAML schema (v1):
       version: 1
       name: <str>
-      defaults: { selector: {...}, timeout_seconds: 30, parallelism: 20, max_output_chars: 8000, ... }
+      defaults:
+        selector: {...}
+        timeout_seconds: 30
+        parallelism: 20
+        max_output_chars: 8000
+        on_error: stop|continue
+        retries: 0
+        retry_delay_seconds: 1
       steps:
         - action: workspace_refresh|inventory_list_nodes|ops_exec|ops_logs|routing_bgp_summary|sleep
           id: <optional str>
           save_as: <optional str>
+          on_error: <optional stop|continue>
+          retries: <optional int>
+          retry_delay_seconds: <optional number>
           ... action-specific args ...
     """
     data = yaml.safe_load(playbook_yaml) or {}
@@ -64,6 +79,24 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
     defaults = data.get("defaults") or {}
     if not isinstance(defaults, dict):
         raise ValueError("playbook.defaults must be a dict.")
+    if "on_error" in defaults:
+        on_err = str(defaults.get("on_error") or "").strip()
+        if on_err not in SUPPORTED_ON_ERROR:
+            raise ValueError("playbook.defaults.on_error must be 'stop' or 'continue'.")
+    if "retries" in defaults:
+        try:
+            retries_i = int(defaults.get("retries"))
+        except Exception:
+            raise ValueError("playbook.defaults.retries must be an int.") from None
+        if retries_i < 0:
+            raise ValueError("playbook.defaults.retries must be >= 0.")
+    if "retry_delay_seconds" in defaults:
+        try:
+            delay_f = float(defaults.get("retry_delay_seconds"))
+        except Exception:
+            raise ValueError("playbook.defaults.retry_delay_seconds must be a number.") from None
+        if delay_f < 0:
+            raise ValueError("playbook.defaults.retry_delay_seconds must be >= 0.")
 
     steps_raw = data.get("steps")
     if not isinstance(steps_raw, list) or not steps_raw:
@@ -81,7 +114,36 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
         save_as = raw.get("save_as")
         save_as_s = str(save_as).strip() if save_as is not None and str(save_as).strip() else None
 
-        args = {k: v for k, v in raw.items() if k not in {"action", "id", "name", "save_as"}}
+        step_on_error = raw.get("on_error")
+        on_error_s = str(step_on_error).strip() if step_on_error is not None and str(step_on_error).strip() else None
+        if on_error_s is not None and on_error_s not in SUPPORTED_ON_ERROR:
+            raise ValueError(f"playbook.steps[{i}].on_error must be 'stop' or 'continue'.")
+
+        retries_raw = raw.get("retries")
+        retries_i: int | None = None
+        if retries_raw is not None:
+            try:
+                retries_i = int(retries_raw)
+            except Exception:
+                raise ValueError(f"playbook.steps[{i}].retries must be an int.") from None
+            if retries_i < 0:
+                raise ValueError(f"playbook.steps[{i}].retries must be >= 0.")
+
+        delay_raw = raw.get("retry_delay_seconds")
+        delay_f: float | None = None
+        if delay_raw is not None:
+            try:
+                delay_f = float(delay_raw)
+            except Exception:
+                raise ValueError(f"playbook.steps[{i}].retry_delay_seconds must be a number.") from None
+            if delay_f < 0:
+                raise ValueError(f"playbook.steps[{i}].retry_delay_seconds must be >= 0.")
+
+        args = {
+            k: v
+            for k, v in raw.items()
+            if k not in {"action", "id", "name", "save_as", "on_error", "retries", "retry_delay_seconds"}
+        }
 
         # Minimal per-action validation
         if action == "ops_exec":
@@ -95,7 +157,16 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
             if "seconds" not in args:
                 raise ValueError(f"playbook.steps[{i}] sleep requires 'seconds'.")
 
-        steps.append(PlaybookStep(action=action, step_id=step_id, args=args, save_as=save_as_s))
+        steps.append(
+            PlaybookStep(
+                action=action,
+                step_id=step_id,
+                args=args,
+                save_as=save_as_s,
+                retries=retries_i,
+                retry_delay_seconds=delay_f,
+                on_error=on_error_s,
+            )
+        )
 
     return Playbook(version=version_i, name=name, defaults=defaults, steps=steps)
-

--- a/mcp-server/seedops/playbooks.py
+++ b/mcp-server/seedops/playbooks.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+
+SUPPORTED_PLAYBOOK_VERSION = 1
+
+SUPPORTED_ACTIONS = {
+    "workspace_refresh",
+    "inventory_list_nodes",
+    "ops_exec",
+    "ops_logs",
+    "routing_bgp_summary",
+    "sleep",
+}
+
+
+@dataclass(frozen=True)
+class PlaybookStep:
+    action: str
+    step_id: str
+    args: dict[str, Any]
+    save_as: str | None
+
+
+@dataclass(frozen=True)
+class Playbook:
+    version: int
+    name: str
+    defaults: dict[str, Any]
+    steps: list[PlaybookStep]
+
+
+def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
+    """Parse and validate a YAML playbook.
+
+    YAML schema (v1):
+      version: 1
+      name: <str>
+      defaults: { selector: {...}, timeout_seconds: 30, parallelism: 20, max_output_chars: 8000, ... }
+      steps:
+        - action: workspace_refresh|inventory_list_nodes|ops_exec|ops_logs|routing_bgp_summary|sleep
+          id: <optional str>
+          save_as: <optional str>
+          ... action-specific args ...
+    """
+    data = yaml.safe_load(playbook_yaml) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Playbook YAML must be a mapping (dict).")
+
+    version = data.get("version", SUPPORTED_PLAYBOOK_VERSION)
+    try:
+        version_i = int(version)
+    except Exception:
+        raise ValueError("Playbook version must be an integer.") from None
+    if version_i != SUPPORTED_PLAYBOOK_VERSION:
+        raise ValueError(f"Unsupported playbook version: {version_i} (supported: {SUPPORTED_PLAYBOOK_VERSION})")
+
+    name = str(data.get("name") or "playbook").strip() or "playbook"
+
+    defaults = data.get("defaults") or {}
+    if not isinstance(defaults, dict):
+        raise ValueError("playbook.defaults must be a dict.")
+
+    steps_raw = data.get("steps")
+    if not isinstance(steps_raw, list) or not steps_raw:
+        raise ValueError("playbook.steps must be a non-empty list.")
+
+    steps: list[PlaybookStep] = []
+    for i, raw in enumerate(steps_raw, start=1):
+        if not isinstance(raw, dict):
+            raise ValueError(f"playbook.steps[{i}] must be a dict.")
+        action = str(raw.get("action") or "").strip()
+        if action not in SUPPORTED_ACTIONS:
+            raise ValueError(f"Unsupported action in playbook.steps[{i}]: {action!r}")
+
+        step_id = str(raw.get("id") or raw.get("name") or f"step{i}").strip() or f"step{i}"
+        save_as = raw.get("save_as")
+        save_as_s = str(save_as).strip() if save_as is not None and str(save_as).strip() else None
+
+        args = {k: v for k, v in raw.items() if k not in {"action", "id", "name", "save_as"}}
+
+        # Minimal per-action validation
+        if action == "ops_exec":
+            if "command" not in args:
+                raise ValueError(f"playbook.steps[{i}] ops_exec requires 'command'.")
+        if action in {"ops_exec", "ops_logs", "routing_bgp_summary", "inventory_list_nodes"}:
+            sel = args.get("selector")
+            if sel is not None and not isinstance(sel, dict):
+                raise ValueError(f"playbook.steps[{i}] selector must be a dict.")
+        if action == "sleep":
+            if "seconds" not in args:
+                raise ValueError(f"playbook.steps[{i}] sleep requires 'seconds'.")
+
+        steps.append(PlaybookStep(action=action, step_id=step_id, args=args, save_as=save_as_s))
+
+    return Playbook(version=version_i, name=name, defaults=defaults, steps=steps)
+

--- a/mcp-server/seedops/playbooks.py
+++ b/mcp-server/seedops/playbooks.py
@@ -18,6 +18,7 @@ SUPPORTED_ACTIONS = {
     "traceroute",
     "inject_fault",
     "capture_evidence",
+    "pcap_capture",
     "sleep",
 }
 
@@ -60,7 +61,7 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
         retries: 0
         retry_delay_seconds: 1
       steps:
-        - action: workspace_refresh|inventory_list_nodes|ops_exec|ops_logs|routing_bgp_summary|ping|traceroute|inject_fault|capture_evidence|sleep
+        - action: workspace_refresh|inventory_list_nodes|ops_exec|ops_logs|routing_bgp_summary|ping|traceroute|inject_fault|capture_evidence|pcap_capture|sleep
           id: <optional str>
           save_as: <optional str>
           on_error: <optional stop|continue>
@@ -169,6 +170,7 @@ def parse_playbook_yaml(playbook_yaml: str) -> Playbook:
             "traceroute",
             "inject_fault",
             "capture_evidence",
+            "pcap_capture",
         }:
             sel = args.get("selector")
             if sel is not None and not isinstance(sel, dict):

--- a/mcp-server/seedops/selectors.py
+++ b/mcp-server/seedops/selectors.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+SUPPORTED_SELECTOR_KEYS = {
+    "asn",
+    "role",
+    "node_name",
+    "class",
+    "network",
+    "container_name",
+    "labels",
+}
+
+
+def _as_list(val: Any) -> list[Any]:
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return val
+    return [val]
+
+
+def _as_int_list(val: Any) -> list[int]:
+    out: list[int] = []
+    for x in _as_list(val):
+        try:
+            out.append(int(x))
+        except Exception:
+            continue
+    return out
+
+
+def match_selector(node: dict[str, Any], selector: dict[str, Any]) -> bool:
+    """Match a node against a selector.
+
+    Semantics:
+      - AND across provided keys
+      - OR within list-valued fields
+      - labels is an AND across k/v
+    """
+    if not selector:
+        return True
+
+    unknown = set(selector.keys()) - SUPPORTED_SELECTOR_KEYS
+    if unknown:
+        raise ValueError(f"Unsupported selector keys: {sorted(unknown)}")
+
+    if "asn" in selector:
+        allowed_list = _as_int_list(selector["asn"])
+        if not allowed_list:
+            return False
+        allowed = set(allowed_list)
+        if int(node.get("asn", -1)) not in allowed:
+            return False
+
+    if "role" in selector:
+        allowed_list = [str(x) for x in _as_list(selector["role"]) if x is not None]
+        if not allowed_list:
+            return False
+        allowed = set(allowed_list)
+        if str(node.get("role", "")) not in allowed:
+            return False
+
+    if "node_name" in selector:
+        allowed_list = [str(x) for x in _as_list(selector["node_name"]) if x is not None]
+        if not allowed_list:
+            return False
+        allowed = set(allowed_list)
+        if str(node.get("node_name", "")) not in allowed:
+            return False
+
+    if "container_name" in selector:
+        allowed_list = [str(x) for x in _as_list(selector["container_name"]) if x is not None]
+        if not allowed_list:
+            return False
+        allowed = set(allowed_list)
+        if str(node.get("container_name", "")) not in allowed:
+            return False
+
+    if "class" in selector:
+        allowed_list = [str(x) for x in _as_list(selector["class"]) if x is not None]
+        if not allowed_list:
+            return False
+        allowed = set(allowed_list)
+        classes = set(node.get("classes") or [])
+        if not (classes & allowed):
+            return False
+
+    if "network" in selector:
+        allowed_list = [str(x) for x in _as_list(selector["network"]) if x is not None]
+        if not allowed_list:
+            return False
+        allowed = set(allowed_list)
+        ifaces = node.get("interfaces") or []
+        iface_nets = {str(i.get("name")) for i in ifaces if isinstance(i, dict)}
+        if not (iface_nets & allowed):
+            return False
+
+    if "labels" in selector:
+        req = selector["labels"]
+        if not isinstance(req, dict):
+            raise ValueError("selector.labels must be a dict")
+        labels = node.get("labels") or {}
+        for k, v in req.items():
+            if str(labels.get(k)) != str(v):
+                return False
+
+    return True
+
+
+def filter_nodes(nodes: list[dict[str, Any]], selector: dict[str, Any]) -> list[dict[str, Any]]:
+    if not selector:
+        return nodes
+    return [n for n in nodes if match_selector(n, selector)]

--- a/mcp-server/seedops/store.py
+++ b/mcp-server/seedops/store.py
@@ -1,0 +1,666 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+SCHEMA_VERSION = 3
+
+
+@dataclass(frozen=True)
+class WorkspaceRow:
+    workspace_id: str
+    name: str
+    attach_type: str
+    attach_config: dict[str, Any]
+    created_at: int
+    updated_at: int
+
+
+@dataclass(frozen=True)
+class EventRow:
+    event_id: int
+    workspace_id: str
+    ts: int
+    level: str
+    event_type: str
+    message: str
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class JobRow:
+    job_id: str
+    workspace_id: str
+    kind: str
+    name: str
+    status: str
+    created_at: int
+    started_at: int
+    finished_at: int
+    progress_current: int
+    progress_total: int
+    message: str
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class JobStepRow:
+    step_id: int
+    job_id: str
+    ts: int
+    level: str
+    step_index: int
+    step_name: str
+    event_type: str
+    message: str
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ArtifactRow:
+    artifact_id: str
+    job_id: str
+    workspace_id: str
+    name: str
+    kind: str
+    path: str
+    size_bytes: int
+    created_at: int
+
+
+@dataclass(frozen=True)
+class SnapshotRow:
+    snapshot_id: int
+    workspace_id: str
+    ts: int
+    snapshot_type: str
+    data: dict[str, Any]
+
+
+class SeedOpsStore:
+    """SQLite persistence for SeedOps (workspaces + events)."""
+
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        os.makedirs(os.path.dirname(os.path.abspath(db_path)), exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _init_db(self) -> None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute("PRAGMA journal_mode=WAL;")
+            cur.execute("PRAGMA foreign_keys=OFF;")
+
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER NOT NULL
+                )
+                """
+            )
+
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workspaces (
+                    workspace_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    attach_type TEXT NOT NULL,
+                    attach_config_json TEXT NOT NULL,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL
+                )
+                """
+            )
+
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    workspace_id TEXT NOT NULL,
+                    ts INTEGER NOT NULL,
+                    level TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    data_json TEXT NOT NULL
+                )
+                """
+            )
+            cur.execute("CREATE INDEX IF NOT EXISTS idx_events_ws_ts ON events(workspace_id, ts DESC)")
+
+            # schema version bootstrap
+            cur.execute("SELECT version FROM schema_version LIMIT 1")
+            row = cur.fetchone()
+            if row is None:
+                # New DB: start at version 0 and apply migrations to SCHEMA_VERSION.
+                cur.execute("INSERT INTO schema_version(version) VALUES (0)")
+                current_version = 0
+            else:
+                current_version = int(row["version"])
+
+            # Migrations
+            if current_version < 2:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS jobs (
+                        job_id TEXT PRIMARY KEY,
+                        workspace_id TEXT NOT NULL,
+                        kind TEXT NOT NULL,
+                        name TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        created_at INTEGER NOT NULL,
+                        started_at INTEGER NOT NULL,
+                        finished_at INTEGER NOT NULL,
+                        progress_current INTEGER NOT NULL,
+                        progress_total INTEGER NOT NULL,
+                        message TEXT NOT NULL,
+                        data_json TEXT NOT NULL
+                    )
+                    """
+                )
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_jobs_ws_created ON jobs(workspace_id, created_at DESC)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status, created_at DESC)")
+
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS job_steps (
+                        step_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        job_id TEXT NOT NULL,
+                        ts INTEGER NOT NULL,
+                        level TEXT NOT NULL,
+                        step_index INTEGER NOT NULL,
+                        step_name TEXT NOT NULL,
+                        event_type TEXT NOT NULL,
+                        message TEXT NOT NULL,
+                        data_json TEXT NOT NULL
+                    )
+                    """
+                )
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_job_steps_job_step ON job_steps(job_id, step_id DESC)")
+
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS artifacts (
+                        artifact_id TEXT PRIMARY KEY,
+                        job_id TEXT NOT NULL,
+                        workspace_id TEXT NOT NULL,
+                        name TEXT NOT NULL,
+                        kind TEXT NOT NULL,
+                        path TEXT NOT NULL,
+                        size_bytes INTEGER NOT NULL,
+                        created_at INTEGER NOT NULL
+                    )
+                    """
+                )
+                cur.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_job_name ON artifacts(job_id, name)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_artifacts_ws_created ON artifacts(workspace_id, created_at DESC)")
+
+                current_version = 2
+
+            if current_version < 3:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS snapshots (
+                        snapshot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        workspace_id TEXT NOT NULL,
+                        ts INTEGER NOT NULL,
+                        snapshot_type TEXT NOT NULL,
+                        data_json TEXT NOT NULL
+                    )
+                    """
+                )
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_snapshots_ws_ts ON snapshots(workspace_id, ts DESC)")
+                cur.execute("CREATE INDEX IF NOT EXISTS idx_snapshots_type_ts ON snapshots(snapshot_type, ts DESC)")
+                current_version = 3
+
+            # Persist schema version
+            cur.execute("UPDATE schema_version SET version = ?", (current_version,))
+
+            self._conn.commit()
+
+    def _row_to_workspace(self, row: sqlite3.Row) -> WorkspaceRow:
+        attach_config = json.loads(row["attach_config_json"]) if row["attach_config_json"] else {}
+        return WorkspaceRow(
+            workspace_id=row["workspace_id"],
+            name=row["name"],
+            attach_type=row["attach_type"],
+            attach_config=attach_config,
+            created_at=int(row["created_at"]),
+            updated_at=int(row["updated_at"]),
+        )
+
+    def _row_to_event(self, row: sqlite3.Row) -> EventRow:
+        data = json.loads(row["data_json"]) if row["data_json"] else {}
+        return EventRow(
+            event_id=int(row["event_id"]),
+            workspace_id=row["workspace_id"],
+            ts=int(row["ts"]),
+            level=row["level"],
+            event_type=row["event_type"],
+            message=row["message"],
+            data=data,
+        )
+
+    def _row_to_job(self, row: sqlite3.Row) -> JobRow:
+        data = json.loads(row["data_json"]) if row["data_json"] else {}
+        return JobRow(
+            job_id=row["job_id"],
+            workspace_id=row["workspace_id"],
+            kind=row["kind"],
+            name=row["name"],
+            status=row["status"],
+            created_at=int(row["created_at"]),
+            started_at=int(row["started_at"]),
+            finished_at=int(row["finished_at"]),
+            progress_current=int(row["progress_current"]),
+            progress_total=int(row["progress_total"]),
+            message=row["message"],
+            data=data,
+        )
+
+    def _row_to_job_step(self, row: sqlite3.Row) -> JobStepRow:
+        data = json.loads(row["data_json"]) if row["data_json"] else {}
+        return JobStepRow(
+            step_id=int(row["step_id"]),
+            job_id=row["job_id"],
+            ts=int(row["ts"]),
+            level=row["level"],
+            step_index=int(row["step_index"]),
+            step_name=row["step_name"],
+            event_type=row["event_type"],
+            message=row["message"],
+            data=data,
+        )
+
+    def _row_to_artifact(self, row: sqlite3.Row) -> ArtifactRow:
+        return ArtifactRow(
+            artifact_id=row["artifact_id"],
+            job_id=row["job_id"],
+            workspace_id=row["workspace_id"],
+            name=row["name"],
+            kind=row["kind"],
+            path=row["path"],
+            size_bytes=int(row["size_bytes"]),
+            created_at=int(row["created_at"]),
+        )
+
+    def _row_to_snapshot(self, row: sqlite3.Row) -> SnapshotRow:
+        data = json.loads(row["data_json"]) if row["data_json"] else {}
+        return SnapshotRow(
+            snapshot_id=int(row["snapshot_id"]),
+            workspace_id=row["workspace_id"],
+            ts=int(row["ts"]),
+            snapshot_type=row["snapshot_type"],
+            data=data,
+        )
+
+    def create_workspace(self, name: str) -> WorkspaceRow:
+        now = int(time.time())
+        workspace_id = str(uuid.uuid4())
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO workspaces(workspace_id, name, attach_type, attach_config_json, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (workspace_id, name, "compose", "{}", now, now),
+            )
+            self._conn.commit()
+        return WorkspaceRow(
+            workspace_id=workspace_id,
+            name=name,
+            attach_type="compose",
+            attach_config={},
+            created_at=now,
+            updated_at=now,
+        )
+
+    def list_workspaces(self) -> list[WorkspaceRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "SELECT workspace_id, name, attach_type, attach_config_json, created_at, updated_at FROM workspaces ORDER BY name"
+            )
+            rows = cur.fetchall()
+        return [self._row_to_workspace(r) for r in rows]
+
+    def get_workspace(self, workspace_id: str) -> WorkspaceRow | None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                "SELECT workspace_id, name, attach_type, attach_config_json, created_at, updated_at FROM workspaces WHERE workspace_id = ?",
+                (workspace_id,),
+            )
+            row = cur.fetchone()
+        return self._row_to_workspace(row) if row else None
+
+    def update_workspace_attach(self, workspace_id: str, attach_type: str, attach_config: dict[str, Any]) -> None:
+        now = int(time.time())
+        attach_config_json = json.dumps(attach_config, separators=(",", ":"), ensure_ascii=False)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE workspaces
+                   SET attach_type = ?, attach_config_json = ?, updated_at = ?
+                 WHERE workspace_id = ?
+                """,
+                (attach_type, attach_config_json, now, workspace_id),
+            )
+            self._conn.commit()
+
+    def insert_event(
+        self,
+        workspace_id: str,
+        *,
+        level: str,
+        event_type: str,
+        message: str,
+        data: dict[str, Any] | None = None,
+    ) -> int:
+        now = int(time.time())
+        payload = json.dumps(data or {}, separators=(",", ":"), ensure_ascii=False)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO events(workspace_id, ts, level, event_type, message, data_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (workspace_id, now, level, event_type, message, payload),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid)
+
+    def list_events(self, workspace_id: str, *, since_ts: int = 0, limit: int = 200) -> list[EventRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT event_id, workspace_id, ts, level, event_type, message, data_json
+                  FROM events
+                 WHERE workspace_id = ?
+                   AND ts >= ?
+                 ORDER BY ts DESC, event_id DESC
+                 LIMIT ?
+                """,
+                (workspace_id, int(since_ts), int(limit)),
+            )
+            rows = cur.fetchall()
+        return [self._row_to_event(r) for r in rows]
+
+    def create_job(
+        self,
+        workspace_id: str,
+        *,
+        kind: str,
+        name: str,
+        status: str = "queued",
+        message: str = "",
+        data: dict[str, Any] | None = None,
+        progress_total: int = 0,
+    ) -> JobRow:
+        now = int(time.time())
+        job_id = str(uuid.uuid4())
+        payload = json.dumps(data or {}, separators=(",", ":"), ensure_ascii=False)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO jobs(
+                    job_id, workspace_id, kind, name, status, created_at, started_at, finished_at,
+                    progress_current, progress_total, message, data_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    workspace_id,
+                    kind,
+                    name,
+                    status,
+                    now,
+                    0,
+                    0,
+                    0,
+                    int(progress_total),
+                    message,
+                    payload,
+                ),
+            )
+            self._conn.commit()
+        return JobRow(
+            job_id=job_id,
+            workspace_id=workspace_id,
+            kind=kind,
+            name=name,
+            status=status,
+            created_at=now,
+            started_at=0,
+            finished_at=0,
+            progress_current=0,
+            progress_total=int(progress_total),
+            message=message,
+            data=data or {},
+        )
+
+    def get_job(self, job_id: str) -> JobRow | None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute("SELECT * FROM jobs WHERE job_id = ?", (job_id,))
+            row = cur.fetchone()
+        return self._row_to_job(row) if row else None
+
+    def list_jobs(self, workspace_id: str, *, status: str | None = None, limit: int = 50) -> list[JobRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            if status:
+                cur.execute(
+                    "SELECT * FROM jobs WHERE workspace_id = ? AND status = ? ORDER BY created_at DESC LIMIT ?",
+                    (workspace_id, status, int(limit)),
+                )
+            else:
+                cur.execute(
+                    "SELECT * FROM jobs WHERE workspace_id = ? ORDER BY created_at DESC LIMIT ?",
+                    (workspace_id, int(limit)),
+                )
+            rows = cur.fetchall()
+        return [self._row_to_job(r) for r in rows]
+
+    def update_job(
+        self,
+        job_id: str,
+        *,
+        status: str | None = None,
+        message: str | None = None,
+        progress_current: int | None = None,
+        progress_total: int | None = None,
+        started_at: int | None = None,
+        finished_at: int | None = None,
+    ) -> None:
+        fields: list[str] = []
+        args: list[Any] = []
+        if status is not None:
+            fields.append("status = ?")
+            args.append(status)
+        if message is not None:
+            fields.append("message = ?")
+            args.append(message)
+        if progress_current is not None:
+            fields.append("progress_current = ?")
+            args.append(int(progress_current))
+        if progress_total is not None:
+            fields.append("progress_total = ?")
+            args.append(int(progress_total))
+        if started_at is not None:
+            fields.append("started_at = ?")
+            args.append(int(started_at))
+        if finished_at is not None:
+            fields.append("finished_at = ?")
+            args.append(int(finished_at))
+        if not fields:
+            return
+        args.append(job_id)
+        sql = "UPDATE jobs SET " + ", ".join(fields) + " WHERE job_id = ?"
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(sql, tuple(args))
+            self._conn.commit()
+
+    def mark_running_jobs_interrupted(self) -> int:
+        """Mark any jobs left in 'running' as 'interrupted' (e.g. after server restart)."""
+        now = int(time.time())
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                UPDATE jobs
+                   SET status = ?, finished_at = ?, message = ?
+                 WHERE status = ?
+                """,
+                ("interrupted", now, "server restarted", "running"),
+            )
+            self._conn.commit()
+            return int(cur.rowcount or 0)
+
+    def insert_job_step(
+        self,
+        job_id: str,
+        *,
+        level: str,
+        step_index: int,
+        step_name: str,
+        event_type: str,
+        message: str,
+        data: dict[str, Any] | None = None,
+    ) -> int:
+        now = int(time.time())
+        payload = json.dumps(data or {}, separators=(",", ":"), ensure_ascii=False)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO job_steps(job_id, ts, level, step_index, step_name, event_type, message, data_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (job_id, now, level, int(step_index), step_name, event_type, message, payload),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid)
+
+    def list_job_steps(self, job_id: str, *, since_step_id: int = 0, limit: int = 200) -> list[JobStepRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                SELECT * FROM job_steps
+                 WHERE job_id = ?
+                   AND step_id > ?
+                 ORDER BY step_id ASC
+                 LIMIT ?
+                """,
+                (job_id, int(since_step_id), int(limit)),
+            )
+            rows = cur.fetchall()
+        return [self._row_to_job_step(r) for r in rows]
+
+    def insert_artifact(
+        self,
+        *,
+        artifact_id: str,
+        job_id: str,
+        workspace_id: str,
+        name: str,
+        kind: str,
+        path: str,
+        size_bytes: int,
+    ) -> None:
+        now = int(time.time())
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO artifacts(artifact_id, job_id, workspace_id, name, kind, path, size_bytes, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (artifact_id, job_id, workspace_id, name, kind, path, int(size_bytes), now),
+            )
+            self._conn.commit()
+
+    def list_artifacts(self, job_id: str, *, limit: int = 200) -> list[ArtifactRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute("SELECT * FROM artifacts WHERE job_id = ? ORDER BY created_at DESC LIMIT ?", (job_id, int(limit)))
+            rows = cur.fetchall()
+        return [self._row_to_artifact(r) for r in rows]
+
+    def get_artifact(self, artifact_id: str) -> ArtifactRow | None:
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute("SELECT * FROM artifacts WHERE artifact_id = ?", (artifact_id,))
+            row = cur.fetchone()
+        return self._row_to_artifact(row) if row else None
+
+    def insert_snapshot(self, workspace_id: str, *, snapshot_type: str, data: dict[str, Any] | None = None) -> int:
+        now = int(time.time())
+        payload = json.dumps(data or {}, separators=(",", ":"), ensure_ascii=False)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO snapshots(workspace_id, ts, snapshot_type, data_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (workspace_id, now, snapshot_type, payload),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid)
+
+    def list_snapshots(
+        self,
+        workspace_id: str,
+        *,
+        snapshot_type: str | None = None,
+        since_ts: int = 0,
+        limit: int = 200,
+    ) -> list[SnapshotRow]:
+        with self._lock:
+            cur = self._conn.cursor()
+            if snapshot_type:
+                cur.execute(
+                    """
+                    SELECT * FROM snapshots
+                     WHERE workspace_id = ?
+                       AND snapshot_type = ?
+                       AND ts >= ?
+                     ORDER BY ts DESC, snapshot_id DESC
+                     LIMIT ?
+                    """,
+                    (workspace_id, snapshot_type, int(since_ts), int(limit)),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT * FROM snapshots
+                     WHERE workspace_id = ?
+                       AND ts >= ?
+                     ORDER BY ts DESC, snapshot_id DESC
+                     LIMIT ?
+                    """,
+                    (workspace_id, int(since_ts), int(limit)),
+                )
+            rows = cur.fetchall()
+        return [self._row_to_snapshot(r) for r in rows]

--- a/mcp-server/seedops/store.py
+++ b/mcp-server/seedops/store.py
@@ -664,3 +664,125 @@ class SeedOpsStore:
                 )
             rows = cur.fetchall()
         return [self._row_to_snapshot(r) for r in rows]
+
+    def prune_events(self, workspace_id: str, *, keep_last: int = 5000) -> int:
+        keep = int(keep_last)
+        with self._lock:
+            cur = self._conn.cursor()
+            if keep <= 0:
+                cur.execute("DELETE FROM events WHERE workspace_id = ?", (workspace_id,))
+                self._conn.commit()
+                return int(cur.rowcount or 0)
+
+            cur.execute(
+                """
+                DELETE FROM events
+                 WHERE workspace_id = ?
+                   AND event_id NOT IN (
+                        SELECT event_id
+                          FROM events
+                         WHERE workspace_id = ?
+                         ORDER BY ts DESC, event_id DESC
+                         LIMIT ?
+                   )
+                """,
+                (workspace_id, workspace_id, keep),
+            )
+            self._conn.commit()
+            return int(cur.rowcount or 0)
+
+    def prune_snapshots(self, workspace_id: str, *, snapshot_type: str | None = None, keep_last: int = 5000) -> int:
+        keep = int(keep_last)
+        with self._lock:
+            cur = self._conn.cursor()
+            if keep <= 0:
+                if snapshot_type:
+                    cur.execute("DELETE FROM snapshots WHERE workspace_id = ? AND snapshot_type = ?", (workspace_id, snapshot_type))
+                else:
+                    cur.execute("DELETE FROM snapshots WHERE workspace_id = ?", (workspace_id,))
+                self._conn.commit()
+                return int(cur.rowcount or 0)
+
+            if snapshot_type:
+                cur.execute(
+                    """
+                    DELETE FROM snapshots
+                     WHERE workspace_id = ?
+                       AND snapshot_type = ?
+                       AND snapshot_id NOT IN (
+                            SELECT snapshot_id
+                              FROM snapshots
+                             WHERE workspace_id = ?
+                               AND snapshot_type = ?
+                             ORDER BY ts DESC, snapshot_id DESC
+                             LIMIT ?
+                       )
+                    """,
+                    (workspace_id, snapshot_type, workspace_id, snapshot_type, keep),
+                )
+            else:
+                cur.execute(
+                    """
+                    DELETE FROM snapshots
+                     WHERE workspace_id = ?
+                       AND snapshot_id NOT IN (
+                            SELECT snapshot_id
+                              FROM snapshots
+                             WHERE workspace_id = ?
+                             ORDER BY ts DESC, snapshot_id DESC
+                             LIMIT ?
+                       )
+                    """,
+                    (workspace_id, workspace_id, keep),
+                )
+            self._conn.commit()
+            return int(cur.rowcount or 0)
+
+    def list_terminal_job_ids_to_prune(self, workspace_id: str, *, keep_last: int = 200) -> list[str]:
+        keep = int(keep_last)
+        terminal = ("succeeded", "failed", "canceled", "interrupted", "succeeded_with_errors")
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(
+                f"""
+                SELECT job_id
+                  FROM jobs
+                 WHERE workspace_id = ?
+                   AND status IN ({",".join("?" for _ in terminal)})
+                 ORDER BY created_at DESC, job_id DESC
+                """,
+                (workspace_id, *terminal),
+            )
+            job_ids = [str(r["job_id"]) for r in cur.fetchall()]
+        if keep <= 0:
+            return job_ids
+        return job_ids[keep:]
+
+    def list_artifacts_for_job_ids(self, job_ids: list[str]) -> list[ArtifactRow]:
+        if not job_ids:
+            return []
+        placeholders = ",".join("?" for _ in job_ids)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(f"SELECT * FROM artifacts WHERE job_id IN ({placeholders})", tuple(job_ids))
+            rows = cur.fetchall()
+        return [self._row_to_artifact(r) for r in rows]
+
+    def delete_jobs_and_related(self, job_ids: list[str]) -> dict[str, int]:
+        if not job_ids:
+            return {"jobs_deleted": 0, "job_steps_deleted": 0, "artifacts_deleted": 0}
+        placeholders = ",".join("?" for _ in job_ids)
+        with self._lock:
+            cur = self._conn.cursor()
+            cur.execute(f"DELETE FROM job_steps WHERE job_id IN ({placeholders})", tuple(job_ids))
+            steps_deleted = int(cur.rowcount or 0)
+            cur.execute(f"DELETE FROM artifacts WHERE job_id IN ({placeholders})", tuple(job_ids))
+            artifacts_deleted = int(cur.rowcount or 0)
+            cur.execute(f"DELETE FROM jobs WHERE job_id IN ({placeholders})", tuple(job_ids))
+            jobs_deleted = int(cur.rowcount or 0)
+            self._conn.commit()
+        return {
+            "jobs_deleted": jobs_deleted,
+            "job_steps_deleted": steps_deleted,
+            "artifacts_deleted": artifacts_deleted,
+        }

--- a/mcp-server/seedops/template.py
+++ b/mcp-server/seedops/template.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+
+_TEMPLATE_RE = re.compile(r"{{\s*(.+?)\s*}}")
+_FULL_TEMPLATE_RE = re.compile(r"^\s*{{\s*(.+?)\s*}}\s*$")
+
+
+class TemplateError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class _Token:
+    kind: str  # "key" | "index"
+    value: str | int
+
+
+def _parse_path(expr: str) -> list[_Token]:
+    s = expr.strip()
+    if not s:
+        raise TemplateError("Empty template expression.")
+
+    i = 0
+    out: list[_Token] = []
+
+    def skip_ws() -> None:
+        nonlocal i
+        while i < len(s) and s[i].isspace():
+            i += 1
+
+    def parse_identifier() -> str:
+        nonlocal i
+        if i >= len(s) or not (s[i].isalpha() or s[i] == "_"):
+            raise TemplateError(f"Expected identifier at: {s[i:]!r}")
+        start = i
+        i += 1
+        while i < len(s) and (s[i].isalnum() or s[i] in {"_", "-"}):
+            i += 1
+        return s[start:i]
+
+    def parse_quoted_string() -> str:
+        nonlocal i
+        q = s[i]
+        i += 1
+        buf: list[str] = []
+        while i < len(s):
+            ch = s[i]
+            i += 1
+            if ch == q:
+                return "".join(buf)
+            if ch == "\\" and i < len(s):
+                esc = s[i]
+                i += 1
+                if esc in {q, "\\", "/"}:
+                    buf.append(esc)
+                elif esc == "n":
+                    buf.append("\n")
+                elif esc == "r":
+                    buf.append("\r")
+                elif esc == "t":
+                    buf.append("\t")
+                else:
+                    buf.append(esc)
+            else:
+                buf.append(ch)
+        raise TemplateError("Unterminated string in template expression.")
+
+    def parse_bracket_token() -> _Token:
+        nonlocal i
+        if s[i] != "[":
+            raise TemplateError("Expected '['")
+        i += 1
+        skip_ws()
+        if i >= len(s):
+            raise TemplateError("Unterminated '[' in template expression.")
+        if s[i] in {"'", '"'}:
+            key = parse_quoted_string()
+            skip_ws()
+            if i >= len(s) or s[i] != "]":
+                raise TemplateError("Expected ']' after string key in template expression.")
+            i += 1
+            return _Token(kind="key", value=key)
+
+        # index
+        start = i
+        while i < len(s) and s[i].isdigit():
+            i += 1
+        if start == i:
+            raise TemplateError("Expected integer index or quoted key in brackets.")
+        idx = int(s[start:i])
+        skip_ws()
+        if i >= len(s) or s[i] != "]":
+            raise TemplateError("Expected ']' after index in template expression.")
+        i += 1
+        return _Token(kind="index", value=idx)
+
+    skip_ws()
+    if i < len(s) and s[i] == "[":
+        out.append(parse_bracket_token())
+    else:
+        out.append(_Token(kind="key", value=parse_identifier()))
+
+    while True:
+        skip_ws()
+        if i >= len(s):
+            break
+        if s[i] == ".":
+            i += 1
+            skip_ws()
+            if i < len(s) and s[i] == "[":
+                out.append(parse_bracket_token())
+            else:
+                out.append(_Token(kind="key", value=parse_identifier()))
+            continue
+        if s[i] == "[":
+            out.append(parse_bracket_token())
+            continue
+        raise TemplateError(f"Unexpected character in template expression: {s[i]!r}")
+
+    return out
+
+
+def _eval_path(expr: str, context: dict[str, Any]) -> Any:
+    cur: Any = context
+    for tok in _parse_path(expr):
+        if tok.kind == "key":
+            key = str(tok.value)
+            if isinstance(cur, dict) and key in cur:
+                cur = cur[key]
+            else:
+                raise TemplateError(f"Missing key {key!r} while evaluating: {expr!r}")
+        else:
+            idx = int(tok.value)  # type: ignore[arg-type]
+            if isinstance(cur, list) and 0 <= idx < len(cur):
+                cur = cur[idx]
+            else:
+                raise TemplateError(f"Invalid index {idx} while evaluating: {expr!r}")
+    return cur
+
+
+def _stringify(val: Any) -> str:
+    if val is None:
+        return ""
+    if isinstance(val, (str, int, float, bool)):
+        return str(val)
+    return json.dumps(val, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def render_value(value: Any, context: dict[str, Any]) -> Any:
+    """Render templates in a value.
+
+    - If a string is exactly `{{ expr }}`, returns the evaluated object (type-preserving).
+    - Otherwise, performs string interpolation using `str(...)` / JSON.
+    """
+    if isinstance(value, dict):
+        return {k: render_value(v, context) for k, v in value.items()}
+    if isinstance(value, list):
+        return [render_value(v, context) for v in value]
+    if not isinstance(value, str):
+        return value
+
+    full = _FULL_TEMPLATE_RE.match(value)
+    if full:
+        expr = full.group(1)
+        return _eval_path(expr, context)
+
+    def repl(m: re.Match[str]) -> str:
+        expr = m.group(1)
+        return _stringify(_eval_path(expr, context))
+
+    if "{{" not in value:
+        return value
+    return _TEMPLATE_RE.sub(repl, value)
+

--- a/mcp-server/seedops/workspaces.py
+++ b/mcp-server/seedops/workspaces.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+from .inventory import DEFAULT_LABEL_PREFIX, Inventory, InventoryBuilder
+from .selectors import filter_nodes
+from .store import EventRow, SeedOpsStore, WorkspaceRow
+
+
+def extract_container_names_from_compose(output_dir: str) -> list[str]:
+    compose_path = os.path.join(output_dir, "docker-compose.yml")
+    with open(compose_path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    services = data.get("services") or {}
+    if not isinstance(services, dict):
+        return []
+    names: list[str] = []
+    for svc in services.values():
+        if not isinstance(svc, dict):
+            continue
+        cname = svc.get("container_name")
+        if cname:
+            names.append(str(cname))
+    # stable order
+    names.sort()
+    return names
+
+
+@dataclass(frozen=True)
+class Workspace:
+    workspace_id: str
+    name: str
+    attach_type: str
+    attach_config: dict[str, Any]
+    created_at: int
+    updated_at: int
+
+
+class WorkspaceManager:
+    def __init__(self, *, store: SeedOpsStore, docker_client: Any | None = None):
+        self._store = store
+        self._docker_client = docker_client
+        self._builder = InventoryBuilder()
+        self._cache: dict[str, Inventory] = {}
+
+    def get_docker_client(self):
+        if self._docker_client is None:
+            import docker
+
+            self._docker_client = docker.from_env()
+        return self._docker_client
+
+    def _to_ws(self, row: WorkspaceRow) -> Workspace:
+        return Workspace(
+            workspace_id=row.workspace_id,
+            name=row.name,
+            attach_type=row.attach_type,
+            attach_config=row.attach_config,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+    def create(self, name: str) -> Workspace:
+        row = self._store.create_workspace(name)
+        self._store.insert_event(
+            row.workspace_id,
+            level="info",
+            event_type="workspace.created",
+            message=f"Workspace created: {name}",
+            data={"name": name},
+        )
+        return self._to_ws(row)
+
+    def list(self) -> list[Workspace]:
+        return [self._to_ws(r) for r in self._store.list_workspaces()]
+
+    def get(self, workspace_id: str) -> Workspace | None:
+        row = self._store.get_workspace(workspace_id)
+        return self._to_ws(row) if row else None
+
+    def attach_compose(self, workspace_id: str, output_dir: str) -> dict[str, Any]:
+        ws = self._store.get_workspace(workspace_id)
+        if not ws:
+            raise ValueError("Workspace not found")
+
+        output_dir_abs = os.path.abspath(output_dir)
+        container_names = extract_container_names_from_compose(output_dir_abs)
+
+        attach_config = {
+            "output_dir": output_dir_abs,
+            "container_names": container_names,
+            "label_prefix": DEFAULT_LABEL_PREFIX,
+        }
+        self._store.update_workspace_attach(workspace_id, "compose", attach_config)
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="workspace.attached",
+            message=f"Attached workspace to compose output: {output_dir_abs}",
+            data={"attach_type": "compose", "output_dir": output_dir_abs, "container_count": len(container_names)},
+        )
+        return self.refresh(workspace_id)
+
+    def attach_labels(self, workspace_id: str, *, name_regex: str, label_prefix: str = DEFAULT_LABEL_PREFIX) -> dict[str, Any]:
+        ws = self._store.get_workspace(workspace_id)
+        if not ws:
+            raise ValueError("Workspace not found")
+
+        attach_config = {
+            "name_regex": name_regex,
+            "label_prefix": label_prefix,
+        }
+        self._store.update_workspace_attach(workspace_id, "labels", attach_config)
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="workspace.attached",
+            message=f"Attached workspace via labels scan: {name_regex}",
+            data={"attach_type": "labels", "name_regex": name_regex, "label_prefix": label_prefix},
+        )
+        return self.refresh(workspace_id)
+
+    def refresh(self, workspace_id: str) -> dict[str, Any]:
+        ws_row = self._store.get_workspace(workspace_id)
+        if not ws_row:
+            raise ValueError("Workspace not found")
+
+        attach_type = ws_row.attach_type
+        attach_config = ws_row.attach_config or {}
+        label_prefix = attach_config.get("label_prefix") or DEFAULT_LABEL_PREFIX
+
+        docker_client = self.get_docker_client()
+        containers: list[Any] = []
+        containers_seen = 0
+        missing_containers = 0
+
+        if attach_type == "compose":
+            names = attach_config.get("container_names") or []
+            if not isinstance(names, list) or not names:
+                raise ValueError("Workspace is not attached (missing container_names). Call workspace_attach_compose first.")
+            containers_seen = len(names)
+            for cname in names:
+                try:
+                    c = docker_client.containers.get(str(cname))
+                    containers.append(c)
+                except Exception:
+                    missing_containers += 1
+
+        elif attach_type == "labels":
+            name_regex = attach_config.get("name_regex")
+            if not name_regex:
+                raise ValueError("Workspace is not attached (missing name_regex). Call workspace_attach_labels first.")
+            rx = re.compile(str(name_regex))
+            all_containers = docker_client.containers.list()
+            for c in all_containers:
+                if not rx.search(getattr(c, "name", "")):
+                    continue
+                labels = getattr(c, "labels", {}) or {}
+                if not isinstance(labels, dict):
+                    continue
+                # Filter quickly by label prefix presence
+                if not any(k.startswith(label_prefix) for k in labels.keys()):
+                    continue
+                containers.append(c)
+            containers_seen = len(containers)
+
+        else:
+            raise ValueError(f"Unknown attach_type: {attach_type}")
+
+        inv = self._builder.build(containers, label_prefix=label_prefix)
+        self._cache[workspace_id] = inv
+
+        # Summary
+        roles: dict[str, int] = {}
+        asn_set: set[int] = set()
+        for n in inv.nodes:
+            roles[str(n.get("role", "unknown"))] = roles.get(str(n.get("role", "unknown")), 0) + 1
+            asn_set.add(int(n.get("asn", -1)))
+
+        sample_nodes = [{"node_id": n["node_id"], "container_name": n["container_name"]} for n in inv.nodes[:10]]
+        summary = {
+            "workspace_id": workspace_id,
+            "counts": {
+                "containers_seen": containers_seen,
+                "nodes_parsed": len(inv.nodes),
+                "missing_containers": missing_containers,
+            },
+            "roles": roles,
+            "asns": sorted([a for a in asn_set if a >= 0]),
+            "sample_nodes": sample_nodes,
+        }
+
+        self._store.insert_event(
+            workspace_id,
+            level="info",
+            event_type="inventory.refreshed",
+            message="Inventory refreshed",
+            data=summary,
+        )
+
+        return summary
+
+    def _ensure_inventory(self, workspace_id: str) -> Inventory:
+        if workspace_id not in self._cache:
+            self.refresh(workspace_id)
+        inv = self._cache.get(workspace_id)
+        if inv is None:
+            raise ValueError("Inventory not available")
+        return inv
+
+    def list_nodes(self, workspace_id: str, *, selector: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        inv = self._ensure_inventory(workspace_id)
+        nodes = inv.nodes
+        if selector:
+            nodes = filter_nodes(nodes, selector)
+        nodes = sorted(nodes, key=lambda n: n.get("node_id", ""))
+        return nodes
+
+    def get_node(self, workspace_id: str, node_id: str) -> dict[str, Any] | None:
+        inv = self._ensure_inventory(workspace_id)
+        return inv.by_node_id.get(node_id)
+
+    def list_events(self, workspace_id: str, *, since_ts: int = 0, limit: int = 200) -> list[EventRow]:
+        return self._store.list_events(workspace_id, since_ts=since_ts, limit=limit)
+

--- a/mcp-server/seedops/workspaces.py
+++ b/mcp-server/seedops/workspaces.py
@@ -14,19 +14,47 @@ from .store import EventRow, SeedOpsStore, WorkspaceRow
 
 
 def extract_container_names_from_compose(output_dir: str) -> list[str]:
-    compose_path = os.path.join(output_dir, "docker-compose.yml")
-    with open(compose_path, "r") as f:
-        data = yaml.safe_load(f) or {}
+    output_dir_s = str(output_dir or "").strip()
+    if not output_dir_s:
+        raise ValueError("output_dir is required.")
+    output_dir_abs = os.path.abspath(output_dir_s)
+    if not os.path.isdir(output_dir_abs):
+        raise ValueError(f"output_dir not found or not a directory: {output_dir_abs}")
+
+    compose_path = os.path.join(output_dir_abs, "docker-compose.yml")
+    if not os.path.exists(compose_path):
+        raise ValueError(f"docker-compose.yml not found at: {compose_path}")
+
+    try:
+        with open(compose_path, "r") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as e:
+        raise ValueError(f"Failed to parse docker-compose.yml: {e}") from e
+
     services = data.get("services") or {}
     if not isinstance(services, dict):
-        return []
+        raise ValueError("docker-compose.yml: 'services' must be a mapping (dict).")
+
+    total_services = 0
+    with_container_name = 0
     names: list[str] = []
     for svc in services.values():
+        total_services += 1
         if not isinstance(svc, dict):
             continue
         cname = svc.get("container_name")
         if cname:
+            with_container_name += 1
             names.append(str(cname))
+
+    if not names:
+        raise ValueError(
+            "No services.*.container_name found in docker-compose.yml "
+            f"(services={total_services}, with_container_name={with_container_name}). "
+            "SeedOps attach_compose requires container_name. "
+            "Recompile with container_name or use workspace_attach_labels."
+        )
+
     # stable order
     names.sort()
     return names
@@ -89,8 +117,9 @@ class WorkspaceManager:
         if not ws:
             raise ValueError("Workspace not found")
 
-        output_dir_abs = os.path.abspath(output_dir)
-        container_names = extract_container_names_from_compose(output_dir_abs)
+        output_dir_s = str(output_dir or "").strip()
+        container_names = extract_container_names_from_compose(output_dir_s)
+        output_dir_abs = os.path.abspath(output_dir_s)
 
         attach_config = {
             "output_dir": output_dir_abs,
@@ -111,6 +140,12 @@ class WorkspaceManager:
         ws = self._store.get_workspace(workspace_id)
         if not ws:
             raise ValueError("Workspace not found")
+
+        # Validate regex at attach time for fast feedback.
+        try:
+            re.compile(str(name_regex))
+        except re.error as e:
+            raise ValueError(f"Invalid name_regex: {e}") from e
 
         attach_config = {
             "name_regex": name_regex,
@@ -228,4 +263,3 @@ class WorkspaceManager:
 
     def list_events(self, workspace_id: str, *, since_ts: int = 0, limit: int = 200) -> list[EventRow]:
         return self._store.list_events(workspace_id, since_ts=since_ts, limit=limit)
-

--- a/mcp-server/serve_http.py
+++ b/mcp-server/serve_http.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Seed Emulator MCP Server (HTTP, streamable-http) with Bearer token auth.
+
+Phase 1: dynamic operational control plane (workspace/inventory/batch ops).
+
+Usage:
+  export SEED_MCP_TOKEN=...
+  export FASTMCP_HOST=0.0.0.0
+  export FASTMCP_PORT=8000
+  export FASTMCP_STREAMABLE_HTTP_PATH=/mcp
+  export SEED_MCP_PUBLIC_URL=http://127.0.0.1:8000
+  python serve_http.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from seedops.config import load_config
+
+
+def main() -> None:
+    cfg = load_config(require_token=True)
+
+    # Signal server.py to construct FastMCP with Streamable-HTTP auth settings.
+    os.environ["SEED_MCP_HTTP"] = "1"
+
+    # Import the existing server module (tools + runtime). Its FastMCP instance
+    # will be constructed using the environment variables above.
+    import server as seed_server  # type: ignore  # noqa: WPS433
+
+    print(
+        f"[serve_http] Starting MCP server on http://{cfg.host}:{cfg.port}{cfg.streamable_http_path} "
+        f"(public_url={cfg.public_url})"
+    )
+    seed_server.mcp.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"[serve_http] Fatal: {e}", file=sys.stderr)
+        raise

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -13,7 +13,50 @@ from seedemu.services import WebService, DomainNameService, BotnetService, Botne
 
 from runtime import runtime
 
-mcp = FastMCP("seed-emulator-mcp")
+
+def _create_mcp() -> FastMCP:
+    # When launched via serve_http.py, enable Streamable-HTTP auth settings at construction time.
+    # This avoids mutating private FastMCP internals after import.
+    if (os.environ.get("SEED_MCP_HTTP") or "").strip() == "1":
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        from seedops.auth import StaticTokenVerifier, build_auth_settings
+        from seedops.config import load_config
+
+        cfg = load_config(require_token=True)
+        auth = build_auth_settings(cfg.public_url)
+        verifier = StaticTokenVerifier(cfg.token or "")
+        transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=cfg.dns_rebinding_protection,
+            allowed_hosts=cfg.allowed_hosts,
+            allowed_origins=cfg.allowed_origins,
+        )
+
+        return FastMCP(
+            "seed-emulator-mcp",
+            host=cfg.host,
+            port=cfg.port,
+            streamable_http_path=cfg.streamable_http_path,
+            auth=auth,
+            token_verifier=verifier,
+            transport_security=transport_security,
+        )
+
+    return FastMCP("seed-emulator-mcp")
+
+
+mcp = _create_mcp()
+
+# Register SeedOps (Phase 1) operational tools (workspace/inventory/batch ops).
+# This keeps existing tools intact and adds new ones for attaching to and operating
+# on already-running simulations.
+try:
+    from seedops import register_tools as _register_seedops_tools
+
+    _register_seedops_tools(mcp)
+except Exception as _e:
+    # Keep server importable even if SeedOps dependencies are missing in a minimal env.
+    pass
 
 # ==============================================================================
 # Infrastructure Tools (Base Layer)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -56,7 +56,7 @@ try:
     _register_seedops_tools(mcp)
 except Exception as _e:
     # Keep server importable even if SeedOps dependencies are missing in a minimal env.
-    pass
+    print(f"[server] SeedOps tools not registered: {_e}", file=sys.stderr)
 
 # ==============================================================================
 # Infrastructure Tools (Base Layer)

--- a/mcp-server/tests/test_seedops_attach_compose.py
+++ b/mcp-server/tests/test_seedops_attach_compose.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.workspaces import extract_container_names_from_compose
+
+
+class TestSeedOpsAttachCompose(unittest.TestCase):
+    def test_extract_container_names(self):
+        mcp_server_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        output_dir = os.path.join(mcp_server_dir, "output_e2e_demo")
+
+        names = extract_container_names_from_compose(output_dir)
+        self.assertTrue(len(names) > 0)
+        self.assertTrue(any("as150" in n for n in names))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_capabilities.py
+++ b/mcp-server/tests/test_seedops_capabilities.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from mcp.server.fastmcp import FastMCP
+
+from seedops import SeedOpsServices, register_tools
+
+
+class TestSeedOpsCapabilities(unittest.TestCase):
+    def test_seedops_capabilities_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prev_db = os.environ.get("SEEDOPS_DB_PATH")
+            prev_data = os.environ.get("SEEDOPS_DATA_DIR")
+            try:
+                os.environ["SEEDOPS_DB_PATH"] = os.path.join(tmpdir, "seedops.db")
+                os.environ["SEEDOPS_DATA_DIR"] = os.path.join(tmpdir, "data")
+
+                mcp = FastMCP("seedops-capabilities-test")
+                services = SeedOpsServices()
+                register_tools(mcp, services=services)
+
+                async def call_tool() -> dict:
+                    result = await mcp.call_tool("seedops_capabilities", arguments={})
+                    text = ""
+                    if isinstance(result, tuple):
+                        content_blocks = result[0] if result else []
+                        if isinstance(content_blocks, list):
+                            text_parts = [x.text for x in content_blocks if getattr(x, "type", "") == "text"]
+                            text = "\n".join(text_parts)
+                        if not text and len(result) > 1 and isinstance(result[1], dict):
+                            text = str(result[1].get("result") or "")
+                    return json.loads(text)
+
+                payload = asyncio.run(call_tool())
+                self.assertEqual(payload["playbook_version"], 1)
+                self.assertIn("routing_bgp_summary", payload["supported_actions"])
+                self.assertIn("seedops_capabilities", payload["tool_names"])
+                self.assertIn("default_limits", payload)
+                self.assertEqual(payload["default_limits"]["parallelism"], 20)
+                services.store.close()
+            finally:
+                if prev_db is None:
+                    os.environ.pop("SEEDOPS_DB_PATH", None)
+                else:
+                    os.environ["SEEDOPS_DB_PATH"] = prev_db
+                if prev_data is None:
+                    os.environ.pop("SEEDOPS_DATA_DIR", None)
+                else:
+                    os.environ["SEEDOPS_DATA_DIR"] = prev_data
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/tests/test_seedops_inventory.py
+++ b/mcp-server/tests/test_seedops_inventory.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.inventory import InventoryBuilder
+from seedops.selectors import match_selector
+
+
+class FakeContainer:
+    def __init__(self, name: str, labels: dict[str, str]):
+        self.name = name
+        self.labels = labels
+
+
+class TestSeedOpsInventory(unittest.TestCase):
+    def test_parse_node_from_labels(self):
+        labels = {
+            "org.seedsecuritylabs.seedemu.meta.asn": "150",
+            "org.seedsecuritylabs.seedemu.meta.nodename": "router0",
+            "org.seedsecuritylabs.seedemu.meta.role": "BorderRouter",
+            "org.seedsecuritylabs.seedemu.meta.class": "[\"Routing\"]",
+            "org.seedsecuritylabs.seedemu.meta.loopback_addr": "10.0.0.1",
+            "org.seedsecuritylabs.seedemu.meta.net.0.name": "net0",
+            "org.seedsecuritylabs.seedemu.meta.net.0.address": "10.150.0.254/24",
+            "org.seedsecuritylabs.seedemu.meta.net.1.name": "ix100",
+            "org.seedsecuritylabs.seedemu.meta.net.1.address": "10.100.0.150/24",
+        }
+        c = FakeContainer("as150brd-router0-10.150.0.254", labels)
+
+        inv = InventoryBuilder().build([c])
+        self.assertEqual(len(inv.nodes), 1)
+
+        node = inv.nodes[0]
+        self.assertEqual(node["node_id"], "as150/router0")
+        self.assertEqual(node["asn"], 150)
+        self.assertEqual(node["role"], "BorderRouter")
+        self.assertIn("Routing", node["classes"])
+        self.assertEqual(node["container_name"], "as150brd-router0-10.150.0.254")
+        self.assertEqual(len(node["interfaces"]), 2)
+
+    def test_selector_matching(self):
+        node = {
+            "node_id": "as150/router0",
+            "asn": 150,
+            "node_name": "router0",
+            "role": "BorderRouter",
+            "classes": ["Routing"],
+            "container_name": "as150brd-router0-10.150.0.254",
+            "interfaces": [{"name": "net0", "address": "10.150.0.254/24"}, {"name": "ix100", "address": "10.100.0.150/24"}],
+            "loopback": "10.0.0.1",
+            "labels": {"k": "v"},
+        }
+
+        self.assertTrue(match_selector(node, {"asn": 150}))
+        self.assertTrue(match_selector(node, {"asn": [150, 151]}))
+        self.assertFalse(match_selector(node, {"asn": 151}))
+        # Empty lists should match nothing (safer than matching everything).
+        self.assertFalse(match_selector(node, {"asn": []}))
+
+        self.assertTrue(match_selector(node, {"role": "BorderRouter", "network": "ix100"}))
+        self.assertFalse(match_selector(node, {"role": "Host"}))
+        self.assertFalse(match_selector(node, {"role": []}))
+
+        self.assertTrue(match_selector(node, {"class": "Routing"}))
+        self.assertFalse(match_selector(node, {"class": "WebService"}))
+        self.assertFalse(match_selector(node, {"network": []}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-server/tests/test_seedops_ops_batch.py
+++ b/mcp-server/tests/test_seedops_ops_batch.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.ops import OpsService
+from seedops.store import SeedOpsStore
+
+
+class FakeExecResult:
+    def __init__(self, exit_code: int, output: bytes):
+        self.exit_code = exit_code
+        self.output = output
+
+
+class FakeContainer:
+    def __init__(self, *, exec_exit: int = 0, exec_out: str = "", logs_out: str = ""):
+        self._exec_exit = exec_exit
+        self._exec_out = exec_out.encode("utf-8")
+        self._logs_out = logs_out.encode("utf-8")
+
+    def exec_run(self, cmd, demux=False):
+        return FakeExecResult(self._exec_exit, self._exec_out)
+
+    def logs(self, tail=200, since=None):
+        return self._logs_out
+
+
+class FakeContainers:
+    def __init__(self, mapping: dict[str, FakeContainer]):
+        self._mapping = mapping
+
+    def get(self, name: str) -> FakeContainer:
+        return self._mapping[name]
+
+
+class FakeDockerClient:
+    def __init__(self, mapping: dict[str, FakeContainer]):
+        self.containers = FakeContainers(mapping)
+
+
+class FakeWorkspaces:
+    def __init__(self, nodes, docker_client):
+        self._nodes = nodes
+        self._docker_client = docker_client
+
+    def list_nodes(self, workspace_id, selector=None):
+        return self._nodes
+
+    def get_docker_client(self):
+        return self._docker_client
+
+
+class TestSeedOpsOpsBatch(unittest.TestCase):
+    def test_ops_exec_and_logs(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+
+            nodes = [
+                {"node_id": "as150/router0", "container_name": "c1"},
+                {"node_id": "as151/router0", "container_name": "c2"},
+            ]
+
+            docker_client = FakeDockerClient(
+                {
+                    "c1": FakeContainer(exec_exit=0, exec_out="OK", logs_out="LOG1"),
+                    "c2": FakeContainer(exec_exit=126, exec_out="ERR", logs_out="LOG2"),
+                }
+            )
+            workspaces = FakeWorkspaces(nodes, docker_client)
+            ops = OpsService(store=store, workspaces=workspaces)
+
+            result = ops.exec("ws1", selector={}, command="echo hi", parallelism=2, max_output_chars=2)
+            self.assertEqual(result["counts"]["total"], 2)
+            self.assertEqual(result["counts"]["ok"], 1)
+            self.assertEqual(result["counts"]["fail"], 1)
+            # output truncated
+            self.assertIn("truncated", result["results"][0]["output"] + result["results"][1]["output"])
+
+            logs = ops.logs("ws1", selector={}, tail=10, parallelism=2, max_output_chars=100)
+            self.assertEqual(logs["counts"]["total"], 2)
+            self.assertEqual(logs["counts"]["ok"], 2)
+            self.assertEqual(len(logs["logs"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_pcap_capture.py
+++ b/mcp-server/tests/test_seedops_pcap_capture.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+import base64
+from unittest.mock import patch
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.artifacts import ArtifactManager
+from seedops.jobs import JobManager
+from seedops.store import SeedOpsStore
+
+
+class FakeWorkspaces:
+    def list_nodes(self, workspace_id: str, selector=None):
+        return [
+            {"node_id": "as150/router0", "container_name": "c0"},
+            {"node_id": "as150/host0", "container_name": "c1"},
+        ]
+
+    def refresh(self, workspace_id: str):
+        return {
+            "workspace_id": workspace_id,
+            "counts": {"containers_seen": 0, "nodes_parsed": 0, "missing_containers": 0},
+            "roles": {},
+            "asns": [],
+            "sample_nodes": [],
+        }
+
+
+class FakeOps:
+    def exec(self, *args, **kwargs):
+        raise AssertionError("Unexpected ops_exec call")
+
+    def logs(self, *args, **kwargs):
+        raise AssertionError("Unexpected ops_logs call")
+
+    def bgp_summary(self, *args, **kwargs):
+        raise AssertionError("Unexpected bgp_summary call")
+
+
+def _wait_for_job(store: SeedOpsStore, job_id: str, *, timeout_seconds: float = 5.0):
+    deadline = time.monotonic() + timeout_seconds
+    last = None
+    while time.monotonic() < deadline:
+        j = store.get_job(job_id)
+        last = j
+        if j and j.status not in {"queued", "running", "cancel_requested"}:
+            return j
+        time.sleep(0.05)
+    return last
+
+
+class TestSeedOpsPcapCapture(unittest.TestCase):
+    def test_pcap_capture_writes_pcap_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+            mgr = JobManager(store=store, workspaces=FakeWorkspaces(), ops=FakeOps(), artifacts=artifacts)
+
+            def fake_capture_pcap_to_file(**kwargs):
+                out_path = kwargs["out_path"]
+                with open(out_path, "wb") as f:
+                    f.write(b"PCAPDATA")
+                return {"exit_code": 0, "bytes_written": 8, "truncated": False, "timed_out": False, "stderr_head": ""}
+
+            with patch("seedops.jobs._capture_pcap_to_file", side_effect=fake_capture_pcap_to_file):
+                job = mgr.start_playbook(
+                    ws.workspace_id,
+                    playbook_yaml="""
+version: 1
+name: pcap
+defaults:
+  selector: {}
+steps:
+  - action: pcap_capture
+    id: cap
+    duration_seconds: 1
+    interface: any
+    max_bytes: 1024
+""",
+                )
+
+                final = _wait_for_job(store, job.job_id, timeout_seconds=5.0)
+                self.assertIsNotNone(final)
+                self.assertEqual(final.status, "succeeded")
+
+                rows = store.list_artifacts(job.job_id, limit=20)
+                self.assertEqual(len(rows), 2)
+                self.assertTrue(all(r.kind == "pcap" for r in rows))
+
+                chunk = artifacts.read_chunk_base64(rows[0].artifact_id, offset=0, max_bytes=16)
+                self.assertIsNotNone(chunk)
+                self.assertGreater(chunk.bytes_read, 0)
+                decoded = base64.b64decode(chunk.content_b64.encode("ascii"))
+                self.assertIn(b"PCAP", decoded)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_phase2_jobs.py
+++ b/mcp-server/tests/test_seedops_phase2_jobs.py
@@ -144,6 +144,65 @@ steps:
             steps = store.list_job_steps(job.job_id, since_step_id=0, limit=200)
             self.assertTrue(any(s.event_type == "step.finished" for s in steps))
 
+    def test_playbook_retries_and_on_error_continue(self):
+        class FlakyOps(FakeOps):
+            def __init__(self):
+                self.calls = 0
+
+            def exec(self, workspace_id: str, *, selector, command: str, timeout_seconds=30, parallelism=20, max_output_chars=8000):
+                self.calls += 1
+                if "flaky" in command and self.calls == 1:
+                    raise RuntimeError("transient error")
+                if "always_fail" in command:
+                    raise RuntimeError("permanent error")
+                return super().exec(
+                    workspace_id,
+                    selector=selector,
+                    command=command,
+                    timeout_seconds=timeout_seconds,
+                    parallelism=parallelism,
+                    max_output_chars=max_output_chars,
+                )
+
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+
+            mgr = JobManager(store=store, workspaces=FakeWorkspaces(), ops=FlakyOps(), artifacts=artifacts)
+            job = mgr.start_playbook(
+                ws.workspace_id,
+                playbook_yaml="""
+version: 1
+name: retry_and_continue
+defaults:
+  selector: {}
+  retries: 1
+  retry_delay_seconds: 0.01
+steps:
+  - action: ops_exec
+    id: flaky
+    selector: {}
+    command: "flaky"
+  - action: ops_exec
+    id: fail_but_continue
+    selector: {}
+    command: "always_fail"
+    on_error: continue
+    retries: 0
+  - action: workspace_refresh
+    id: refresh
+""",
+            )
+
+            final = _wait_for_job(store, job.job_id, timeout_seconds=5.0)
+            self.assertIsNotNone(final)
+            self.assertEqual(final.status, "succeeded_with_errors")
+
+            steps = store.list_job_steps(job.job_id, since_step_id=0, limit=500)
+            self.assertTrue(any(s.event_type == "step.retry" for s in steps))
+            self.assertTrue(any(s.event_type == "step.failed" for s in steps))
+
     def test_collector_job_and_snapshots(self):
         with tempfile.TemporaryDirectory() as td:
             store = SeedOpsStore(os.path.join(td, "seedops.db"))

--- a/mcp-server/tests/test_seedops_phase2_jobs.py
+++ b/mcp-server/tests/test_seedops_phase2_jobs.py
@@ -1,0 +1,163 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.artifacts import ArtifactManager
+from seedops.jobs import JobManager
+from seedops.playbooks import parse_playbook_yaml
+from seedops.store import SeedOpsStore
+
+
+class FakeWorkspaces:
+    def refresh(self, workspace_id: str):
+        return {
+            "workspace_id": workspace_id,
+            "counts": {"containers_seen": 0, "nodes_parsed": 0, "missing_containers": 0},
+            "roles": {},
+            "asns": [],
+            "sample_nodes": [],
+        }
+
+    def list_nodes(self, workspace_id: str, selector=None):
+        return [{"node_id": "as150/router0"}]
+
+
+class FakeOps:
+    def exec(self, workspace_id: str, *, selector, command: str, timeout_seconds=30, parallelism=20, max_output_chars=8000):
+        return {
+            "command": command,
+            "command_hash": "deadbeef",
+            "backend": "sdk",
+            "counts": {"total": 1, "ok": 1, "fail": 0},
+            "fail_reasons": {},
+            "results": [{"node_id": "as150/router0", "ok": True, "exit_code": 0, "output": "OK"}],
+        }
+
+    def logs(self, workspace_id: str, *, selector, tail=200, since_seconds=0, parallelism=20, max_output_chars=8000):
+        return {"counts": {"total": 1, "ok": 1, "fail": 0}, "fail_reasons": {}, "logs": []}
+
+    def bgp_summary(self, workspace_id: str, *, selector):
+        return {
+            "backend": "sdk",
+            "counts": {"nodes": 1, "nodes_ok": 1, "nodes_error": 0, "bgp_up": 1, "bgp_down": 0},
+            "nodes": [],
+        }
+
+
+def _wait_for_job(store: SeedOpsStore, job_id: str, *, timeout_seconds: float = 5.0):
+    deadline = time.monotonic() + timeout_seconds
+    last = None
+    while time.monotonic() < deadline:
+        j = store.get_job(job_id)
+        last = j
+        if j and j.status not in {"queued", "running", "cancel_requested"}:
+            return j
+        time.sleep(0.05)
+    return last
+
+
+class TestSeedOpsPhase2Jobs(unittest.TestCase):
+    def test_playbook_parse_validate(self):
+        pb = parse_playbook_yaml(
+            """
+version: 1
+name: test
+defaults:
+  selector: {}
+steps:
+  - action: workspace_refresh
+  - action: ops_exec
+    selector: {}
+    command: "echo hi"
+"""
+        )
+        self.assertEqual(pb.version, 1)
+        self.assertEqual(pb.name, "test")
+        self.assertEqual(len(pb.steps), 2)
+
+        with self.assertRaises(ValueError):
+            parse_playbook_yaml(
+                """
+version: 1
+steps:
+  - action: ops_exec
+    selector: {}
+"""
+            )
+
+    def test_playbook_job_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+
+            mgr = JobManager(store=store, workspaces=FakeWorkspaces(), ops=FakeOps(), artifacts=artifacts)
+
+            job = mgr.start_playbook(
+                ws.workspace_id,
+                playbook_yaml="""
+version: 1
+name: demo
+defaults:
+  selector: {}
+steps:
+  - action: workspace_refresh
+    id: refresh
+    save_as: refresh_result
+  - action: ops_exec
+    id: exec
+    selector: {}
+    command: "echo hi"
+    save_as: exec_result
+  - action: sleep
+    seconds: 0.1
+""",
+            )
+
+            final = _wait_for_job(store, job.job_id, timeout_seconds=5.0)
+            self.assertIsNotNone(final)
+            self.assertEqual(final.status, "succeeded")
+            self.assertEqual(final.progress_current, 3)
+
+            arts = store.list_artifacts(job.job_id)
+            self.assertEqual(len(arts), 2)
+            names = {a.name for a in arts}
+            self.assertIn("refresh_result", names)
+            self.assertIn("exec_result", names)
+
+            read = artifacts.read(arts[0].artifact_id, max_chars=2000)
+            self.assertIsNotNone(read)
+            self.assertIn("{", read.content)
+
+            steps = store.list_job_steps(job.job_id, since_step_id=0, limit=200)
+            self.assertTrue(any(s.event_type == "step.finished" for s in steps))
+
+    def test_collector_job_and_snapshots(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+
+            mgr = JobManager(store=store, workspaces=FakeWorkspaces(), ops=FakeOps(), artifacts=artifacts)
+            job = mgr.start_collector(ws.workspace_id, interval_seconds=1, selector={}, include_bgp_summary=True)
+
+            # Let at least one tick happen.
+            time.sleep(0.2)
+            mgr.cancel_job(job.job_id)
+
+            final = _wait_for_job(store, job.job_id, timeout_seconds=5.0)
+            self.assertIsNotNone(final)
+            self.assertIn(final.status, {"canceled", "failed"})
+
+            snaps = store.list_snapshots(ws.workspace_id, limit=50)
+            self.assertTrue(any(s.snapshot_type == "inventory_summary" for s in snaps))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_phase2_jobs.py
+++ b/mcp-server/tests/test_seedops_phase2_jobs.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import time
 import unittest
+import base64
 
 # Add parent directory (mcp-server) to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -134,6 +135,12 @@ steps:
             self.assertIsNotNone(read)
             self.assertIn("{", read.content)
 
+            chunk = artifacts.read_chunk_base64(arts[0].artifact_id, offset=0, max_bytes=64)
+            self.assertIsNotNone(chunk)
+            self.assertGreater(chunk.bytes_read, 0)
+            decoded = base64.b64decode(chunk.content_b64.encode("ascii"))
+            self.assertIn(b"{", decoded)
+
             steps = store.list_job_steps(job.job_id, since_step_id=0, limit=200)
             self.assertTrue(any(s.event_type == "step.finished" for s in steps))
 
@@ -160,4 +167,3 @@ steps:
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/mcp-server/tests/test_seedops_playbook_actions.py
+++ b/mcp-server/tests/test_seedops_playbook_actions.py
@@ -1,0 +1,140 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.artifacts import ArtifactManager
+from seedops.jobs import JobManager
+from seedops.playbooks import parse_playbook_yaml
+from seedops.store import SeedOpsStore
+
+
+class FakeWorkspaces:
+    def refresh(self, workspace_id: str):
+        return {
+            "workspace_id": workspace_id,
+            "counts": {"containers_seen": 0, "nodes_parsed": 0, "missing_containers": 0},
+            "roles": {},
+            "asns": [],
+            "sample_nodes": [],
+        }
+
+    def list_nodes(self, workspace_id: str, selector=None):
+        return [{"node_id": "as150/router0"}]
+
+
+class RecordingOps:
+    def __init__(self):
+        self.commands = []
+
+    def exec(self, workspace_id: str, *, selector, command: str, timeout_seconds=30, parallelism=20, max_output_chars=8000):
+        self.commands.append(command)
+        return {
+            "command": command,
+            "command_hash": "deadbeef",
+            "backend": "sdk",
+            "counts": {"total": 1, "ok": 1, "fail": 0},
+            "fail_reasons": {},
+            "results": [{"node_id": "as150/router0", "ok": True, "exit_code": 0, "output": "OK"}],
+        }
+
+    def logs(self, workspace_id: str, *, selector, tail=200, since_seconds=0, parallelism=20, max_output_chars=8000):
+        raise AssertionError("Unexpected logs call")
+
+    def bgp_summary(self, workspace_id: str, *, selector):
+        raise AssertionError("Unexpected bgp_summary call")
+
+
+def _wait_for_job(store: SeedOpsStore, job_id: str, *, timeout_seconds: float = 5.0):
+    deadline = time.monotonic() + timeout_seconds
+    last = None
+    while time.monotonic() < deadline:
+        j = store.get_job(job_id)
+        last = j
+        if j and j.status not in {"queued", "running", "cancel_requested"}:
+            return j
+        time.sleep(0.05)
+    return last
+
+
+class TestSeedOpsPlaybookActions(unittest.TestCase):
+    def test_parse_requires_action_specific_args(self):
+        with self.assertRaises(ValueError):
+            parse_playbook_yaml(
+                """
+version: 1
+name: bad
+defaults:
+  selector: {}
+steps:
+  - action: ping
+"""
+            )
+
+        with self.assertRaises(ValueError):
+            parse_playbook_yaml(
+                """
+version: 1
+name: bad
+defaults:
+  selector: {}
+steps:
+  - action: inject_fault
+    selector: {}
+"""
+            )
+
+    def test_playbook_actions_call_ops_exec(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+            ops = RecordingOps()
+
+            mgr = JobManager(store=store, workspaces=FakeWorkspaces(), ops=ops, artifacts=artifacts)
+            job = mgr.start_playbook(
+                ws.workspace_id,
+                playbook_yaml="""
+version: 1
+name: actions
+defaults:
+  selector: {}
+  timeout_seconds: 5
+steps:
+  - action: ping
+    id: p
+    dst: 1.1.1.1
+    count: 2
+  - action: traceroute
+    id: t
+    dst: 8.8.8.8
+  - action: inject_fault
+    id: f
+    fault_type: packet_loss
+    params: "20"
+  - action: capture_evidence
+    id: e
+    evidence_type: routing_snapshot
+""",
+            )
+
+            final = _wait_for_job(store, job.job_id, timeout_seconds=5.0)
+            self.assertIsNotNone(final)
+            self.assertEqual(final.status, "succeeded")
+
+            self.assertEqual(len(ops.commands), 4)
+            self.assertEqual(ops.commands[0], "ping -c 2 1.1.1.1")
+            self.assertIn("traceroute -n 8.8.8.8", ops.commands[1])
+            self.assertIn("tracepath -n 8.8.8.8", ops.commands[1])
+            self.assertIn("tc qdisc add dev eth0 root netem loss 20%", ops.commands[2])
+            self.assertIn("ip route", ops.commands[3])
+            self.assertIn("birdc", ops.commands[3])
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_prune.py
+++ b/mcp-server/tests/test_seedops_prune.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.artifacts import ArtifactManager
+from seedops.store import SeedOpsStore
+
+
+class TestSeedOpsPrune(unittest.TestCase):
+    def test_prune_events_and_snapshots(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+
+            for i in range(10):
+                store.insert_event(ws.workspace_id, level="info", event_type="test", message=f"e{i}", data={"i": i})
+
+            deleted = store.prune_events(ws.workspace_id, keep_last=3)
+            self.assertGreaterEqual(deleted, 7)
+            events = store.list_events(ws.workspace_id, since_ts=0, limit=200)
+            self.assertEqual(len(events), 3)
+
+            for i in range(8):
+                store.insert_snapshot(ws.workspace_id, snapshot_type="inventory_summary", data={"i": i})
+
+            deleted_s = store.prune_snapshots(ws.workspace_id, snapshot_type="inventory_summary", keep_last=2)
+            self.assertGreaterEqual(deleted_s, 6)
+            snaps = store.list_snapshots(ws.workspace_id, snapshot_type="inventory_summary", since_ts=0, limit=200)
+            self.assertEqual(len(snaps), 2)
+
+    def test_prune_terminal_jobs_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+
+            for i in range(3):
+                job = store.create_job(ws.workspace_id, kind="playbook", name=f"job{i}")
+                store.update_job(job.job_id, status="succeeded", finished_at=int(time.time()), message="done")
+                artifacts.write_json(workspace_id=ws.workspace_id, job_id=job.job_id, name=f"out{i}", data={"i": i})
+
+            to_prune = store.list_terminal_job_ids_to_prune(ws.workspace_id, keep_last=1)
+            self.assertEqual(len(to_prune), 2)
+
+            artifact_rows = store.list_artifacts_for_job_ids(to_prune)
+            self.assertEqual(len(artifact_rows), 2)
+            paths = [a.path for a in artifact_rows]
+            artifact_ids = [a.artifact_id for a in artifact_rows]
+
+            file_counts = artifacts.delete_files(artifact_rows)
+            self.assertEqual(file_counts["deleted"], 2)
+            for p in paths:
+                self.assertFalse(os.path.exists(p))
+
+            db_counts = store.delete_jobs_and_related(to_prune)
+            self.assertEqual(db_counts["jobs_deleted"], 2)
+            self.assertEqual(db_counts["artifacts_deleted"], 2)
+
+            for aid in artifact_ids:
+                self.assertIsNone(store.get_artifact(aid))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_store.py
+++ b/mcp-server/tests/test_seedops_store.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.store import SeedOpsStore
+
+
+class TestSeedOpsStore(unittest.TestCase):
+    def test_workspace_crud_and_events(self):
+        with tempfile.TemporaryDirectory() as td:
+            db_path = os.path.join(td, "seedops.db")
+            store = SeedOpsStore(db_path)
+
+            ws = store.create_workspace("lab1")
+            self.assertEqual(ws.name, "lab1")
+            self.assertTrue(ws.workspace_id)
+
+            items = store.list_workspaces()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0].workspace_id, ws.workspace_id)
+
+            got = store.get_workspace(ws.workspace_id)
+            self.assertIsNotNone(got)
+            self.assertEqual(got.name, "lab1")
+
+            store.update_workspace_attach(
+                ws.workspace_id,
+                "compose",
+                {"output_dir": "/tmp/output", "container_names": ["c1", "c2"], "label_prefix": "org.seedsecuritylabs.seedemu.meta."},
+            )
+            got2 = store.get_workspace(ws.workspace_id)
+            self.assertIsNotNone(got2)
+            self.assertEqual(got2.attach_type, "compose")
+            self.assertIn("output_dir", got2.attach_config)
+
+            eid = store.insert_event(ws.workspace_id, level="info", event_type="test.event", message="hello", data={"x": 1})
+            events = store.list_events(ws.workspace_id, since_ts=0, limit=10)
+            self.assertTrue(any(ev.event_id == eid for ev in events))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/mcp-server/tests/test_seedops_template.py
+++ b/mcp-server/tests/test_seedops_template.py
@@ -1,0 +1,129 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+# Add parent directory (mcp-server) to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from seedops.artifacts import ArtifactManager
+from seedops.jobs import JobManager
+from seedops.store import SeedOpsStore
+from seedops.template import TemplateError, render_value
+
+
+class FakeWorkspaces:
+    def refresh(self, workspace_id: str):
+        return {
+            "workspace_id": workspace_id,
+            "counts": {"containers_seen": 0, "nodes_parsed": 0, "missing_containers": 0},
+            "roles": {},
+            "asns": [],
+            "sample_nodes": [],
+        }
+
+    def list_nodes(self, workspace_id: str, selector=None):
+        return [{"node_id": "as150/router0"}]
+
+
+class RecordingOps:
+    def __init__(self):
+        self.calls = []
+
+    def exec(self, workspace_id: str, *, selector, command: str, timeout_seconds=30, parallelism=20, max_output_chars=8000):
+        self.calls.append({"selector": selector, "command": command})
+        return {
+            "command": command,
+            "command_hash": "deadbeef",
+            "backend": "sdk",
+            "counts": {"total": 1, "ok": 1, "fail": 0},
+            "fail_reasons": {},
+            "results": [{"node_id": "as150/router0", "ok": True, "exit_code": 0, "output": "OK"}],
+        }
+
+    def logs(self, workspace_id: str, *, selector, tail=200, since_seconds=0, parallelism=20, max_output_chars=8000):
+        raise AssertionError("Unexpected logs call")
+
+    def bgp_summary(self, workspace_id: str, *, selector):
+        raise AssertionError("Unexpected bgp_summary call")
+
+
+def _wait_for_job(store: SeedOpsStore, job_id: str, *, timeout_seconds: float = 5.0):
+    deadline = time.monotonic() + timeout_seconds
+    last = None
+    while time.monotonic() < deadline:
+        j = store.get_job(job_id)
+        last = j
+        if j and j.status not in {"queued", "running", "cancel_requested"}:
+            return j
+        time.sleep(0.05)
+    return last
+
+
+class TestSeedOpsTemplate(unittest.TestCase):
+    def test_render_value_full_template_returns_typed(self):
+        ctx = {"vars": {"obj": {"a": 1}, "arr": [10, 20], "k": {"x": "y"}}}
+        self.assertEqual(render_value("{{ vars.obj }}", ctx), {"a": 1})
+        self.assertEqual(render_value("{{ vars.arr[1] }}", ctx), 20)
+        self.assertEqual(render_value("{{ vars.k['x'] }}", ctx), "y")
+
+    def test_render_value_interpolation(self):
+        ctx = {"vars": {"asn": 150, "name": "r0"}}
+        self.assertEqual(render_value("as{{ vars.asn }}/{{ vars.name }}", ctx), "as150/r0")
+
+    def test_render_value_recursive(self):
+        ctx = {"vars": {"asn": 150}}
+        v = {"selector": {"asn": "{{ vars.asn }}"}, "list": ["{{ vars.asn }}", 1]}
+        self.assertEqual(render_value(v, ctx), {"selector": {"asn": 150}, "list": [150, 1]})
+
+    def test_render_value_missing_key_raises(self):
+        with self.assertRaises(TemplateError):
+            render_value("{{ vars.missing }}", {"vars": {}})
+
+    def test_playbook_job_renders_defaults_and_step_args(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = SeedOpsStore(os.path.join(td, "seedops.db"))
+            ws = store.create_workspace("lab1")
+            artifacts = ArtifactManager(base_dir=os.path.join(td, "data"), store=store)
+            ops = RecordingOps()
+
+            mgr = JobManager(store=store, workspaces=FakeWorkspaces(), ops=ops, artifacts=artifacts)
+            job = mgr.start_playbook(
+                ws.workspace_id,
+                playbook_yaml="""
+version: 1
+name: templating
+vars:
+  asn: 150
+  sel:
+    asn: [150]
+defaults:
+  selector: "{{ vars.sel }}"
+steps:
+  - action: workspace_refresh
+    id: refresh
+  - action: ops_exec
+    id: echo
+    command: "echo {{ vars.asn }} {{ steps.refresh.summary.counts.nodes_parsed }}"
+  - action: ops_exec
+    id: override
+    selector: "{{ vars.sel }}"
+    command: "echo hi"
+""",
+            )
+
+            final = _wait_for_job(store, job.job_id, timeout_seconds=5.0)
+            self.assertIsNotNone(final)
+            self.assertEqual(final.status, "succeeded")
+
+            self.assertEqual(len(ops.calls), 2)
+            self.assertEqual(ops.calls[0]["selector"], {"asn": [150]})
+            self.assertEqual(ops.calls[0]["command"], "echo 150 0")
+            self.assertEqual(ops.calls[1]["selector"], {"asn": [150]})
+            self.assertEqual(ops.calls[1]["command"], "echo hi")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary

This PR targets **`origin/mcp-server`** as base and delivers the next increment of the SeedOps operations control plane.

It completes a focused hardening/feature batch across:

- playbook execution reliability,
- artifact retrieval ergonomics,
- workspace lifecycle maintenance,
- diagnostics/templating,
- packet capture support,
- and capability discovery for upstream orchestrators.

It also aligns user-facing docs and cross-repo entrypoints for the SeedAgent ↔ SeedOps closed loop.

---

## Base Branch and Scope

- **Base**: `mcp-server` (not `master`)
- **Head**: `feat/mcp-server`
- **Delta**: 15 commits (2026-02-10 to 2026-02-11)
- **Diff footprint**: 31 files changed, 5989 insertions, 87 deletions

---

## What’s Included

### 1) SeedOps control-plane expansion and modularization

- Introduce/extend `seedops` modules for:
  - workspaces
  - inventory/selectors
  - ops actions
  - playbook parsing/validation
  - jobs orchestration
  - artifacts handling
- Add HTTP serving entrypoint and corresponding wiring.

### 2) Artifact retrieval improvements

- Add chunked artifact reads for binary/large artifact workflows.
- Improve docs for remote-friendly artifact retrieval patterns.

### 3) Playbook reliability semantics

- Add support for:
  - `retries`
  - `retry_delay_seconds`
  - `on_error: stop|continue`
- Ensure job execution and event streams reflect retry/error behavior explicitly.

### 4) Workspace maintenance lifecycle

- Add workspace pruning capability and documentation.

### 5) Templating and diagnostics

- Add templating-driven value rendering and diagnostics-oriented playbook actions/workflows.

### 6) PCAP capture workflow

- Add `pcap_capture` action support.
- Persist generated captures as artifacts and expose retrieval path.

### 7) Capability discovery endpoint

- Add `seedops_capabilities()` to publish:
  - supported playbook/action surface
  - relevant defaults/limits
  - tool-level capability hints
- Enables upstream planner/orchestrator capability-aware behavior.

### 8) Documentation and entrypoint alignment

- Expand `docs/user_manual/mcp_seedops.md`.
- Update top-level docs/indices and cross-repo navigation to reflect current closed-loop usage with SeedAgent.

---

## Compatibility and Risk

- This PR is additive to the `mcp-server` line and does not rename the existing low-level SeedOps namespace.
- New behaviors are introduced behind explicit playbook fields/actions, preserving existing default execution paths.
- Docs updates are aligned with currently shipped behavior.

---

## Validation

Executed targeted regression for this change set:

```bash
pytest -q mcp-server/tests/test_seedops_*.py
```

Result:

- **20 passed**

Additionally, capability-discovery coverage is included in:

- `mcp-server/tests/test_seedops_capabilities.py`

---

## Review Guide (Suggested Order)

1. `mcp-server/seedops/playbooks.py`, `mcp-server/seedops/jobs.py`
2. `mcp-server/seedops/artifacts.py`
3. `mcp-server/seedops/template.py`
4. `mcp-server/seedops/__init__.py` (tool surface incl. capabilities)
5. `mcp-server/tests/test_seedops_*.py`
6. docs: `docs/user_manual/mcp_seedops.md`, README/index updates

---

## Commit Timeline (This Increment)

Primary delivery window:

- **2026-02-10**: core features (ops plane, artifacts chunking, retries/on_error, prune, templating, pcap, docs)
- **2026-02-11**: cross-repo entrypoint/docs alignment