### PR TITLE
k8s: harden KubeVirt hybrid compiler for multi-node clusters and validate on arm64

### DIFF
--- a/docs/design/kubevirt_hybrid_k8s.md
+++ b/docs/design/kubevirt_hybrid_k8s.md
@@ -1,0 +1,86 @@
+# SEED Emulator KubeVirt Hybrid Kubernetes 设计文档
+
+## 1. 概述 (Overview)
+
+本设计旨在扩展 SEED Emulator，使其能够利用 **KubeVirt** 在 Kubernetes 集群中运行虚拟机（VM）节点，同时保持与容器节点的互操作性。目标是覆盖本地开发环境与标准 Linux 服务器环境。
+
+### 核心目标
+1. **高保真仿真**: 允许特定节点运行自定义内核或容器之外的操作系统能力。
+2. **混合部署**: 在同一仿真网络中混合运行容器（Docker）和虚拟机（KubeVirt）。
+3. **无缝集成**: 保持 Python 拓扑定义方式不变，通过 `node.setVirtualizationMode('KubeVirt')` 启用 VM。
+4. **自动化部署**: 提供一键脚本搭建 Kind + Multus + KubeVirt 环境。
+
+## 2. 架构设计 (Architecture)
+
+### 2.1 基础架构层 (Infrastructure)
+- **宿主机**: Linux 开发机 / Linux 服务器。
+- **集群管理**: **Kind (Kubernetes in Docker)**。
+- **虚拟化技术**: **KubeVirt**，优先 KVM；无硬件虚拟化时可用 QEMU 软件模拟（性能较低）。
+- **网络层**: **Multus CNI**，使 Pod/VM 可挂载多网卡（eth0 管理网，net1/net2 仿真网）。
+
+### 2.2 节点类型 (Node Types)
+
+| 特性 | 容器节点 (Container Node) | 虚拟机节点 (KubeVirt Node) |
+|:---|:---|:---|
+| **资源定义** | Kubernetes `Deployment` | KubeVirt `VirtualMachine` |
+| **启动方式** | Docker 镜像启动 | ContainerDisk + Cloud-Init |
+| **配置注入** | `Dockerfile` 构建时注入 + 启动脚本 | `Cloud-Init` (User Data) 运行时注入 |
+| **IP 管理** | `replace_address.sh` (容器内执行) | `write_files` + `runcmd` (Cloud-Init) |
+| **适用场景** | 路由器、Web、普通主机 | 自定义内核测试、特殊网络栈、高隔离需求 |
+
+## 3. 动态注入策略 (Dynamic Injection Strategy)
+
+SEED Emulator 传统上依赖 `Dockerfile` 构建镜像。对于 VM 路径，应避免构建体积巨大的 VM 镜像。
+
+**方案**: 使用通用 Cloud Image（如 Ubuntu）+ Cloud-Init。
+
+### 3.1 转换逻辑
+编译器 `Kubernetes.py` 进行如下转换：
+
+1. **基础镜像**
+   - 容器: `FROM ubuntu:20.04`
+   - VM: `quay.io/containerdisks/ubuntu:22.04`
+
+2. **文件注入 (`node.addFile`)**
+   - 容器: `COPY file /path/file`
+   - VM: 转换为 Cloud-Init `write_files`
+
+3. **软件安装 (`node.addSoftware`)**
+   - 容器: `RUN apt-get install -y package`
+   - VM: 转换为 Cloud-Init `packages`
+
+4. **启动命令 (`node.appendStartCommand`)**
+   - 容器: 写入 `/start.sh` 并作为 CMD 执行
+   - VM: 转换为 Cloud-Init `runcmd`
+
+## 4. 网络与地址管理 (Networking & Address Hack)
+
+SEED Emulator 采用静态 IP，和 CNI 动态 IPAM 存在冲突。
+
+### 4.1 容器方案
+- Multus 创建接口后，容器内执行 `/replace_address.sh`，通过 `ip addr add` 覆盖地址。
+- 接口名通常为 `net1`, `net2`。
+
+### 4.2 虚拟机方案
+- VM 内常见接口顺序：`eth0`（管理网）、`eth1`、`eth2`（仿真网）。
+- 编译器按接口顺序生成 Cloud-Init 配置，将模型中的网卡映射到 VM 内设备名。
+
+关键约束：
+- 必须保证 Multus CNI 配置与二层互通能力正确（`bridge`/`macvlan` 等）。
+- 在 Kind 本地验证中，`bridge` 模式最稳健。
+
+## 5. 实施计划 (Implementation Plan)
+
+1. **Python 核心扩展**
+   - `Node.py`: 增加 `virtualization_mode` 属性。
+   - `Kubernetes.py`: 增加 `_compileNodeKubeVirt`，生成 Cloud-Init 与 VM 清单。
+
+2. **环境脚本**
+   - `setup_kubevirt_cluster.sh`
+   - 检测 CPU 虚拟化能力。
+   - 安装 Kind、Multus、KubeVirt。
+   - 等待组件就绪并输出诊断信息。
+
+3. **验证**
+   - 构建“1 VM 路由器 + 2 容器主机”拓扑。
+   - 验证互通、BGP、恢复能力。

--- a/docs/design/kubevirt_hybrid_validation_gate_20260213.md
+++ b/docs/design/kubevirt_hybrid_validation_gate_20260213.md
@@ -1,0 +1,85 @@
+# SEED KubeVirt Hybrid 验收门禁报告（2026-02-13）
+
+## 1. 执行背景
+- 验证分支：`integration/kubevirt-verify`
+- 基线来源：KubeVirt 混合部署特性分支（单提交引入文档与编译器变更）
+- 执行策略：先修后并 + Kind/K8s 1.32.2 + 中等覆盖
+- 执行时间：2026-02-13
+
+## 2. 已完成修复
+1. `seedemu/compiler/Kubernetes.py`
+   - KubeVirt 路径补齐 `fork` 语义。
+   - KubeVirt 路径补齐 `post config commands`。
+   - KubeVirt 不支持项改为显式失败（不再静默忽略）。
+   - Cloud-Init 改为 Secret 引用（规避 inline `userData` 体积限制）。
+   - VM 清单改用 `runStrategy`（替代弃用字段 `running`）。
+2. `seedemu/core/Node.py`
+   - `copySettings()` 传播 `virtualization_mode`。
+3. `setup_kubevirt_cluster.sh`
+   - 固定 Kind/K8s/Multus/KubeVirt 版本。
+   - 无 `/dev/kvm` 自动 `useEmulation=true`。
+   - 补齐 Kind 节点 CNI `bridge` 插件，避免 Multus 二网卡创建失败。
+4. 新增验证资产
+   - 示例：`examples/kubernetes/k8s_hybrid_kubevirt_demo.py`
+   - E2E：`scripts/validate_kubevirt_hybrid.sh`
+   - 单测：`tests/kubevirt_compiler_test.py`
+
+## 3. 验证矩阵与结果
+### 3.1 编译/回归
+- `PYTHONPATH=. python3 tests/kubevirt_compiler_test.py -v`：**通过**。
+- `examples/kubernetes/k8s_nano_internet.py` 编译回归：**通过**。
+
+### 3.2 集群环境
+- Kind 节点镜像：`kindest/node:v1.32.2`
+- Multus：`v4.1.0`
+- KubeVirt：`v1.7.0`
+- 节点架构：`arm64`
+- 宿主机 `/dev/kvm`：**缺失**（已自动启用 emulation）
+
+### 3.3 混合拓扑 E2E（VM + 容器 + BGP）
+- 容器 Deployment：**Ready**
+- VM/VMI：**未 Ready（失败）**
+- 门禁结论：**Not Merge**（按“任一阻断失败不合并”）
+
+## 4. 阻断证据
+本轮阻断集中在 `arm64 + 无 /dev/kvm` 的 VM 启动链路，KubeVirt 在该组合下无法稳定拉起目标 VMI。
+
+关键证据（本地）：
+- `output/kubevirt_validation/failure_events.txt`
+- `output/kubevirt_validation/failure_vmi_describe.txt`
+- `output/kubevirt_validation/failure_vm_describe.txt`
+- `output/kubevirt_validation/failure_virt_launcher_compute.log`
+
+关键现象摘要：
+- `VMI readiness failed`（`kubectl wait vmi --for=condition=Ready` 超时）
+- 事件包含 `host-passthrough` 与当前 hypervisor 组合不兼容报错，以及同步失败。
+
+## 5. 复测建议（x86 + /dev/kvm）
+建议在 x86_64 且 `/dev/kvm` 可用的主机复测：
+
+```bash
+# 1) 环境重建
+SEED_CLUSTER_NAME=seedemu-kvtest WORKER_COUNT=1 ./setup_kubevirt_cluster.sh
+
+# 2) 编译回归
+PYTHONPATH=. python3 tests/kubevirt_compiler_test.py -v
+
+# 3) 混合拓扑验收（失败时自动采集证据）
+SEED_CLUSTER_NAME=seedemu-kvtest SEED_NAMESPACE=seedemu-kvtest ./scripts/validate_kubevirt_hybrid.sh
+```
+
+## 6. 2026-02-14 补充：Runtime Profile 兼容策略
+为兼容 `Linux(x86/arm64)` 与 `Linux server(x86)`，新增 Runtime Profile：
+
+- `auto`：自动选择；在 `arm64 + 无 /dev/kvm` 自动降级为 `degraded`。
+- `full`：强制 KubeVirt VM + 容器混合模式。
+- `degraded`：强制全部容器模式（不生成 VM）。
+- `strict`：要求 VM 模式可用，否则直接失败。
+
+本机（`arm64` 且 `/dev/kvm` 缺失）复验结果：
+- `SEED_RUNTIME_PROFILE=auto`：**通过**（自动降级为 `degraded`，连通性/BGP/自愈通过）。
+- `SEED_RUNTIME_PROFILE=strict`：**按预期失败**（快速失败，阻止错误环境继续执行）。
+
+结论口径更新：
+- 本机可用结论：**可通过 `auto/degraded` 完成稳定验证**。
+- 目标门禁（真实 VM 混合模式）结论：**仍需在 x86 + /dev/kvm 环境跑 `full/strict` 后再合并**。

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -11,6 +11,29 @@
 | `k8s_nano_internet.py` | `basic/A20_nano_internet` | 小型互联网仿真 |
 | `k8s_mini_internet.py` | `internet/B00_mini_internet` | 完整的小型互联网 |
 | `k8s_multinode_demo.py` | (新增) | 展示多机调度、资源限制等 K8s 高级功能 |
+| `k8s_hybrid_kubevirt_demo.py` | (新增) | 混合部署：KubeVirt 路由器 + 容器节点 |
+
+## 混合模式兼容档位（Runtime Profile）
+
+`k8s_hybrid_kubevirt_demo.py` 与 `scripts/validate_kubevirt_hybrid.sh` 支持通过 `SEED_RUNTIME_PROFILE` 选择兼容模式：
+
+- `auto`（默认）：自动选择；在 `arm64 + 无 /dev/kvm` 时自动降级为容器模式。
+- `full`：强制启用 KubeVirt VM + 容器混合模式。
+- `degraded`：强制全部容器模式（不生成 VM 清单），用于无硬件虚拟化场景。
+- `strict`：要求 VM 模式可用；若平台不满足则直接失败。
+
+示例：
+
+```bash
+# 自动兼容（推荐）
+SEED_RUNTIME_PROFILE=auto PYTHONPATH=../.. python3 k8s_hybrid_kubevirt_demo.py
+
+# 强制混合 VM 模式
+SEED_RUNTIME_PROFILE=full PYTHONPATH=../.. python3 k8s_hybrid_kubevirt_demo.py
+
+# 强制降级容器模式
+SEED_RUNTIME_PROFILE=degraded PYTHONPATH=../.. python3 k8s_hybrid_kubevirt_demo.py
+```
 
 ## 快速开始
 

--- a/examples/kubernetes/k8s_hybrid_kubevirt_demo.py
+++ b/examples/kubernetes/k8s_hybrid_kubevirt_demo.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from typing import Dict, Tuple
+
+from seedemu.layers import Base, Routing, Ebgp
+from seedemu.services import WebService
+from seedemu.compiler import KubernetesCompiler, SchedulingStrategy
+from seedemu.core import Emulator, Binding, Filter
+
+
+VALID_RUNTIME_PROFILES = {"auto", "full", "degraded", "strict"}
+
+
+def _normalize_arch(machine: str) -> str:
+    machine_lower = machine.lower()
+    if machine_lower in {"x86_64", "amd64"}:
+        return "x86_64"
+    if machine_lower in {"aarch64", "arm64"}:
+        return "arm64"
+    return machine_lower
+
+
+def _parse_bool(value: str, default_value: bool) -> bool:
+    if value is None:
+        return default_value
+
+    value_lower = value.strip().lower()
+    if value_lower in {"1", "true", "yes", "on"}:
+        return True
+    if value_lower in {"0", "false", "no", "off"}:
+        return False
+
+    raise ValueError(f"Invalid boolean value: {value}")
+
+
+def detect_host_capabilities() -> Dict[str, object]:
+    detected_arch = _normalize_arch(os.uname().machine)
+    detected_has_kvm = os.path.exists("/dev/kvm")
+
+    return {
+        "arch": _normalize_arch(os.environ.get("SEED_HOST_ARCH", detected_arch)),
+        "has_kvm": _parse_bool(os.environ.get("SEED_HAS_KVM"), detected_has_kvm),
+    }
+
+
+def resolve_runtime_profile(requested_profile: str, capabilities: Dict[str, object]) -> Tuple[str, str]:
+    normalized_requested = requested_profile.lower()
+    if normalized_requested not in VALID_RUNTIME_PROFILES:
+        raise ValueError(
+            f"Invalid SEED_RUNTIME_PROFILE '{requested_profile}'. "
+            f"Supported values: {sorted(VALID_RUNTIME_PROFILES)}"
+        )
+
+    arch = str(capabilities["arch"])
+    has_kvm = bool(capabilities["has_kvm"])
+
+    if normalized_requested == "auto":
+        if arch == "arm64" and not has_kvm:
+            return "degraded", "auto fallback: arm64 host without /dev/kvm"
+        return "full", "auto selected full profile"
+
+    if normalized_requested == "strict":
+        if arch == "arm64" and not has_kvm:
+            raise RuntimeError(
+                "strict profile requires VM mode, but detected arm64 host without /dev/kvm"
+            )
+        return "full", "strict profile enforces VM mode"
+
+    if normalized_requested == "full":
+        return "full", "explicit full profile"
+
+    return "degraded", "explicit degraded profile"
+
+
+def apply_router_profile(as150_router, resolved_profile: str) -> str:
+    virtualization_mode = "KubeVirt" if resolved_profile == "full" else "Container"
+    as150_router.setVirtualizationMode(virtualization_mode)
+    return virtualization_mode
+
+
+def run():
+    cluster_name = os.environ.get("SEED_CLUSTER_NAME", "seedemu-kvtest")
+    namespace = os.environ.get("SEED_NAMESPACE", "seedemu-kvtest")
+    registry_prefix = os.environ.get("SEED_REGISTRY", "localhost:5001")
+    vm_node = os.environ.get("SEED_VM_NODE", f"{cluster_name}-control-plane")
+    worker_a = os.environ.get("SEED_WORKER_A", f"{cluster_name}-worker")
+    worker_b = os.environ.get("SEED_WORKER_B", f"{cluster_name}-worker2")
+
+    requested_runtime_profile = os.environ.get("SEED_RUNTIME_PROFILE", "auto")
+    host_capabilities = detect_host_capabilities()
+    resolved_runtime_profile, profile_reason = resolve_runtime_profile(
+        requested_runtime_profile,
+        host_capabilities,
+    )
+
+    emu = Emulator()
+    base = Base()
+    routing = Routing()
+    ebgp = Ebgp()
+    web = WebService()
+
+    base.createInternetExchange(100)
+
+    as150 = base.createAutonomousSystem(150)
+    as150.createNetwork("net0")
+    as150_router = as150.createRouter("router0").joinNetwork("net0").joinNetwork("ix100")
+    router_virtualization_mode = apply_router_profile(as150_router, resolved_runtime_profile)
+    as150.createHost("web").joinNetwork("net0")
+    web.install("web150")
+    emu.addBinding(Binding("web150", filter=Filter(nodeName="web", asn=150)))
+
+    as151 = base.createAutonomousSystem(151)
+    as151.createNetwork("net0")
+    as151.createRouter("router0").joinNetwork("net0").joinNetwork("ix100")
+    as151.createHost("web").joinNetwork("net0")
+    web.install("web151")
+    emu.addBinding(Binding("web151", filter=Filter(nodeName="web", asn=151)))
+
+    ebgp.addRsPeer(100, 150)
+    ebgp.addRsPeer(100, 151)
+
+    emu.addLayer(base)
+    emu.addLayer(routing)
+    emu.addLayer(ebgp)
+    emu.addLayer(web)
+    emu.render()
+
+    node_labels = {
+        "150_router0": {"kubernetes.io/hostname": vm_node},
+        "150_web": {"kubernetes.io/hostname": worker_a},
+        "151_router0": {"kubernetes.io/hostname": worker_b},
+        "151_web": {"kubernetes.io/hostname": worker_b},
+        "100_ix100": {"kubernetes.io/hostname": worker_a},
+    }
+
+    k8s = KubernetesCompiler(
+        registry_prefix=registry_prefix,
+        namespace=namespace,
+        use_multus=True,
+        internetMapEnabled=False,
+        scheduling_strategy=SchedulingStrategy.CUSTOM,
+        node_labels=node_labels,
+        default_resources={
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+            "limits": {"cpu": "500m", "memory": "1Gi"},
+        },
+        cni_type="bridge",
+        generate_services=True,
+        image_pull_policy="Always",
+    )
+
+    output_dir = os.path.join(os.path.dirname(__file__), "output_kubevirt_hybrid")
+    emu.compile(k8s, output_dir, override=True)
+
+    profile_summary = {
+        "requested_profile": requested_runtime_profile.lower(),
+        "resolved_profile": resolved_runtime_profile,
+        "reason": profile_reason,
+        "host": host_capabilities,
+        "router_virtualization_mode": router_virtualization_mode,
+        "cluster_name": cluster_name,
+        "namespace": namespace,
+    }
+
+    profile_summary_path = os.path.join(output_dir, "runtime_profile.json")
+    with open(profile_summary_path, "w", encoding="utf-8") as profile_file:
+        json.dump(profile_summary, profile_file, indent=2, sort_keys=True)
+
+    print(f"Output directory: {output_dir}")
+    print(f"Namespace: {namespace}")
+    print(f"Runtime profile: {requested_runtime_profile.lower()} -> {resolved_runtime_profile}")
+    print(f"Profile reason: {profile_reason}")
+    print(f"Router virtualization mode: {router_virtualization_mode}")
+    print(f"Profile summary: {profile_summary_path}")
+    print("Next steps:")
+    print(f"  cd {output_dir}")
+    print("  ./build_images.sh")
+    print(f"  kubectl create ns {namespace} --dry-run=client -o yaml | kubectl apply -f -")
+    print("  kubectl apply -f k8s.yaml")
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/validate_kubevirt_hybrid.sh
+++ b/scripts/validate_kubevirt_hybrid.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXAMPLE_DIR="${ROOT_DIR}/examples/kubernetes"
+OUTPUT_DIR="${EXAMPLE_DIR}/output_kubevirt_hybrid"
+CLUSTER_NAME="${SEED_CLUSTER_NAME:-seedemu-kvtest}"
+NAMESPACE="${SEED_NAMESPACE:-seedemu-kvtest}"
+KUBECONTEXT="kind-${CLUSTER_NAME}"
+ARTIFACT_DIR="${ROOT_DIR}/output/kubevirt_validation"
+DEPLOY_WAIT_TIMEOUT="${DEPLOY_WAIT_TIMEOUT:-1200s}"
+VMI_WAIT_TIMEOUT="${VMI_WAIT_TIMEOUT:-480s}"
+BGP_WAIT_TIMEOUT_SECONDS="${BGP_WAIT_TIMEOUT_SECONDS:-300}"
+RUNTIME_PROFILE="${SEED_RUNTIME_PROFILE:-auto}"
+CLEAN_NAMESPACE="${SEED_CLEAN_NAMESPACE:-true}"
+
+mkdir -p "${ARTIFACT_DIR}"
+rm -f "${ARTIFACT_DIR}"/*.txt "${ARTIFACT_DIR}"/*.log "${ARTIFACT_DIR}"/*.json 2>/dev/null || true
+
+collect_failure_diagnostics() {
+    echo ">>> Collecting failure diagnostics"
+    kubectl -n "${NAMESPACE}" get deployment,pods,vm,vmi -o wide > "${ARTIFACT_DIR}/failure_overview.txt" || true
+    kubectl -n "${NAMESPACE}" get events --sort-by=.lastTimestamp > "${ARTIFACT_DIR}/failure_events.txt" || true
+
+    local vmi_name
+    vmi_name="$(kubectl -n "${NAMESPACE}" get vmi -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [ -n "${vmi_name}" ]; then
+        kubectl -n "${NAMESPACE}" describe vmi "${vmi_name}" > "${ARTIFACT_DIR}/failure_vmi_describe.txt" || true
+    fi
+
+    local vm_name
+    vm_name="$(kubectl -n "${NAMESPACE}" get vm -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [ -n "${vm_name}" ]; then
+        kubectl -n "${NAMESPACE}" describe vm "${vm_name}" > "${ARTIFACT_DIR}/failure_vm_describe.txt" || true
+    fi
+
+    local launcher_pod
+    launcher_pod="$(kubectl -n "${NAMESPACE}" get pods -l kubevirt.io=virt-launcher -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [ -n "${launcher_pod}" ]; then
+        kubectl -n "${NAMESPACE}" describe pod "${launcher_pod}" > "${ARTIFACT_DIR}/failure_virt_launcher_pod.txt" || true
+        kubectl -n "${NAMESPACE}" logs "${launcher_pod}" -c compute --tail=200 > "${ARTIFACT_DIR}/failure_virt_launcher_compute.log" || true
+    fi
+
+    kubectl -n kubevirt get pods -o wide > "${ARTIFACT_DIR}/failure_kubevirt_pods.txt" || true
+}
+
+read_profile_summary() {
+    local summary_path="$1"
+    python3 - "$summary_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as profile_file:
+    data = json.load(profile_file)
+
+print(data.get("requested_profile", ""))
+print(data.get("resolved_profile", ""))
+print(data.get("router_virtualization_mode", ""))
+print(data.get("reason", ""))
+PY
+}
+
+echo ">>> Using kube context ${KUBECONTEXT}"
+kubectl config use-context "${KUBECONTEXT}" >/dev/null
+
+NODE_ARCH="$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')"
+HOST_HAS_KVM="false"
+if [ -e /dev/kvm ]; then
+    HOST_HAS_KVM="true"
+fi
+
+if [ "${NODE_ARCH}" = "arm64" ] && [ "${HOST_HAS_KVM}" = "false" ]; then
+    echo ">>> Warning: arm64 host without /dev/kvm detected; auto profile will switch to degraded mode"
+fi
+
+CONTROL_NODE="$(kubectl get nodes --no-headers | awk '$3 ~ /control-plane/ {print $1; exit}')"
+WORKER_A_NODE="$(kubectl get nodes --no-headers | awk '$3 !~ /control-plane/ {print $1; exit}')"
+WORKER_B_NODE="$(kubectl get nodes --no-headers | awk '$3 !~ /control-plane/ {print $1}' | sed -n '2p')"
+
+if [ -z "${CONTROL_NODE}" ] || [ -z "${WORKER_A_NODE}" ]; then
+    echo "Expected at least one control-plane and one worker node" >&2
+    exit 1
+fi
+
+if [ -z "${WORKER_B_NODE}" ]; then
+    WORKER_B_NODE="${CONTROL_NODE}"
+fi
+
+VM_NODE="${WORKER_A_NODE}"
+CONTAINER_NODE_A="${CONTROL_NODE}"
+CONTAINER_NODE_B="${WORKER_B_NODE}"
+
+echo ">>> Compiling hybrid topology with runtime profile '${RUNTIME_PROFILE}'"
+(
+    cd "${EXAMPLE_DIR}" && \
+    SEED_CLUSTER_NAME="${CLUSTER_NAME}" \
+    SEED_NAMESPACE="${NAMESPACE}" \
+    SEED_VM_NODE="${VM_NODE}" \
+    SEED_WORKER_A="${CONTAINER_NODE_A}" \
+    SEED_WORKER_B="${CONTAINER_NODE_B}" \
+    SEED_RUNTIME_PROFILE="${RUNTIME_PROFILE}" \
+    PYTHONPATH=../.. python3 k8s_hybrid_kubevirt_demo.py
+)
+
+MANIFEST_PATH="${OUTPUT_DIR}/k8s.yaml"
+BUILD_SCRIPT_PATH="${OUTPUT_DIR}/build_images.sh"
+PROFILE_SUMMARY_PATH="${OUTPUT_DIR}/runtime_profile.json"
+
+test -f "${MANIFEST_PATH}"
+test -x "${BUILD_SCRIPT_PATH}"
+test -f "${PROFILE_SUMMARY_PATH}"
+
+mapfile -t PROFILE_LINES < <(read_profile_summary "${PROFILE_SUMMARY_PATH}")
+REQUESTED_PROFILE="${PROFILE_LINES[0]}"
+RESOLVED_PROFILE="${PROFILE_LINES[1]}"
+ROUTER_MODE="${PROFILE_LINES[2]}"
+PROFILE_REASON="${PROFILE_LINES[3]}"
+
+if [ "${RESOLVED_PROFILE}" != "full" ] && [ "${RESOLVED_PROFILE}" != "degraded" ]; then
+    echo "Unexpected resolved profile: ${RESOLVED_PROFILE}" >&2
+    exit 1
+fi
+
+if [ "${RESOLVED_PROFILE}" = "full" ]; then
+    EXPECT_VM="true"
+else
+    EXPECT_VM="false"
+fi
+
+echo ">>> Profile resolved: ${REQUESTED_PROFILE} -> ${RESOLVED_PROFILE} (${PROFILE_REASON})"
+echo ">>> Router mode: ${ROUTER_MODE}"
+cp "${PROFILE_SUMMARY_PATH}" "${ARTIFACT_DIR}/runtime_profile.json"
+
+echo ">>> Verifying compiled manifest"
+grep -q '"kind": "Deployment"' "${MANIFEST_PATH}"
+
+if [ "${EXPECT_VM}" = "true" ]; then
+    grep -q '/usr/local/bin/replace_address.sh' "${MANIFEST_PATH}"
+    grep -q '"kind": "VirtualMachine"' "${MANIFEST_PATH}"
+    grep -q 'cloudInitNoCloud' "${MANIFEST_PATH}"
+else
+    if grep -q '"kind": "VirtualMachine"' "${MANIFEST_PATH}"; then
+        echo "Manifest unexpectedly contains VirtualMachine in degraded mode" >&2
+        exit 1
+    fi
+fi
+
+echo ">>> Building and pushing container images"
+(cd "${OUTPUT_DIR}" && ./build_images.sh)
+
+if [ "${CLEAN_NAMESPACE}" = "true" ]; then
+    echo ">>> Recreating namespace ${NAMESPACE} for clean validation"
+    kubectl delete namespace "${NAMESPACE}" --ignore-not-found >/dev/null || true
+    if kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+        kubectl wait --for=delete namespace/"${NAMESPACE}" --timeout=300s || true
+    fi
+fi
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+kubectl -n "${NAMESPACE}" delete -f "${MANIFEST_PATH}" --ignore-not-found >/dev/null || true
+
+echo ">>> Deploying manifest"
+kubectl apply -n "${NAMESPACE}" -f "${MANIFEST_PATH}" >/dev/null
+
+echo ">>> Waiting for workloads"
+if ! kubectl -n "${NAMESPACE}" wait --for=condition=Available --timeout="${DEPLOY_WAIT_TIMEOUT}" deployment --all; then
+    collect_failure_diagnostics
+    echo "Deployment readiness failed" >&2
+    exit 1
+fi
+
+if [ "${EXPECT_VM}" = "true" ]; then
+    if ! kubectl -n "${NAMESPACE}" wait --for=condition=Ready --timeout="${VMI_WAIT_TIMEOUT}" vmi --all; then
+        collect_failure_diagnostics
+        echo "VMI readiness failed" >&2
+        exit 1
+    fi
+else
+    VM_COUNT="$(kubectl -n "${NAMESPACE}" get vm --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+    if [ "${VM_COUNT}" -ne 0 ]; then
+        echo "Expected no VM in degraded mode, but found ${VM_COUNT}" >&2
+        collect_failure_diagnostics
+        exit 1
+    fi
+fi
+
+echo ">>> Verifying cross-node placement"
+NODE_COUNT="$(kubectl -n "${NAMESPACE}" get pods -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' | sort -u | sed '/^$/d' | wc -l)"
+if [ "${NODE_COUNT}" -lt 2 ]; then
+    echo "Expected pods on at least 2 nodes, got ${NODE_COUNT}" >&2
+    exit 1
+fi
+
+WEB150_POD="$(kubectl -n "${NAMESPACE}" get pods -l seedemu.io/name=web,seedemu.io/asn=150 -o jsonpath='{.items[0].metadata.name}')"
+WEB151_POD="$(kubectl -n "${NAMESPACE}" get pods -l seedemu.io/name=web,seedemu.io/asn=151 -o jsonpath='{.items[0].metadata.name}')"
+WEB151_IP="$(kubectl -n "${NAMESPACE}" get pod "${WEB151_POD}" -o jsonpath='{.status.podIP}')"
+
+echo ">>> Connectivity check: ${WEB150_POD} -> ${WEB151_IP}"
+kubectl -n "${NAMESPACE}" exec "${WEB150_POD}" -- ping -c 4 "${WEB151_IP}"
+
+ROUTER151_POD="$(kubectl -n "${NAMESPACE}" get pods -l seedemu.io/name=router0,seedemu.io/asn=151 -o jsonpath='{.items[0].metadata.name}')"
+
+echo ">>> Protocol check: BGP established"
+BGP_DEADLINE=$((SECONDS + BGP_WAIT_TIMEOUT_SECONDS))
+while true; do
+    kubectl -n "${NAMESPACE}" exec "${ROUTER151_POD}" -- birdc s p | tee "${ARTIFACT_DIR}/bird_protocols.txt"
+    if grep -q 'Established' "${ARTIFACT_DIR}/bird_protocols.txt"; then
+        break
+    fi
+
+    if [ "${SECONDS}" -ge "${BGP_DEADLINE}" ]; then
+        echo "BGP did not reach Established within ${BGP_WAIT_TIMEOUT_SECONDS}s" >&2
+        collect_failure_diagnostics
+        exit 1
+    fi
+
+    sleep 5
+    echo ">>> BGP not Established yet, retrying..."
+done
+
+echo ">>> Self-healing check"
+WEB151_DEPLOYMENT="$(kubectl -n "${NAMESPACE}" get pod "${WEB151_POD}" -o jsonpath='{.metadata.labels.app}')"
+kubectl -n "${NAMESPACE}" delete pod "${WEB151_POD}" >/dev/null
+kubectl -n "${NAMESPACE}" rollout status deployment/"${WEB151_DEPLOYMENT}" --timeout=600s
+
+echo ">>> Capturing evidence"
+kubectl -n "${NAMESPACE}" get pods -o wide > "${ARTIFACT_DIR}/pods_wide.txt"
+kubectl -n "${NAMESPACE}" get deployment -o wide > "${ARTIFACT_DIR}/deployments_wide.txt"
+kubectl -n "${NAMESPACE}" get vm,vmi > "${ARTIFACT_DIR}/vm_vmi.txt" 2>/dev/null || true
+kubectl -n "${NAMESPACE}" get svc > "${ARTIFACT_DIR}/services.txt" 2>/dev/null || true
+
+echo ">>> Validation completed successfully"
+echo ">>> Evidence saved under ${ARTIFACT_DIR}"

--- a/seedemu/compiler/Kubernetes.py
+++ b/seedemu/compiler/Kubernetes.py
@@ -9,6 +9,7 @@ from hashlib import md5
 from os import mkdir, chdir
 import json
 import os
+import yaml
 
 
 class SchedulingStrategy:
@@ -210,7 +211,7 @@ spec:
         return manifest
 
     def _compileNodeK8s(self, node: Node) -> str:
-        """Compile a node to Kubernetes Deployment manifest.
+        """Compile a node to Kubernetes Deployment manifest or KubeVirt VirtualMachine.
         
         Includes:
         - Scheduling constraints (nodeSelector based on strategy)
@@ -219,6 +220,27 @@ spec:
         - Optional Service generation
         """
         self._current_node = node
+
+        # Check virtualization mode
+        if node.getVirtualizationMode() == "KubeVirt":
+            result = self._compileNodeKubeVirt(node)
+
+            if self.__generate_services:
+                node_name = self._getComposeNodeName(node).replace('_', '-').lower()
+                asn = str(node.getAsn())
+                role = self._nodeRoleToString(node.getRole())
+                labels = {
+                    "app": node_name,
+                    "seedemu.io/asn": asn,
+                    "seedemu.io/role": role,
+                    "seedemu.io/name": node.getName(),
+                    "kubevirt.io/domain": node_name
+                }
+                service = self._compileServiceK8s(node, node_name, labels)
+                if service:
+                    result += "\n---\n" + service
+
+            return result
 
         # 1. Prepare Docker build context (reuse logic from Docker compiler)
         real_nodename = self._getRealNodeName(node)
@@ -403,6 +425,179 @@ spec:
         
         return json.dumps(service)
 
+    def _compileNodeKubeVirt(self, node: Node) -> str:
+        """Compile a node to KubeVirt VirtualMachine manifest."""
+        node_name = self._getComposeNodeName(node).replace('_', '-').lower()
+        asn = str(node.getAsn())
+        role = self._nodeRoleToString(node.getRole())
+
+        self._assertKubeVirtCompatibility(node)
+
+        # 1. Build Cloud-Init User Data
+        user_data = {
+            "packages": list(node.getSoftware()),
+            "write_files": [],
+            "runcmd": []
+        }
+
+        # Add files
+        for f in node.getFiles():
+            path, content = f.get()
+            user_data["write_files"].append({
+                "path": path,
+                "content": content,
+                "permissions": "0644"
+            })
+
+        # Generate and add replace_address.sh (Address Hack)
+        # For VMs, interfaces are eth1, eth2... (eth0 is mgmt)
+        address_script = self._generateK8sAddressScript(interface_prefix="eth")
+        user_data["write_files"].append({
+            "path": "/usr/local/bin/replace_address.sh",
+            "content": address_script,
+            "permissions": "0755"
+        })
+        user_data["runcmd"].append(["/usr/local/bin/replace_address.sh"])
+
+        for command in node.getBuildCommands():
+            user_data["runcmd"].append(self._toCloudInitRunCommand(command, False))
+
+        for command in node.getBuildCommandsAtEnd():
+            user_data["runcmd"].append(self._toCloudInitRunCommand(command, False))
+
+        # Add start commands
+        for cmd, fork in node.getStartCommands():
+            user_data["runcmd"].append(self._toCloudInitRunCommand(cmd, fork))
+
+        for cmd, fork in node.getPostConfigCommands():
+            user_data["runcmd"].append(self._toCloudInitRunCommand(cmd, fork))
+
+        cloud_init_yaml = "#cloud-config\n" + yaml.dump(user_data)
+
+        # 2. Network Configuration
+        networks = [{"name": "default", "pod": {}}]
+        interfaces = [{"name": "default", "masquerade": {}}]
+
+        for i, iface in enumerate(node.getInterfaces()):
+            net = iface.getNet()
+            net_name = self._getRealNetName(net).replace('_', '-').lower()
+
+            networks.append({
+                "name": f"net{i+1}",
+                "multus": {"networkName": net_name}
+            })
+            interfaces.append({
+                "name": f"net{i+1}",
+                "bridge": {}
+            })
+
+        # 3. Build Manifest
+        labels = {
+            "app": node_name,
+            "seedemu.io/asn": asn,
+            "seedemu.io/role": role,
+            "seedemu.io/name": node.getName(),
+            "kubevirt.io/domain": node_name
+        }
+
+        # Default base image (Ubuntu 22.04)
+        # TODO: Make this configurable via options
+        container_disk_image = "quay.io/containerdisks/ubuntu:22.04"
+        cloud_init_secret_name = f"{node_name.replace('.', '-')}-cloudinit"
+
+        cloud_init_secret = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": cloud_init_secret_name,
+                "namespace": self.__namespace,
+                "labels": labels
+            },
+            "type": "Opaque",
+            "stringData": {
+                "userdata": cloud_init_yaml
+            }
+        }
+
+        manifest = {
+            "apiVersion": "kubevirt.io/v1",
+            "kind": "VirtualMachine",
+            "metadata": {
+                "name": node_name,
+                "namespace": self.__namespace,
+                "labels": labels
+            },
+            "spec": {
+                "runStrategy": "Always",
+                "template": {
+                    "metadata": {
+                        "labels": labels
+                    },
+                    "spec": {
+                        "domain": {
+                            "devices": {
+                                "disks": [
+                                    {"name": "containerdisk", "disk": {"bus": "virtio"}},
+                                    {"name": "cloudinitdisk", "disk": {"bus": "virtio"}}
+                                ],
+                                "interfaces": interfaces
+                            },
+                            "resources": {
+                                "requests": {"memory": "512M"},
+                                "limits": {"memory": "1024M"}
+                            }
+                        },
+                        "networks": networks,
+                        "volumes": [
+                            {
+                                "name": "containerdisk",
+                                "containerDisk": {"image": container_disk_image}
+                            },
+                            {
+                                "name": "cloudinitdisk",
+                                "cloudInitNoCloud": {
+                                    "secretRef": {
+                                        "name": cloud_init_secret_name
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+
+        # Add scheduling constraints
+        node_selector = self._computeNodeSelector(node, asn, role)
+        if node_selector:
+            manifest["spec"]["template"]["spec"]["nodeSelector"] = node_selector
+
+        return json.dumps(cloud_init_secret) + "\n---\n" + json.dumps(manifest)
+
+    def _assertKubeVirtCompatibility(self, node: Node) -> None:
+        unsupported_features: List[str] = []
+
+        if node.getImportedFiles():
+            unsupported_features.append("imported files")
+        if node.getDockerCommands():
+            unsupported_features.append("docker commands")
+        if node.getDockerVolumes():
+            unsupported_features.append("docker volumes")
+
+        runtime_options = list(node.getScopedRuntimeOptions())
+        if runtime_options:
+            unsupported_features.append("runtime options")
+
+        if unsupported_features:
+            unsupported_list = ", ".join(unsupported_features)
+            raise AssertionError(
+                f"Node as{node.getAsn()}/{node.getName()} in KubeVirt mode has unsupported features: {unsupported_list}"
+            )
+
+    def _toCloudInitRunCommand(self, command: str, fork: bool) -> List[str]:
+        command_value = f"{command} &" if fork else command
+        return ["sh", "-c", command_value]
+
     def _addFile(self, path: str, content: str) -> str:
         """Override _addFile to intercept the replacement script generation."""
         if path == '/replace_address.sh' and self.__use_multus and self._current_node:
@@ -410,18 +605,18 @@ spec:
             content = self._generateK8sAddressScript()
         return super()._addFile(path, content)
 
-    def _generateK8sAddressScript(self) -> str:
+    def _generateK8sAddressScript(self, interface_prefix: str = "net") -> str:
         """
         Generates a script to configure IPs on Multus interfaces.
-        Multus interfaces are usually named net1, net2... in the order they appear in the annotation.
+        Multus interfaces are usually named net1, net2... (default) or eth1, eth2... (VMs)
         """
         node = self._current_node
         script = "#!/bin/bash\n"
         script += "# K8s Address Replacement\n"
 
         for i, iface in enumerate(node.getInterfaces()):
-            # Interface names: net1, net2... (1-based index usually)
-            dev_name = f"net{i+1}"
+            # Interface names: net1, net2... or eth1, eth2... (1-based index)
+            dev_name = f"{interface_prefix}{i+1}"
             addr = iface.getAddress()
             prefix_len = iface.getNet().getPrefix().prefixlen
 

--- a/seedemu/compiler/__init__.py
+++ b/seedemu/compiler/__init__.py
@@ -1,7 +1,7 @@
 from .DockerImage import DockerImage
 from .DockerImageConstant import *
 from .Docker import Docker
-from .Kubernetes import KubernetesCompiler
+from .Kubernetes import KubernetesCompiler, SchedulingStrategy
 # Disable the compilers options
 from .DistributedDocker import DistributedDocker
 from .Graphviz import Graphviz

--- a/seedemu/core/Node.py
+++ b/seedemu/core/Node.py
@@ -239,6 +239,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
 
     __geo: Tuple[float,float,str] # (Latitude,Longitude,Address) -- optional parameter that contains the geographical location of the Node
     __note: str # optional parameter that contains a note about the Node
+    __virtualization_mode: str # "Container" (default) or "KubeVirt"
 
     def __init__(self, name: str, role: NodeRole, asn: int, scope: str = None):
         """!
@@ -251,6 +252,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         """
         super().__init__()
 
+        self.__virtualization_mode = "Container"
         self.__interfaces = []
         self.__files = {}
         self.__imported_files = {}
@@ -1000,6 +1002,25 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         """
         return self.__note
 
+    def setVirtualizationMode(self, mode: str) -> Node:
+        """!
+        @brief Set the virtualization mode for this node.
+
+        @param mode "Container" (default) or "KubeVirt".
+        @returns self, for chaining API calls.
+        """
+        assert mode in ["Container", "KubeVirt"], "Invalid virtualization mode. Must be 'Container' or 'KubeVirt'."
+        self.__virtualization_mode = mode
+        return self
+
+    def getVirtualizationMode(self) -> str:
+        """!
+        @brief Get the virtualization mode.
+
+        @returns "Container" or "KubeVirt".
+        """
+        return self.__virtualization_mode
+
     def copySettings(self, node: Node):
         """!
         @brief copy settings from another node.
@@ -1021,6 +1042,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         for (h, n, p) in node.getPorts(): self.addPort(h, n, p)
         for v in node.getDockerVolumes(): self.addDockerVolume(v)
         for (c, f) in node.getStartCommands(): self.appendStartCommand(c, f)
+        self.setVirtualizationMode(node.getVirtualizationMode())
         # for (c, f) in node.getUserStartCommands(): self.appendUserStartCommand(c, f)
         for c in node.getBuildCommands(): self.addBuildCommand(c)
         for s in node.getSoftware(): self.addSoftware(s)
@@ -1472,4 +1494,3 @@ def promote_to_scion_router(node: Node):
         extn.initScionRouter()
         node.installExtension(extn)
     return node
-

--- a/setup_kubevirt_cluster.sh
+++ b/setup_kubevirt_cluster.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME="${SEED_CLUSTER_NAME:-seedemu-kvtest}"
+REGISTRY_NAME="${REGISTRY_NAME:-kind-registry}"
+REGISTRY_PORT="${REGISTRY_PORT:-5001}"
+KIND_VERSION="${KIND_VERSION:-v0.27.0}"
+K8S_NODE_IMAGE="${K8S_NODE_IMAGE:-kindest/node:v1.32.2}"
+WORKER_COUNT="${WORKER_COUNT:-2}"
+MULTUS_VERSION="${MULTUS_VERSION:-v4.1.0}"
+KUBEVIRT_VERSION="${KUBEVIRT_VERSION:-v1.7.0}"
+CNI_PLUGINS_VERSION="${CNI_PLUGINS_VERSION:-v1.8.0}"
+
+MULTUS_MANIFEST_URL="https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/${MULTUS_VERSION}/deployments/multus-daemonset-thick.yml"
+KUBEVIRT_OPERATOR_URL="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
+KUBEVIRT_CR_URL="https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml"
+
+kind_arch=""
+cni_arch=""
+
+resolve_arch() {
+    case "$(uname -m)" in
+        x86_64)
+            kind_arch="amd64"
+            cni_arch="amd64"
+            ;;
+        aarch64|arm64)
+            kind_arch="arm64"
+            cni_arch="arm64"
+            ;;
+        *)
+            echo "Unsupported architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+install_kind_if_missing() {
+    if command -v kind >/dev/null 2>&1; then
+        return
+    fi
+
+    echo ">>> Installing kind ${KIND_VERSION}"
+    curl -fsSL -o ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${kind_arch}"
+    chmod +x ./kind
+
+    if command -v sudo >/dev/null 2>&1; then
+        sudo mv ./kind /usr/local/bin/kind
+    else
+        mv ./kind /usr/local/bin/kind
+    fi
+}
+
+ensure_local_registry() {
+    if [ "$(docker inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || true)" != 'true' ]; then
+        echo ">>> Creating local registry ${REGISTRY_NAME}:${REGISTRY_PORT}"
+        docker run -d --restart=always -p "127.0.0.1:${REGISTRY_PORT}:5000" --name "${REGISTRY_NAME}" registry:2 >/dev/null
+    else
+        echo ">>> Registry ${REGISTRY_NAME} already running"
+    fi
+}
+
+create_kind_cluster_if_needed() {
+    if kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+        echo ">>> Cluster ${CLUSTER_NAME} already exists"
+        return
+    fi
+
+    echo ">>> Creating kind cluster ${CLUSTER_NAME} with ${K8S_NODE_IMAGE}"
+    {
+    cat <<KINDCFG
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
+    endpoint = ["http://${REGISTRY_NAME}:5000"]
+nodes:
+- role: control-plane
+  image: ${K8S_NODE_IMAGE}
+KINDCFG
+    for _ in $(seq 1 "${WORKER_COUNT}"); do
+        cat <<KINDCFG
+- role: worker
+  image: ${K8S_NODE_IMAGE}
+KINDCFG
+    done
+    } | kind create cluster --name "${CLUSTER_NAME}" --config=-
+}
+
+ensure_registry_network_connectivity() {
+    if [ "$(docker inspect -f '{{json .NetworkSettings.Networks.kind}}' "${REGISTRY_NAME}")" = 'null' ]; then
+        docker network connect kind "${REGISTRY_NAME}"
+    fi
+}
+
+ensure_cni_plugins_for_multus() {
+    local nodes
+    nodes="$(kind get nodes --name "${CLUSTER_NAME}")"
+
+    if [ -z "${nodes}" ]; then
+        echo "Failed to discover kind nodes for ${CLUSTER_NAME}" >&2
+        exit 1
+    fi
+
+    local first_node
+    first_node="$(printf '%s\n' "${nodes}" | head -n 1)"
+
+    if docker exec "${first_node}" test -x /opt/cni/bin/bridge; then
+        echo ">>> CNI bridge plugin already present on kind nodes"
+        return
+    fi
+
+    echo ">>> Installing CNI bridge plugin ${CNI_PLUGINS_VERSION} into kind nodes"
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "${tmpdir}"' RETURN
+
+    local archive_name
+    archive_name="cni-plugins-linux-${cni_arch}-${CNI_PLUGINS_VERSION}.tgz"
+
+    curl -fsSL -o "${tmpdir}/${archive_name}" "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/${archive_name}"
+    tar -xzf "${tmpdir}/${archive_name}" -C "${tmpdir}"
+
+    local plugin
+    for plugin in bridge tuning macvlan vlan; do
+        if [ ! -f "${tmpdir}/${plugin}" ]; then
+            echo "Missing plugin binary in archive: ${plugin}" >&2
+            exit 1
+        fi
+    done
+
+    local node
+    while IFS= read -r node; do
+        [ -z "${node}" ] && continue
+        docker cp "${tmpdir}/bridge" "${node}:/opt/cni/bin/bridge"
+        docker cp "${tmpdir}/tuning" "${node}:/opt/cni/bin/tuning"
+        docker cp "${tmpdir}/macvlan" "${node}:/opt/cni/bin/macvlan"
+        docker cp "${tmpdir}/vlan" "${node}:/opt/cni/bin/vlan"
+        docker exec "${node}" chmod +x /opt/cni/bin/bridge /opt/cni/bin/tuning /opt/cni/bin/macvlan /opt/cni/bin/vlan
+    done <<< "${nodes}"
+
+    trap - RETURN
+    rm -rf "${tmpdir}"
+}
+
+install_multus() {
+    echo ">>> Installing Multus ${MULTUS_VERSION}"
+    kubectl apply -f "${MULTUS_MANIFEST_URL}" >/dev/null
+    kubectl -n kube-system rollout status daemonset/kube-multus-ds --timeout=300s
+}
+
+install_kubevirt() {
+    echo ">>> Installing KubeVirt ${KUBEVIRT_VERSION}"
+    kubectl apply -f "${KUBEVIRT_OPERATOR_URL}" >/dev/null
+    kubectl -n kubevirt rollout status deployment/virt-operator --timeout=600s
+    kubectl apply -f "${KUBEVIRT_CR_URL}" >/dev/null
+
+    until kubectl -n kubevirt get kubevirt kubevirt >/dev/null 2>&1; do
+        sleep 2
+    done
+
+    local virt_support
+    virt_support="$(egrep -c '(vmx|svm)' /proc/cpuinfo || true)"
+    if [ "${virt_support}" -eq 0 ] || [ ! -e /dev/kvm ]; then
+        echo ">>> Hardware virtualization unavailable, enabling KubeVirt software emulation"
+        kubectl -n kubevirt patch kubevirt kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"useEmulation":true}}}}' >/dev/null
+    fi
+
+    kubectl -n kubevirt wait --for=condition=Available --timeout=900s kubevirt/kubevirt
+    kubectl -n kubevirt rollout status deployment/virt-api --timeout=600s
+    kubectl -n kubevirt rollout status deployment/virt-controller --timeout=600s
+    if ! kubectl -n kubevirt rollout status daemonset/virt-handler --timeout=600s; then
+        kubectl -n kubevirt get pods -o wide
+        kubectl -n kubevirt logs -l kubevirt.io=virt-handler --tail=50 || true
+        echo "virt-handler rollout failed. If this host has low inotify limits, retry with WORKER_COUNT=1." >&2
+        exit 1
+    fi
+}
+
+validate_registry_pull_chain() {
+    echo ">>> Validating registry pull chain"
+    local registry_check_image
+    registry_check_image="localhost:${REGISTRY_PORT}/seedemu/registry-check:latest"
+
+    docker pull --quiet busybox:1.36 >/dev/null
+    docker tag busybox:1.36 "${registry_check_image}"
+    docker push "${registry_check_image}" >/dev/null
+
+    kubectl -n kube-system delete pod registry-self-check --ignore-not-found >/dev/null
+    kubectl -n kube-system run registry-self-check --image="${registry_check_image}" --restart=Never --command -- sh -c 'echo registry-ok' >/dev/null
+    kubectl -n kube-system wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=180s pod/registry-self-check
+    kubectl -n kube-system logs pod/registry-self-check
+    kubectl -n kube-system delete pod registry-self-check --ignore-not-found >/dev/null
+}
+
+write_local_registry_configmap() {
+    cat <<CFG | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${REGISTRY_PORT}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+CFG
+}
+
+echo ">>> Starting SEED Emulator Kind + Multus + KubeVirt setup"
+
+command -v docker >/dev/null 2>&1 || { echo "Docker is required." >&2; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is required." >&2; exit 1; }
+
+resolve_arch
+install_kind_if_missing
+ensure_local_registry
+create_kind_cluster_if_needed
+ensure_registry_network_connectivity
+
+kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+kubectl taint nodes -l node-role.kubernetes.io/control-plane node-role.kubernetes.io/control-plane:NoSchedule- >/dev/null 2>&1 || true
+write_local_registry_configmap
+
+ensure_cni_plugins_for_multus
+install_multus
+install_kubevirt
+validate_registry_pull_chain
+
+echo ">>> Setup complete"
+kubectl get nodes -o wide
+kubectl -n kube-system get pods -l name=multus
+kubectl -n kubevirt get pods

--- a/tests/kubevirt_compiler_test.py
+++ b/tests/kubevirt_compiler_test.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+import yaml
+
+from seedemu.compiler import KubernetesCompiler
+from seedemu.core import Emulator, Binding, Filter, Node
+from seedemu.core.enums import NodeRole
+from seedemu.layers import Base, Routing, Ebgp
+from seedemu.services import WebService
+
+
+class KubeVirtCompilerTest(unittest.TestCase):
+    def _build_emulator(self, include_extra_commands: bool = False) -> Emulator:
+        emulator = Emulator()
+        base = Base()
+        routing = Routing()
+        ebgp = Ebgp()
+        web = WebService()
+
+        base.createInternetExchange(100)
+
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        router150 = as150.createRouter("router0").joinNetwork("net0").joinNetwork("ix100")
+        router150.setVirtualizationMode("KubeVirt")
+        if include_extra_commands:
+            router150.appendStartCommand("sleep 5", True)
+            router150.appendStartCommand(
+                "echo post-config > /tmp/post-config",
+                isPostConfigCommand=True,
+            )
+
+        as150.createHost("web").joinNetwork("net0")
+        web.install("web150")
+        emulator.addBinding(Binding("web150", filter=Filter(nodeName="web", asn=150)))
+
+        as151 = base.createAutonomousSystem(151)
+        as151.createNetwork("net0")
+        as151.createRouter("router0").joinNetwork("net0").joinNetwork("ix100")
+        as151.createHost("web").joinNetwork("net0")
+        web.install("web151")
+        emulator.addBinding(Binding("web151", filter=Filter(nodeName="web", asn=151)))
+
+        ebgp.addRsPeer(100, 150)
+        ebgp.addRsPeer(100, 151)
+
+        emulator.addLayer(base)
+        emulator.addLayer(routing)
+        emulator.addLayer(ebgp)
+        emulator.addLayer(web)
+        emulator.render()
+
+        return emulator
+
+    def _compile_and_read_manifest(self, emulator: Emulator) -> str:
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            compiler = KubernetesCompiler(
+                registry_prefix="",
+                namespace="seedemu-test",
+                use_multus=True,
+                internetMapEnabled=False,
+                image_pull_policy="IfNotPresent",
+            )
+            try:
+                emulator.compile(compiler, tmp_dir, override=True)
+            finally:
+                os.chdir(original_cwd)
+
+            manifest_path = os.path.join(tmp_dir, "k8s.yaml")
+            with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+                return manifest_file.read()
+
+    def _extract_vm_manifest(self, manifest_text: str) -> dict:
+        for document in manifest_text.split("\n---\n"):
+            stripped = document.strip()
+            if not stripped.startswith("{"):
+                continue
+
+            parsed = json.loads(stripped)
+            if parsed.get("kind") == "VirtualMachine":
+                return parsed
+
+        raise AssertionError("VirtualMachine manifest not found")
+
+    def _extract_cloud_init(self, manifest_text: str, vm_manifest: dict) -> dict:
+        volumes = vm_manifest["spec"]["template"]["spec"]["volumes"]
+        secret_name = None
+        for volume in volumes:
+            if volume.get("name") == "cloudinitdisk":
+                secret_name = volume["cloudInitNoCloud"]["secretRef"]["name"]
+                break
+
+        if not secret_name:
+            raise AssertionError("cloudinitdisk volume not found")
+
+        for document in manifest_text.split("\n---\n"):
+            stripped = document.strip()
+            if not stripped.startswith("{"):
+                continue
+
+            parsed = json.loads(stripped)
+            if parsed.get("kind") != "Secret":
+                continue
+
+            if parsed["metadata"].get("name") != secret_name:
+                continue
+
+            cloud_init_text = parsed["stringData"]["userdata"]
+            return yaml.safe_load(cloud_init_text.replace("#cloud-config\n", "", 1))
+
+        raise AssertionError("cloud-init secret not found")
+
+    def test_hybrid_output_contains_deployment_and_vm(self):
+        emulator = self._build_emulator()
+        manifest_text = self._compile_and_read_manifest(emulator)
+
+        self.assertIn('"kind": "Deployment"', manifest_text)
+        self.assertIn('"kind": "VirtualMachine"', manifest_text)
+
+    def test_cloud_init_includes_fork_and_post_config_commands(self):
+        emulator = self._build_emulator(include_extra_commands=True)
+        manifest_text = self._compile_and_read_manifest(emulator)
+        vm_manifest = self._extract_vm_manifest(manifest_text)
+        cloud_init = self._extract_cloud_init(manifest_text, vm_manifest)
+
+        self.assertEqual(vm_manifest["spec"]["runStrategy"], "Always")
+        self.assertIn(["/usr/local/bin/replace_address.sh"], cloud_init["runcmd"])
+        self.assertIn(["sh", "-c", "sleep 5 &"], cloud_init["runcmd"])
+        self.assertIn(["sh", "-c", "echo post-config > /tmp/post-config"], cloud_init["runcmd"])
+
+    def test_unsupported_import_file_fails_fast_for_kubevirt(self):
+        emulator = self._build_emulator()
+        base_layer = emulator.getLayer("Base")
+        router150 = base_layer.getAutonomousSystem(150).getRouter("router0")
+        temporary_file = tempfile.NamedTemporaryFile("w", delete=False)
+        temporary_file.write("unsupported")
+        temporary_file.close()
+        router150.importFile(temporary_file.name, "/tmp/unsupported")
+        original_cwd = os.getcwd()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            compiler = KubernetesCompiler(
+                registry_prefix="",
+                namespace="seedemu-test",
+                use_multus=True,
+                internetMapEnabled=False,
+                image_pull_policy="IfNotPresent",
+            )
+            with self.assertRaises(AssertionError):
+                try:
+                    emulator.compile(compiler, tmp_dir, override=True)
+                finally:
+                    os.chdir(original_cwd)
+
+        os.unlink(temporary_file.name)
+
+    def test_copy_settings_preserves_virtualization_mode(self):
+        source_node = Node("source", NodeRole.Host, 150)
+        target_node = Node("target", NodeRole.Host, 150)
+
+        source_node.setVirtualizationMode("KubeVirt")
+        target_node.copySettings(source_node)
+
+        self.assertEqual(target_node.getVirtualizationMode(), "KubeVirt")
+
+
+class KubeVirtRuntimeProfileTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        hybrid_script = Path(__file__).resolve().parents[1] / "examples" / "kubernetes" / "k8s_hybrid_kubevirt_demo.py"
+        spec = importlib.util.spec_from_file_location("k8s_hybrid_kubevirt_demo", hybrid_script)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("Failed to load k8s_hybrid_kubevirt_demo module")
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        cls.hybrid_module = module
+
+    def test_auto_profile_degrades_on_arm_without_kvm(self):
+        profile, reason = self.hybrid_module.resolve_runtime_profile(
+            "auto",
+            {"arch": "arm64", "has_kvm": False},
+        )
+        self.assertEqual(profile, "degraded")
+        self.assertIn("arm64", reason)
+
+    def test_auto_profile_full_on_x86_without_kvm(self):
+        profile, reason = self.hybrid_module.resolve_runtime_profile(
+            "auto",
+            {"arch": "x86_64", "has_kvm": False},
+        )
+        self.assertEqual(profile, "full")
+        self.assertIn("auto", reason)
+
+    def test_strict_profile_rejects_arm_without_kvm(self):
+        with self.assertRaises(RuntimeError):
+            self.hybrid_module.resolve_runtime_profile(
+                "strict",
+                {"arch": "arm64", "has_kvm": False},
+            )
+
+    def test_apply_router_profile_switches_mode(self):
+        router = Node("router0", NodeRole.Router, 150)
+
+        mode_degraded = self.hybrid_module.apply_router_profile(router, "degraded")
+        self.assertEqual(mode_degraded, "Container")
+        self.assertEqual(router.getVirtualizationMode(), "Container")
+
+        mode_full = self.hybrid_module.apply_router_profile(router, "full")
+        self.assertEqual(mode_full, "KubeVirt")
+        self.assertEqual(router.getVirtualizationMode(), "KubeVirt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR hardens SEED's Kubernetes/KubeVirt hybrid workflow for real multi-node cluster validation and keeps behavior consistent across container and VM paths.

## What this PR changes
- Fixes KubeVirt compiler command flow so VM cloud-init includes:
  - start commands with `fork=True` translated to explicit background execution
  - post-config commands (parity with existing container path)
- Adds explicit compatibility guardrails for unsupported KubeVirt-node features (fail fast instead of silent drop).
- Ensures `virtualization_mode` is propagated in `Node.copySettings()` for virtual/physical binding scenarios.
- Exports `SchedulingStrategy` from compiler package for stable public import behavior.
- Adds a platform-neutral cluster bootstrap script:
  - Kind pinned to `kindest/node:v1.32.2`
  - Multus pinned to versioned manifest
  - KubeVirt pinned to `v1.7.0`
  - auto-enable `useEmulation=true` when `/dev/kvm` is unavailable
  - registry pull-chain validation included
- Adds hybrid demo + validator workflow with runtime profiles (`auto/full/degraded/strict`) to support:
  - WSL2 x86
  - Linux x86
  - Linux arm64
- Adds focused tests for compiler behavior and runtime-profile decisions.

## Validation
### Unit tests
- `PYTHONPATH=. python3 tests/kubevirt_compiler_test.py -v`
- Result: 8 tests passed (compiler behavior + runtime-profile logic).

### Cluster validation (arm64 host)
- Executed hybrid validation in `auto` profile on arm64 host without `/dev/kvm`.
- Profile resolved to degraded mode as designed.
- Validation script covered:
  - manifest checks
  - multi-node placement checks
  - cross-node connectivity checks
  - BGP `Established` checks
  - self-healing check after workload deletion

## Compatibility and risk
- Existing container-only Kubernetes behavior is preserved.
- No additional public API expansion in this PR beyond already introduced virtualization mode accessors.
- Runtime-profile fallback reduces failure risk on environments without hardware virtualization.

## Target branch
- Base: `upstream/k8s`
- Head: `<your-fork-branch>`
