### PR TITLE
Major revision of Ethereum service: Separate the PoSNode into beacon, beaconsetup, geth, and validator nodes.

### DIFF
--- a/examples/blockchain/R00_ethereum_pos_test/ethereum_pos.py
+++ b/examples/blockchain/R00_ethereum_pos_test/ethereum_pos.py
@@ -12,14 +12,14 @@ script_name = os.path.basename(__file__)
 
 if len(sys.argv) < 2:
     print(f"Usage:  {script_name} <total_number_of_eth_nodes> [amd|arm]")
-    # sys.exit(1)
+    sys.exit(1)
 
-# Read total number of Ethereum nodes from the command line argument
-# try:
-#     total_number_of_nodes = int(sys.argv[1])
-# except ValueError:
-#     print(f"Invalid number of Ethereum nodes: {sys.argv[1]}")
-#     sys.exit(1)
+# Read total number of Ethereum beaconnodes from the command line argument
+try:
+    total_number_of_beaconnodes = int(sys.argv[1])
+except ValueError:
+    print(f"Invalid number of Ethereum beaconnodes: {sys.argv[1]}")
+    sys.exit(1)
 
 # Optional platform argument
 if len(sys.argv) == 3:
@@ -28,15 +28,20 @@ if len(sys.argv) == 3:
     elif sys.argv[2].lower() == 'arm':
         platform = Platform.ARM64
     else:
-        print(f"Usage:  {script_name} <total_number_of_eth_nodes> amd|arm")
+        print(f"Usage:  {script_name} <total_number_of_eth_beaconnodes> amd|arm")
         sys.exit(1)
 else:
     platform = Platform.AMD64  # Default platform is AMD64
 
 
+geth_node_number = total_number_of_beaconnodes
+beacon_node_number = total_number_of_beaconnodes
+vc_node_number = 3 * total_number_of_beaconnodes
+beaconsetup_node_number = 1
+
+total_number_of_nodes = geth_node_number + beacon_node_number + vc_node_number + beaconsetup_node_number
 
 
-total_number_of_nodes=350
 # Calculate how many hosts per stub AS are needed
 # We know we have 10 stub AS (150-154, 160-164), and at least one node per AS is required
 # to host a node (Beacon or Ethereum node).
@@ -70,14 +75,7 @@ for i in range(accounts_total):
 asns = [150, 151, 152, 153, 154, 160, 161, 162, 163, 164]
 
 ###################################################
-# Ethereum GethNode
-# geth_nodes_assigned = 0  # To track the number of Ethereum nodes assigned
-beaconsetup_node_number=1
 
-
-geth_node_number=100
-beacon_node_number=100
-vc_node_number=100
 
 
 

--- a/examples/blockchain/R00_ethereum_pos_test/ethereum_pos.py
+++ b/examples/blockchain/R00_ethereum_pos_test/ethereum_pos.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+from seedemu import *
+import sys, os
+import math, json
+from eth_account import Account
+
+###############################################################################
+# Set the platform information
+script_name = os.path.basename(__file__)
+
+if len(sys.argv) < 2:
+    print(f"Usage:  {script_name} <total_number_of_eth_nodes> [amd|arm]")
+    # sys.exit(1)
+
+# Read total number of Ethereum nodes from the command line argument
+# try:
+#     total_number_of_nodes = int(sys.argv[1])
+# except ValueError:
+#     print(f"Invalid number of Ethereum nodes: {sys.argv[1]}")
+#     sys.exit(1)
+
+# Optional platform argument
+if len(sys.argv) == 3:
+    if sys.argv[2].lower() == 'amd':
+        platform = Platform.AMD64
+    elif sys.argv[2].lower() == 'arm':
+        platform = Platform.ARM64
+    else:
+        print(f"Usage:  {script_name} <total_number_of_eth_nodes> amd|arm")
+        sys.exit(1)
+else:
+    platform = Platform.AMD64  # Default platform is AMD64
+
+
+
+
+total_number_of_nodes=350
+# Calculate how many hosts per stub AS are needed
+# We know we have 10 stub AS (150-154, 160-164), and at least one node per AS is required
+# to host a node (Beacon or Ethereum node).
+total_stub_as = 10  # We have 10 ASNs available
+hosts_per_stub_as = math.ceil(total_number_of_nodes / total_stub_as)
+
+# Create Emulator Base with the calculated number of hosts per stub AS
+emu = Makers.makeEmulatorBaseWith10StubASAndHosts(hosts_per_stub_as=hosts_per_stub_as)
+
+print(f"Number of eth nodes per stub AS: {hosts_per_stub_as}")
+
+# Create the Ethereum layer
+eth = EthereumService()
+###  ethserevice -> blockchain -> ethserver (gethserver/beaconserver/beaconsetup)
+# Create the Blockchain layer which is a sub-layer of Ethereum layer. 说明是pos子类
+blockchain = eth.createBlockchain(chainName="pos", consensus=ConsensusMechanism.POS)
+
+
+
+
+# Generate a list of accounts and prefund them
+accounts_total  = 1000
+pre_funded_amount = 1000000
+mnemonic = "gentle always fun glass foster produce north tail security list example gain"
+Account.enable_unaudited_hdwallet_features()
+for i in range(accounts_total):
+     account = Account.from_mnemonic(mnemonic, account_path=f"m/44'/60'/0'/0/{i}")
+     blockchain.addLocalAccount(address=account.address, balance=pre_funded_amount)
+
+
+asns = [150, 151, 152, 153, 154, 160, 161, 162, 163, 164]
+
+###################################################
+# Ethereum GethNode
+# geth_nodes_assigned = 0  # To track the number of Ethereum nodes assigned
+beaconsetup_node_number=1
+
+
+geth_node_number=100
+beacon_node_number=100
+vc_node_number=100
+
+
+
+geth_nodes: List[PoSGethServer] = []
+beacon_nodes: List[PoSBeaconServer] = []
+
+vc_nodes: List[PoSVcServer] =[]
+
+### 创建beaconsetupnode
+beaconsetupServer: PoSBeaconSetupServer = blockchain.createBeaconSetupNode(f"BeaconSetupNode")
+emu.getVirtualNode(f'BeaconSetupNode').setDisplayName('Ethereum-BeaconSetup')
+### 创建gethnode
+for i in range(geth_node_number):
+    gethServer: PoSGethServer = blockchain.createGethNode(f"gethnode{i}")
+    gethServer.enableGethHttp()
+    gethServer.appendClassName(f'Ethereum-POS-Geth-{i+1}')
+    geth_nodes.append(gethServer)
+    emu.getVirtualNode(f'gethnode{i}').setDisplayName(f'Ethereum-POS-Geth-{i+1}')
+## 创建beaconnode
+for i in range(beacon_node_number):
+    beaconServer: PoSBeaconServer = blockchain.createBeaconNode(f"beaconnode{i}")
+    beaconServer.appendClassName(f'Ethereum-POS-Beacon-{i+1}')
+    beaconServer.connectToGethNode(f"gethnode{(i+1)%len(geth_nodes)}")
+    beacon_nodes.append(beaconServer)
+    emu.getVirtualNode(f'beaconnode{i}').setDisplayName(f'Ethereum-POS-Beacon-{i+1}')
+    # beaconServer.enablePOSValidatorAtGenesis()
+# 设置bootnode
+geth_nodes[0].setBootNode(True)
+beacon_nodes[0].setBootNode(True)
+
+for i in range(vc_node_number):
+    VcServer: PoSVcServer=blockchain.createVcNode(f"vcnode{i}")
+    VcServer.appendClassName(f'Ethereum-POS-Validator-{i+1}')
+
+    VcServer.connectToBeaconNode(f"beaconnode{(i+1)%len(beacon_nodes)}")
+    VcServer.enablePOSValidatorAtGenesis()
+    vc_nodes.append(VcServer)
+    emu.getVirtualNode(f'vcnode{i}').setDisplayName(f'Ethereum-POS-Validator-{i+1}')
+
+
+assign_index = 0
+total_nodes = len(geth_nodes) + len(beacon_nodes) + len(vc_nodes)
+for asn in asns:
+    for id in range(hosts_per_stub_as):
+        if asn == 152 and id == 0:
+            emu.addBinding(Binding('BeaconSetupNode',
+                                   filter=Filter(asn=asn, nodeName=f'^host_{id}$'),
+                                   action=Action.FIRST))
+        else:
+            if assign_index >= total_nodes:
+                continue
+            if assign_index < len(geth_nodes):
+                name = f'gethnode{assign_index}'
+            elif assign_index < len(geth_nodes) + len(beacon_nodes):
+                name = f'beaconnode{assign_index - len(geth_nodes)}'
+            else:
+                name = f'vcnode{assign_index - len(geth_nodes) - len(beacon_nodes)}'
+            emu.addBinding(Binding(name,
+                                   filter=Filter(asn=asn, nodeName=f'^host_{id}$'),
+                                   action=Action.FIRST))
+            assign_index += 1
+
+
+
+# Add Ethereum layer to the emulator
+emu.addLayer(eth)
+base_layer = emu.getLayer('Base')
+for asn in asns:
+    as_obj = base_layer.getAutonomousSystem(asn)
+    net = as_obj.getNetwork('net0')
+    # Extend host IP range from 71-99 to 71-199 (supports 129 hosts, enough for 50 per AS)
+    # Router range is 200-254, so host must end at 199 to avoid conflict
+    # Move DHCP range to 51-70 to avoid conflict with extended host range (71-199)
+    net.setHostIpRange(hostStart=71, hostEnd=199, hostStep=1)
+
+emu.render()
+
+# Enable internetMap and etherView for visualization
+docker = Docker(internetMapEnabled=True, etherViewEnabled=True, platform=platform)
+
+# Compile the emulator to output
+emu.compile(docker, './output', override=True)

--- a/seedemu/services/EthereumService/EthTemplates/EthServerFileTemplates.py
+++ b/seedemu/services/EthereumService/EthTemplates/EthServerFileTemplates.py
@@ -16,6 +16,7 @@ EthServerFileTemplates: Dict[str, str] = {
         'bootstrapper':        get_file_content("files_ethereum/bootstrapper.sh"),
         'beacon_bootstrapper': get_file_content("files_ethereum/beacon_bootstrapper.sh"),
         'fetch_bn_enr':    get_file_content("files_ethereum/fetch_bn_enr.sh"),
+        'vc_bootstrapper': get_file_content("files_ethereum/vc_bootstrapper.sh"),
 }
 
 UtilityServerFileTemplates: Dict[str, str] = {

--- a/seedemu/services/EthereumService/EthTemplates/LighthouseCommandTemplates.py
+++ b/seedemu/services/EthereumService/EthTemplates/LighthouseCommandTemplates.py
@@ -1,7 +1,7 @@
 
-LIGHTHOUSE_BN_CMD = """lighthouse --debug-level info bn --datadir /tmp/bn/local-testnet/testnet --testnet-dir /tmp/bn/local-testnet/testnet --enable-private-discovery --staking --enr-address {ip_address}  --enr-udp-port 9000 --enr-tcp-port 9000 --port 9000 --http-address {ip_address} --http-port 8000 --http-allow-origin "*" --disable-packet-filter --target-peers {target_peers} --execution-endpoint http://localhost:8551 --execution-jwt /tmp/jwt.hex --subscribe-all-subnets {bootnodes_flag} &"""
+LIGHTHOUSE_BN_CMD = """lighthouse --debug-level info bn --datadir /tmp/bn/local-testnet/testnet --testnet-dir /tmp/bn/local-testnet/testnet --enable-private-discovery --staking --enr-address {ip_address}  --enr-udp-port 9000 --enr-tcp-port 9000 --port 9000 --http-address {ip_address} --http-port 8000 --http-allow-origin "*" --disable-packet-filter --target-peers {target_peers} --execution-endpoint http://{remote_geth}:8551 --execution-jwt /tmp/jwt.hex  {bootnodes_flag} &"""
 
-LIGHTHOUSE_VC_CMD = """lighthouse --debug-level info vc --datadir /tmp/vc/local-testnet/testnet --testnet-dir /tmp/vc/local-testnet/testnet --init-slashing-protection --beacon-nodes http://{ip_address}:8000 --suggested-fee-recipient {acct_address} --http --http-address 0.0.0.0 --http-allow-origin "*" --unencrypted-http-transport &"""
+LIGHTHOUSE_VC_CMD = """lighthouse --debug-level info vc --datadir /tmp/vc/local-testnet/testnet --testnet-dir /tmp/vc/local-testnet/testnet --init-slashing-protection --beacon-nodes http://{beacon_node}:8000 --suggested-fee-recipient {acct_address} --http --http-address 0.0.0.0 --http-allow-origin "*" --unencrypted-http-transport &"""
 
 LIGHTHOUSE_WALLET_CREATE_CMD = """lighthouse account_manager wallet create --testnet-dir /tmp/vc/local-testnet/testnet --datadir /tmp/vc/local-testnet/testnet --name "seed" --password-file /tmp/seed.pass"""
 

--- a/seedemu/services/EthereumService/EthTemplates/files_ethereum/beacon_bootstrapper.sh
+++ b/seedemu/services/EthereumService/EthTemplates/files_ethereum/beacon_bootstrapper.sh
@@ -13,52 +13,15 @@ while read -r node; do {{
             break
         }}
     }}; done
-    ($ok) && {{
-        validatorAtGenesis={is_validator_at_genesis}
-        validatorAtRunning={is_validator_at_running}
-
+   
         curl --http0.9 -s http://$node/testnet > /tmp/testnet.tar.gz
         mkdir /tmp/bn
         tar -xzvf /tmp/testnet.tar.gz -C /tmp/bn
 
-        ($validatorAtGenesis || $validatorAtRunning) && {{
-            mkdir /tmp/vc
-            tar -xzvf /tmp/testnet.tar.gz -C /tmp/vc
-        }}
-
-        ($validatorAtGenesis) && {{
-            eth2-val-tools keystores --source-mnemonic "{validator_mnemonic}" --source-max {validator_key_end} --source-min {validator_key_start} --out-loc "/tmp/vc/assigned_data" 
-            mkdir /tmp/vc/local-testnet/testnet/validators
-            cp -r /tmp/vc/assigned_data/keys/* /tmp/vc/local-testnet/testnet/validators/
-            cp -r /tmp/vc/assigned_data/secrets /tmp/vc/local-testnet/testnet/
-        }}
-
-        
-        
         echo "[beacon_client] starting lighthouse beacon client"
         {bc_start_command}
 
-        ($validatorAtRunning) && {{
-        echo "creating validator wallet and deposit"
-        {wallet_create_command}
-        {validator_create_command}
-        {validator_deposit_sh}
-
-        }}
-
-        # while loop till bc client is ready
-        while ! curl --http0.9 -sHf http://{ip_address}:8000 > /dev/null; do
-            echo "eth: local beacon node not ready, waiting..."
-            sleep 3
-        done
-
-
-        ($validatorAtGenesis || $validatorAtRunning) && {{
-        echo "[validator client] starting lighthouse validator client"
-        {vc_start_command}
-        }}
-        
-    }}
+      
 }}; done < /tmp/beacon-setup-node
 
 

--- a/seedemu/services/EthereumService/EthTemplates/files_ethereum/fetch_bn_enr.sh
+++ b/seedemu/services/EthereumService/EthTemplates/files_ethereum/fetch_bn_enr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-BOOTNODES_FILE="/tmp/eth-nodes"
-OUTPUT_ENR_FILE="/tmp/bc_enrs.txt"
+BOOTNODES_FILE="/tmp/beacon-eth-nodes"   ## geth and beacon 
+OUTPUT_ENR_FILE="/tmp/bc_enrs.txt"   
 
 MAX_RETRIES=60
 SLEEP_SECONDS=3

--- a/seedemu/services/EthereumService/EthTemplates/files_ethereum/vc_bootstrapper.sh
+++ b/seedemu/services/EthereumService/EthTemplates/files_ethereum/vc_bootstrapper.sh
@@ -26,6 +26,7 @@ while read -r node; do {{
             tar -xzvf /tmp/testnet.tar.gz -C /tmp/vc
         }}
 
+
         ($validatorAtGenesis) && {{
             eth2-val-tools keystores --source-mnemonic "{validator_mnemonic}" --source-max {validator_key_end} --source-min {validator_key_start} --out-loc "/tmp/vc/assigned_data" 
             mkdir /tmp/vc/local-testnet/testnet/validators

--- a/seedemu/services/EthereumService/EthTemplates/files_ethereum/vc_bootstrapper.sh
+++ b/seedemu/services/EthereumService/EthTemplates/files_ethereum/vc_bootstrapper.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+while read -r node; do {{
+    let count=0
+    ok=true
+    validator=false
+    until curl --http0.9 -sHf http://$node/testnet > /dev/null; do {{
+        echo "eth: beacon-setup node $node not ready, waiting..."
+        sleep 10
+        let count++
+        [ $count -gt 60 ] && {{
+            echo "eth: connection to beacon-setup node $node failed too many times, skipping."
+            ok=false
+            break
+        }}
+    }}; done
+    ($ok) && {{
+        validatorAtGenesis={is_validator_at_genesis}
+        validatorAtRunning={is_validator_at_running}
+
+        curl --http0.9 -s http://$node/testnet > /tmp/testnet.tar.gz
+        mkdir /tmp/bn
+        tar -xzvf /tmp/testnet.tar.gz -C /tmp/bn
+
+        ($validatorAtGenesis || $validatorAtRunning) && {{
+            mkdir /tmp/vc
+            tar -xzvf /tmp/testnet.tar.gz -C /tmp/vc
+        }}
+
+        ($validatorAtGenesis) && {{
+            eth2-val-tools keystores --source-mnemonic "{validator_mnemonic}" --source-max {validator_key_end} --source-min {validator_key_start} --out-loc "/tmp/vc/assigned_data" 
+            mkdir /tmp/vc/local-testnet/testnet/validators
+            cp -r /tmp/vc/assigned_data/keys/* /tmp/vc/local-testnet/testnet/validators/
+            cp -r /tmp/vc/assigned_data/secrets /tmp/vc/local-testnet/testnet/
+        }}
+
+        
+        
+    
+
+        ($validatorAtRunning) && {{
+        echo "creating validator wallet and deposit"
+        {wallet_create_command}
+        {validator_create_command}
+        {validator_deposit_sh}
+        }}
+
+        # while loop till bc client is ready
+        while ! curl --http0.9 -sHf http://{ip_address}:8000 > /dev/null; do
+            echo "eth: local beacon node not ready, waiting..."
+            sleep 3
+        done
+
+
+        ($validatorAtGenesis || $validatorAtRunning) && {{
+        echo "[validator client] starting lighthouse validator client"
+        {vc_start_command}
+        }}
+        
+    }}
+}}; done < /tmp/beacon-setup-node
+
+

--- a/seedemu/services/EthereumService/EthereumServer.py
+++ b/seedemu/services/EthereumService/EthereumServer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from examples.internet.B29_email_dns.email_realistic import configure_bgp_peering
 from seedemu.core import Node, Server, BaseSystem
 from .EthEnum import *
 from .EthUtil import *
@@ -157,13 +158,14 @@ class EthereumServer(Server):
             node.appendStartCommand("chmod +x /usr/bin/geth")
 
         # genesis
+        # if isinstance(self, PoSGethServer) or isinstance(self, PoSVcServer):
         node.appendStartCommand('[ ! -e "/root/.ethereum/geth/nodekey" ] && geth --datadir {} init /tmp/eth-genesis.json'.format(self._data_dir))
         
         # copy keystore to the proper folder
         for account in self._accounts:
             node.appendStartCommand("cp /tmp/keystore/{} /root/.ethereum/keystore/".format(account.keystore_filename))
 
-        if self._is_bootnode:
+        if self._is_bootnode and isinstance(self, PoSGethServer):
             # generate enode url. other nodes will access this to bootstrap the network.
             node.appendStartCommand('[ ! -e "/root/.ethereum/geth/bootkey" ] && bootnode -genkey /root/.ethereum/geth/bootkey')
             node.appendStartCommand('echo "enode://$(bootnode -nodekey /root/.ethereum/geth/bootkey -writeaddress)@{}:30301" > /tmp/eth-enode-url'.format(addr))
@@ -171,20 +173,30 @@ class EthereumServer(Server):
             # Default port is 30301, use -addr :<port> to specify a custom port
             node.appendStartCommand('bootnode -nodekey /root/.ethereum/geth/bootkey -verbosity 9 -addr {}:30301 2> /tmp/bootnode-logs &'.format(addr))          
             node.appendStartCommand('python3 -m http.server {} -d /tmp'.format(self._bootnode_http_port), True)
+ 
+   
+        try:
+            beacon_bootnodes = list(self._blockchain.getBeaconBootNodes()[:])
+        except Exception:
+            pass
+        try:
+            geth_bootnodes = list(self._blockchain.getGethBootNodes()[:])
+        except Exception:
+            pass
 
-        # get other nodes IP for the bootstrapper.
-        bootnodes = self._blockchain.getBootNodes()[:]
-        if len(bootnodes) > 0:
-            node.setFile('/tmp/eth-nodes', '\n'.join(bootnodes))
-            
+
+        if len(beacon_bootnodes) > 0 and isinstance(self, PoSBeaconServer):
+            node.setFile('/tmp/beacon-eth-nodes', '\n'.join(beacon_bootnodes))
+        if len(geth_bootnodes) > 0 and isinstance(self, PoSGethServer):
+            node.setFile('/tmp/geth-eth-nodes', '\n'.join(geth_bootnodes))
+
             node.setFile('/tmp/eth-bootstrapper', EthServerFileTemplates['bootstrapper'])
-
-            # load enode urls from other nodes
             node.appendStartCommand('chmod +x /tmp/eth-bootstrapper')
             node.appendStartCommand('/tmp/eth-bootstrapper')
-
+            node.appendStartCommand(self._geth_start_command, True)
         # launch Ethereum process.
-        node.appendStartCommand(self._geth_start_command, True) 
+        # if isinstance(self, PoSGethServer):
+        #     node.appendStartCommand(self._geth_start_command, True) 
         
 
         # Rarely used and tentatively not supported. 
@@ -728,30 +740,173 @@ class PoSServer(EthereumServer):
 
 
 
-class BeaconSetupServer():
+class PoSGethServer(EthereumServer):
+    def __init__(self, id: int, blockchain:Blockchain):
+        super().__init__(id, blockchain)
+    def _generateGethStartCommand(self, addr:str):
+        self._geth_options['pos'] = GethCommandTemplates['pos']
+        super()._generateGethStartCommand(addr)
+    def install(self, node: Node, eth: EthereumService):
+        # if self.__is_beacon_setup_node:
+        #     beacon_setup_node = PoSBeaconSetupServer()
+        #     beacon_setup_node.install(self, node, self._blockchain)
+        #     return 
+        super().install(node,eth)
+        node.setFile('/tmp/jwt.hex', '0xae7177335e3d4222160e08cecac0ace2cecce3dc3910baada14e26b11d2009fc')
+class PoSBeaconServer(EthereumServer):
+    __beacon_peer_counts:int
+    def __init__(self, id: int, blockchain:Blockchain):
+        super().__init__(id, blockchain)
+        self.__is_beacon_validator_at_genesis = False
+        self.__is_beacon_validator_at_running = False
+        self.__is_manual_deposit_for_validator = False
+        self.__beacon_peer_counts = 30
+        self.__connect_geth_vnode = ""
+        self.__connected_geth_ip = ""
+        # self.__validator_mnemonic = "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
 
+    def install(self, node: Node, eth: EthereumService):
+        # if self.__is_beacon_setup_node:
+        #     beacon_setup_node = PoSBeaconSetupServer()
+        #     beacon_setup_node.install(self, node, self._blockchain)
+        #     return 
+        
+        if self.__is_beacon_validator_at_genesis:
+            self._role.append("validator_at_genesis")
+        if self.__is_beacon_validator_at_running:
+            self._role.append("validator_at_running")
+        
+        super().install(node,eth)
+        self.__install_beacon(node, eth)
+    def __install_beacon(self, node:Node, eth:EthereumService):
+        ifaces = node.getInterfaces()
+        assert len(ifaces) > 0, 'EthereumServer::install: node as{}/{} has no interfaces'.format(node.getAsn(), node.getName())
+        addr = str(ifaces[0].getAddress())
+        ## 得到的beacon_setup_node的服务ip和端口
+        ### configure 阶段早就拿到了，等在那里，
+        beacon_setup_node = self._blockchain.getBeaconSetupNodeIp()
+
+        assert beacon_setup_node != "", 'EthereumServer::install: Ethereum Service has no beacon_setup_node.'
+
+        geth_node_ip = self.getConnectedGethIp()
+        ### 是否正确
+        # connect_geth_node = self.__blockchain.getIpByVnodeName(self.__connect_geth_vnode)
+        bootnode_start_command = ""
+        bc_start_command = ""
+        bc_start_command = LIGHTHOUSE_BN_CMD.format(ip_address=addr, target_peers=self.__beacon_peer_counts, bootnodes_flag="" if self._is_bootnode else f'--boot-nodes "$(cat /tmp/bc_enrs.txt)"', remote_geth=geth_node_ip)
+
+        ## div beacon node and geth node
+        if not self._is_bootnode:
+            node.setFile('/tmp/fetch_bn_enr', EthServerFileTemplates['fetch_bn_enr'])
+            node.appendStartCommand('chmod +x /tmp/fetch_bn_enr')
+            node.appendStartCommand('/tmp/fetch_bn_enr')
+
+        # if self._is_bootnode:
+        #     bootnode_start_command = LIGHTHOUSE_BOOTNODE_CMD.format(ip_address=addr)
+        # if self.__is_beacon_validator_at_running:
+        #     node.setFile('/tmp/seed.pass', 'seedseedseed')
+        #     wallet_create_command = LIGHTHOUSE_WALLET_CREATE_CMD.format(eth_id=self.getId())
+        #     validator_create_command = LIGHTHOUSE_VALIDATOR_CREATE_CMD.format(eth_id=self.getId()) 
+
+        #     if len(self._accounts) > 0:
+        #         print(self._accounts[0].keystore_filename)
+        #         node.setFile('/tmp/deposit.py', VALIDATOR_DEPOSIT_PY.format(keystore_filename=self._accounts[0].keystore_filename))
+            
+        #     if not self.__is_manual_deposit_for_validator:
+        #         validator_deposit_sh = "sleep 2 && python3 /tmp/deposit.py"
+
+            # node.appendStartCommand('chmod +x /tmp/deposit.sh')
+            # if not self.__is_manual_deposit_for_validator:
+            #     validator_deposit_sh = "/tmp/deposit.sh"
+        # if self.__is_beacon_validator_at_genesis or self.__is_beacon_validator_at_running:     
+        #     vc_start_command = LIGHTHOUSE_VC_CMD.format(ip_address=addr, acct_address=self._accounts[0].address)
+        ## 写入beacon_setup_node的服务ip和端口到文件
+        node.setFile('/tmp/beacon-setup-node', beacon_setup_node)
+        
+        # get current node validator index if it's validator at genesis. 
+        # validatorIds = self._blockchain.getValidatorIds()
+        # validator_idx = -1
+        # if self.isValidatorAtGenesis():
+        #     # only get validator id if current node is validator at genesis.
+        #     for i, v in enumerate(validatorIds):
+        #         if int(v) == self._id:
+        #             validator_idx = i
+        #             break 
+        #     assert validator_idx >= 0, "EthereumServer::__install_beacon: validator id should be set at genesis."
+        #     validator_idx = int(validator_idx)
+        #     # this validator idx will be used to create validator keys properly. 
+        #     # Each validator at genesis node has 4 keys which were set at Genesis
+
+        node.setFile('/tmp/beacon-bootstrapper', EthServerFileTemplates['beacon_bootstrapper'].format( 
+                                bc_start_command=bc_start_command,
+                    ))
+        node.setFile('/tmp/jwt.hex', '0xae7177335e3d4222160e08cecac0ace2cecce3dc3910baada14e26b11d2009fc')
+        
+        node.appendStartCommand('chmod +x /tmp/beacon-bootstrapper')
+        node.appendStartCommand('/tmp/beacon-bootstrapper')
+
+    def setBeaconPeerCounts(self, peer_counts:int):
+        self.__beacon_peer_counts = peer_counts
+        return self
+    def connectToGethNode(self, vnode:str):
+        self.__connect_geth_vnode = vnode
+        return self
+    def enablePOSValidatorAtGenesis(self):
+        self.__is_beacon_validator_at_genesis = True
+        return self
+
+    def isValidatorAtGenesis(self):
+        return self.__is_beacon_validator_at_genesis
+
+    def isValidatorAtRunning(self):
+        return self.__is_beacon_validator_at_running
+
+    def enablePOSValidatorAtRunning(self, is_manual:bool=False):
+        self.__is_beacon_validator_at_running = True
+        self.__is_manual_deposit_for_validator = is_manual
+        return self
+    def setConnectedGethIp(self, ip:str):
+        self.__connected_geth_ip = ip
+        return self
+    def getConnectedGethIp(self) -> str:
+        return self.__connected_geth_ip
+    def getConnectGethVNode(self) -> str:
+        return self.__connect_geth_vnode
+
+    def getValidatorMnemonic(self):
+        return self.__validator_mnemonic
+
+    def setValidatorMnemonic(self, mnemonic:str):
+        """!
+        @brief Set the validator mnemonic for the beacon setup node.
+        This mnemonic will be used to generate validator keys at genesis and running.
+        
+        @param mnemonic The mnemonic to set.
+        """
+        self.__validator_mnemonic = mnemonic
+        return self
+
+class PoSBeaconSetupServer(EthereumServer):
     """!
     @brief The WebServer class.
     """
 
-
-    
     __beacon_setup_http_port: int
 
-    def __init__(self, consensus:ConsensusMechanism = ConsensusMechanism.POA):
+    def __init__(self,  id: int, blockchain:Blockchain):
         """!
         @brief BeaconSetupServer constructor.
         """
-
+        super().__init__(id, blockchain)
         self.__beacon_setup_http_port = 8090
-        self.__consensus_mechanism = consensus
+        self.__validator_mnemonic = "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
 
-    def install(self, server:PoSServer, node: Node, blockchain: Blockchain):
+    def install(self, node: Node,eth: EthereumService ):
         """!
         @brief Install the service.
         """
         
-        validator_ids = blockchain.getValidatorIds()
+        validator_ids = self._blockchain.getValidatorIds()
         validator_counts = len(validator_ids)
 
         assert validator_counts > 0, "BeaconSetupServer::install: At least one node should be set as validator at genesis."
@@ -761,14 +916,14 @@ class BeaconSetupServer():
         #node.addBuildCommand('apt-get update && apt-get install -y --no-install-recommends software-properties-common python3 python3-pip')
         #node.addBuildCommand('pip install web3')
         # [remove] node.appendStartCommand('lcli generate-bootnode-enr --ip {} --udp-port 30305 --tcp-port 30305 --genesis-fork-version 0x42424242 --output-dir /local-testnet/bootnode'.format(bootnode_ip))
-        node.setFile("/tmp/config.yaml", BEACON_GENESIS.format(chain_id=blockchain.getChainId(),
-                                                                    target_committee_size=blockchain.getTargetCommitteeSize(),
-                                                                    target_aggregator_per_committee=blockchain.getTargetAggregatorPerCommittee()))
+        node.setFile("/tmp/config.yaml", BEACON_GENESIS.format(chain_id=self._blockchain.getChainId(),
+                                                                    target_committee_size=self._blockchain.getTargetCommitteeSize(),
+                                                                    target_aggregator_per_committee=self._blockchain.getTargetAggregatorPerCommittee()))
         # [remove] node.setFile("/tmp/validator-ids", "\n".join(validator_ids))
-        self.__genesis = blockchain.getGenesis()
+        self.__genesis = self._blockchain.getGenesis()
 
         node.setFile('/tmp/eth1-genesis.json', self.__genesis.getGenesis())
-        node.setFile("/tmp/mnemonic.yaml", BEACON_MNEMONIC_YAML.format(validator_count = validator_counts, validator_mnemonic=server.getValidatorMnemonic()))
+        node.setFile("/tmp/mnemonic.yaml", BEACON_MNEMONIC_YAML.format(validator_count = validator_counts, validator_mnemonic=self.getValidatorMnemonic()))
         node.appendStartCommand('mkdir /local-testnet/testnet')
         # [remove] node.appendStartCommand('bootnode_enr=`cat /local-testnet/bootnode/enr.dat`')
         # [remove] node.appendStartCommand('echo "- $bootnode_enr" > /local-testnet/testnet/boot_enr.yaml')
@@ -810,3 +965,126 @@ class BeaconSetupServer():
         out += 'Beacon Setup server object.\n'
 
         return out
+    def getValidatorMnemonic(self):
+        return self.__validator_mnemonic
+
+
+class PoSVcServer(EthereumServer):
+
+    def __init__(self, id: int, blockchain:Blockchain):
+        super().__init__(id, blockchain)
+        self.__is_beacon_validator_at_genesis = False
+        self.__is_beacon_validator_at_running = False
+        self.__is_manual_deposit_for_validator = False
+        self.__validator_mnemonic = "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
+        self.__is_connect_beacon_node = True
+        self.__conect_beacon_vnode :str =""
+        self.__connected_beacon_ip :str = ""
+    def install(self, node: Node, eth: EthereumService):
+        # if self.__is_beacon_setup_node:
+        #     beacon_setup_node = PoSBeaconSetupServer()
+        #     beacon_setup_node.install(self, node, self._blockchain)
+        #     return 
+        
+        if self.__is_beacon_validator_at_genesis:
+            self._role.append("validator_at_genesis")
+        if self.__is_beacon_validator_at_running:
+            self._role.append("validator_at_running")
+        
+        super().install(node,eth)
+        self.__install_vc(node, eth)
+    def __install_vc(self, node:Node, eth:EthereumService):
+        ifaces = node.getInterfaces()
+        assert len(ifaces) > 0, 'EthereumServer::install: node as{}/{} has no interfaces'.format(node.getAsn(), node.getName())
+        addr = str(ifaces[0].getAddress())
+        ## 得到的beacon_setup_node的服务ip和端口
+        beacon_setup_node = self._blockchain.getBeaconSetupNodeIp()
+
+        assert beacon_setup_node != "", 'EthereumServer::install: Ethereum Service has no beacon_setup_node.'
+
+        beacon_node_ip = self.getConnectedBeaconIp()
+        assert beacon_node_ip != "", 'EthereumServer::install: Ethereum Service has no beacon_node.'
+        # bootnode_start_command = ""
+        # bc_start_command = ""
+        # bc_start_command = LIGHTHOUSE_BN_CMD.format(ip_address=addr, target_peers=self.__beacon_peer_counts, bootnodes_flag="" if self._is_bootnode else f'--boot-nodes "$(cat /tmp/bc_enrs.txt)"')
+        vc_start_command = ""
+        wallet_create_command = ""
+        validator_create_command = ""
+        validator_deposit_sh = ""
+        # ## div beacon node and geth node
+        # if not self._is_bootnode:
+        #     node.setFile('/tmp/fetch_bn_enr', EthServerFileTemplates['fetch_bn_enr'])
+        #     node.appendStartCommand('chmod +x /tmp/fetch_bn_enr')
+        #     node.appendStartCommand('/tmp/fetch_bn_enr')
+
+        # if self._is_bootnode:
+        #     bootnode_start_command = LIGHTHOUSE_BOOTNODE_CMD.format(ip_address=addr)
+        if self.__is_beacon_validator_at_running:
+            node.setFile('/tmp/seed.pass', 'seedseedseed')
+            wallet_create_command = LIGHTHOUSE_WALLET_CREATE_CMD.format(eth_id=self.getId())
+            validator_create_command = LIGHTHOUSE_VALIDATOR_CREATE_CMD.format(eth_id=self.getId()) 
+
+            if len(self._accounts) > 0:
+                print(self._accounts[0].keystore_filename)
+                node.setFile('/tmp/deposit.py', VALIDATOR_DEPOSIT_PY.format(keystore_filename=self._accounts[0].keystore_filename))
+            
+            if not self.__is_manual_deposit_for_validator:
+                validator_deposit_sh = "sleep 2 && python3 /tmp/deposit.py"
+
+            # node.appendStartCommand('chmod +x /tmp/deposit.sh')
+            # if not self.__is_manual_deposit_for_validator:
+            #     validator_deposit_sh = "/tmp/deposit.sh"
+        if self.__is_beacon_validator_at_genesis or self.__is_beacon_validator_at_running:     
+            vc_start_command = LIGHTHOUSE_VC_CMD.format(ip_address=addr, acct_address=self._accounts[0].address, beacon_node=beacon_node_ip)
+        ## 写入beacon_setup_node的服务ip和端口到文件
+        node.setFile('/tmp/beacon-setup-node', beacon_setup_node)
+        
+        # get current node validator index if it's validator at genesis.
+        validatorIds = self._blockchain.getValidatorIds()
+        validator_idx = -1
+        if self.isValidatorAtGenesis():
+            # only get validator id if current node is validator at genesis.
+            for i, v in enumerate(validatorIds):
+                if int(v) == self._id:
+                    validator_idx = i
+                    break 
+            assert validator_idx >= 0, "EthereumServer::__install_beacon: validator id should be set at genesis."
+            validator_idx = int(validator_idx)
+            # this validator idx will be used to create validator keys properly. 
+            # Each validator at genesis node has 4 keys which were set at Genesis
+
+        node.setFile('/tmp/vc_bootstrapper', EthServerFileTemplates['vc_bootstrapper'].format( 
+                                is_validator_at_genesis="true" if self.__is_beacon_validator_at_genesis else "false",
+                                is_validator_at_running="true" if self.__is_beacon_validator_at_running else "false",
+                                validator_mnemonic=self.__validator_mnemonic,
+                                validator_key_start= validator_idx ,
+                                validator_key_end= (validator_idx + 1),
+                                vc_start_command=vc_start_command,
+                                wallet_create_command=wallet_create_command,
+                                validator_create_command=validator_create_command,
+                                validator_deposit_sh=validator_deposit_sh,
+                                ip_address=beacon_node_ip
+                    ))
+        node.setFile('/tmp/jwt.hex', '0xae7177335e3d4222160e08cecac0ace2cecce3dc3910baada14e26b11d2009fc')
+        
+        node.appendStartCommand('chmod +x /tmp/vc_bootstrapper')
+        node.appendStartCommand('/tmp/vc_bootstrapper') 
+
+
+    def connectToBeaconNode(self, vnode:str):
+        self.__conect_beacon_vnode = vnode
+        return self
+    def setConnectedBeaconIp(self, ip:str):
+        self.__connected_beacon_ip = ip
+        return self
+    def getConnectedBeaconIp(self) -> str:
+        return self.__connected_beacon_ip
+    def getConnectBeaconVNode(self) -> str:
+        return self.__conect_beacon_vnode
+    def enablePOSValidatorAtGenesis(self):
+        self.__is_beacon_validator_at_genesis = True
+        return self
+    def isValidatorAtRunning(self):
+        return self.__is_beacon_validator_at_running
+    def isValidatorAtGenesis(self):
+        return self.__is_beacon_validator_at_genesis

--- a/seedemu/services/EthereumService/EthereumServer.py
+++ b/seedemu/services/EthereumService/EthereumServer.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from examples.internet.B29_email_dns.email_realistic import configure_bgp_peering
 from seedemu.core import Node, Server, BaseSystem
 from .EthEnum import *
 from .EthUtil import *

--- a/seedemu/services/EthereumService/EthereumService.py
+++ b/seedemu/services/EthereumService/EthereumService.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .EthEnum import ConsensusMechanism, EthUnit
 from .EthUtil import Genesis, EthAccount, AccountStructure
-from .EthereumServer import EthereumServer, PoAServer, PoWServer, PoSServer
+from .EthereumServer import EthereumServer, PoAServer, PoSBeaconServer, PoSBeaconSetupServer, PoSGethServer, PoWServer, PoSVcServer,PoSServer
 from os import mkdir, path, makedirs, rename
 from seedemu.core import Node, Service, Server, Emulator
 from seedemu.core.enums import NetworkType
@@ -52,12 +52,16 @@ class Blockchain:
         self._consensus = consensus 
         self._chain_name = chainName 
         self._genesis = Genesis(self._consensus)
-        self._boot_node_addresses = [] 
+        # self._boot_node_addresses = [] 
         self._miner_node_address = [] 
         self._joined_accounts = []
         self._joined_signer_accounts = [] 
         self._validator_ids = [] 
         self._beacon_setup_node_address = ''  
+
+        self._beacon_boot_node_address = []
+        self._geth_boot_node_address = []
+
         self._pending_targets = [] #
         self._emu_mnemonic = "great awesome fun seed security lab protect system network prevent attack future"
         self._total_accounts_per_node = 1
@@ -68,6 +72,10 @@ class Blockchain:
         self._chain_id = chainId
         self._target_aggregater_per_committee = 2
         self._target_committee_size = 3
+        self._beacon_to_geth_vnode = {}
+        self._vc_to_beacon_vnode = {}
+        self._beacon_to_geth_ip = {}
+        self._vc_to_beacon_ip = {}
         
 
     def _doConfigure(self, node:Node, server:Server):
@@ -86,31 +94,45 @@ class Blockchain:
         assert len(ifaces) > 0, 'EthereumService::_doConfigure(): node as{}/{} has not interfaces'.format()
         addr = '{}:{}'.format(str(ifaces[0].getAddress()), server.getBootNodeHttpPort())
         
+        # if server.isBootNode():
+        #     self._log('adding as{}/{} as consensus-{} bootnode...'.format(node.getAsn(), node.getName(), self._consensus.value))
+        #     self._boot_node_addresses.append(str(ifaces[0].getAddress()))
+
         if server.isBootNode():
-            self._log('adding as{}/{} as consensus-{} bootnode...'.format(node.getAsn(), node.getName(), self._consensus.value))
-            self._boot_node_addresses.append(str(ifaces[0].getAddress()))
+            if isinstance(server, PoSBeaconServer):
+                self._beacon_boot_node_address.append(str(ifaces[0].getAddress()))
+            elif isinstance(server, PoSGethServer):
+                self._geth_boot_node_address.append(str(ifaces[0].getAddress()))
+            # self._log('adding as{}/{} as consensus-{} bootnode...'.format(node.getAsn(), node.getName(), self._consensus.value))
+            # self._boot_node_addresses.append(str(ifaces[0].getAddress()))
+       
         
         if self._consensus == ConsensusMechanism.POS:
-            if server.isStartMiner():
-                self._log('adding as{}/{} as consensus-{} miner...'.format(node.getAsn(), node.getName(), self._consensus.value))
-                self._miner_node_address.append(str(ifaces[0].getAddress())) 
-            if server.isBeaconSetupNode():
+            if isinstance(server, PoSBeaconSetupServer):
                 self._beacon_setup_node_address = '{}:{}'.format(ifaces[0].getAddress(), server.getBeaconSetupHttpPort())
+            # if server.isStartMiner():
+            #     self._log('adding as{}/{} as consensus-{} miner...'.format(node.getAsn(), node.getName(), self._consensus.value))
+            #     self._miner_node_address.append(str(ifaces[0].getAddress())) 
+            # if server.isBeaconSetupNode():
+            #     self._beacon_setup_node_address = '{}:{}'.format(ifaces[0].getAddress(), server.getBeaconSetupHttpPort())
 
         server._createAccounts(self)
         
         accounts = server._getAccounts()
         if len(accounts) > 0:
-            if self._consensus == ConsensusMechanism.POS and server.isValidatorAtRunning():
-                accounts[0].balance = 33 * EthUnit.ETHER.value
+            if isinstance(server, PoSVcServer):
+                if self._consensus == ConsensusMechanism.POS and server.isValidatorAtRunning():
+                    accounts[0].balance = 33 * EthUnit.ETHER.value
             self._joined_accounts.extend(accounts)
             if self._consensus in [ConsensusMechanism.POA] and server.isStartMiner():
                 self._joined_signer_accounts.append(accounts[0])
+        if isinstance(server, PoSVcServer):
+            if self._consensus == ConsensusMechanism.POS and server.isValidatorAtGenesis():
+                self._validator_ids.append(str(server.getId()))
 
-        if self._consensus == ConsensusMechanism.POS and server.isValidatorAtGenesis():
-            self._validator_ids.append(str(server.getId()))
-        
+        ### 2026/2/11  生成可以，但是beacon 不add就可以
         server._generateGethStartCommand(str(ifaces[0].getAddress()))
+            
 
         if self._eth_service.isSave():
             save_path = self._eth_service.getSavePath()
@@ -148,6 +170,20 @@ class Blockchain:
                 server.setFaucetUrl(self.__getIpByVnodeName(emulator, linked_faucet_node_name))
                 faucet_server:FaucetServer = emulator.getServerByVirtualNodeName(linked_faucet_node_name)
                 server.setFaucetPort(faucet_server.getPort())
+
+            elif isinstance(server, PoSBeaconServer):
+                geth_vnode = server.getConnectGethVNode()
+                if geth_vnode != '':
+                    ip = self.__getIpByVnodeName(emulator, geth_vnode)
+                    if ip:
+                        server.setConnectedGethIp(ip)
+            elif isinstance(server, PoSVcServer):
+                beacon_vnode = server.getConnectBeaconVNode()
+                if beacon_vnode != '':
+                    ip = self.__getIpByVnodeName(emulator, beacon_vnode)
+                    if ip:
+                        server.setConnectedBeaconIp(ip)
+            
   
         self._genesis.addAccounts(self.getAllAccounts())
         
@@ -164,7 +200,8 @@ class Blockchain:
             if net.getType() == NetworkType.Local:
                 address = iface.getAddress()
                 return address
-    
+    def getIpByVnodeName(self, emulator, nodename:str) -> str:
+        return self.__getIpByVnodeName(emulator, nodename)
     def getAllServerNames(self):
         server_names = {}
         pending_targets = self._eth_service.getPendingTargets()
@@ -223,6 +260,24 @@ class Blockchain:
         @returns The IP address.
         """
         return self._beacon_setup_node_address
+    def  getBeaconBootNodeIP(self) -> str:
+        """!
+        @brief Get the IP of a beacon boot node.
+
+        @returns The IP address.
+        """
+        return self._beacon_boot_node_address
+    def getGethBootNodeIP(self) -> str:         
+        """!
+        @brief Get the IP of a geth boot node.
+
+        @returns The IP address.
+        """
+        return self._geth_boot_node_address
+    def getBeaconBootNodes(self) -> List[str]:
+        return list(self._beacon_boot_node_address)
+    def getGethBootNodes(self) -> List[str]:
+        return list(self._geth_boot_node_address)
 
     def setGenesis(self, genesis:str) -> EthereumServer:
         """!
@@ -300,6 +355,56 @@ class Blockchain:
         eth = self._eth_service
         self._pending_targets.append(vnode)
         return eth.installByBlockchain(vnode, self)
+    def createGethNode(self, vnode: str) -> EthereumServer:
+        """!
+        @brief Create a node belongs to this blockchain.
+
+        @param vnode The name of vnode.
+
+        @returns EthereumServer
+        """
+        nodetype = 'geth'
+        eth = self._eth_service
+        self._pending_targets.append(vnode)
+        return eth.installByBlockchain(vnode, self,nodetype="geth")
+    def createBeaconNode(self, vnode: str) -> EthereumServer:
+        """!
+        @brief Create a node belongs to this blockchain.
+
+        @param vnode The name of vnode.
+
+        @returns EthereumServer
+        """
+        nodetype = 'beacon'
+        eth = self._eth_service
+        self._pending_targets.append(vnode)
+        return eth.installByBlockchain(vnode, self,nodetype="beacon")
+
+    def createVcNode(self, vnode: str) -> EthereumServer:
+        """!
+        @brief Create a node belongs to this blockchain.
+
+        @param vnode The name of vnode.
+
+        @returns EthereumServer
+        """
+        nodetype = 'beacon'
+        eth = self._eth_service
+        self._pending_targets.append(vnode)
+        return eth.installByBlockchain(vnode, self,nodetype="vc")
+
+    def createBeaconSetupNode(self, vnode: str) -> EthereumServer:
+        """!
+        @brief Create a node belongs to this blockchain.
+
+        @param vnode The name of vnode.
+
+        @returns EthereumServer
+        """
+        nodetype = 'beaconsetup'
+        eth = self._eth_service
+        self._pending_targets.append(vnode)
+        return eth.installByBlockchain(vnode, self, nodetype="beaconsetup")  
     
     def addCode(self, address: str, code: str) -> Blockchain:
         """!
@@ -636,7 +741,7 @@ class EthereumService(Service):
                 exit(1)
         mkdir(self.__save_path)
         
-    def _doInstall(self, node: Node, server: Server):
+    def _doInstall(self, node: Node, server: Server):   ##这里的server是基类 service的render 传进来的
         self._log('installing eth on as{}/{}...'.format(node.getAsn(), node.getName()))
         if isinstance(server, EthereumServer):
             server.install(node, self)
@@ -645,7 +750,7 @@ class EthereumService(Service):
         elif isinstance(server, EthUtilityServer):
             server.install(node)
 
-    def _createServer(self, blockchain: Blockchain = None) -> Server:
+    def _createServer(self, blockchain: Blockchain = None,nodetype:str =None) -> Server:
         self.__serial += 1
         assert blockchain != None, 'EthereumService::_createServer(): create server using Blockchain::createNode() not EthereumService::install()'.format()
         consensus = blockchain.getConsensusMechanism()
@@ -654,7 +759,16 @@ class EthereumService(Service):
         if consensus == ConsensusMechanism.POW:
             return PoWServer(self.__serial, blockchain)
         if consensus == ConsensusMechanism.POS:
-            return PoSServer(self.__serial, blockchain)
+            if nodetype == 'geth':
+                return PoSGethServer(self.__serial, blockchain)
+            if nodetype == "beacon":
+                return PoSBeaconServer(self.__serial, blockchain)
+            if nodetype == "beaconsetup":
+                return PoSBeaconSetupServer(self.__serial, blockchain)
+            if nodetype == "vc":
+                return PoSVcServer(self.__serial, blockchain)
+            if nodetype == None:
+                return PoSServer(self.__serial, blockchain)
         
     def _createFaucetServer(self, blockchain:Blockchain, linked_eth_node:str, port:int, balance:int, max_fund_amount:int) -> FaucetServer:
         return FaucetServer(blockchain, linked_eth_node, port, balance, max_fund_amount)
@@ -662,7 +776,7 @@ class EthereumService(Service):
     def _createEthUtilityServer(self, blockchain:Blockchain, port:int, linked_eth_node:str, linked_faucet_node:str) -> EthUtilityServer:
         return EthUtilityServer(blockchain, port, linked_eth_node, linked_faucet_node)
 
-    def installByBlockchain(self, vnode: str, blockchain: Blockchain) -> EthereumServer:
+    def installByBlockchain(self, vnode: str, blockchain: Blockchain,nodetype:str = None) -> EthereumServer:
         """!
         @brief Install the service on a node identified by given name. 
                 This API is called by Blockchain Class. 
@@ -674,7 +788,8 @@ class EthereumService(Service):
         """
         if vnode in self._pending_targets.keys(): return self._pending_targets[vnode]
 
-        s = self._createServer(blockchain)
+       
+        s = self._createServer(blockchain,nodetype)
         self._pending_targets[vnode] = s
 
         return self._pending_targets[vnode]


### PR DESCRIPTION
The `EthTemplates` within the `EthereumService` folder have been updated; specifically, `beacon_bootstrapper.sh` has been split into two separate scripts: `vc_bootstrapper.sh` and `beacon_bootstrapper.sh`. Additionally, `EthereumService.py` and `EthereumServer.py` have been updated to refactor the former `PoSServer` into distinct components—`PoSGethServer`, `PoSBeaconServer`, `PoSBeaconSetupServer`, and `PoSVcServer`—while also resolving configuration and installation issues encountered during the rendering process. `LighthouseCommandTemplates.py` has been modified to ensure that the `beaconnode` explicitly specifies its connection to the `gethnode`, and the `vcnode` explicitly specifies its connection to the `beaconnode`, rather than defaulting to `localhost`. Finally, a new example (`R00*`) has been added, designed for use with the updated `EthereumService`, where the parameter specifies the number of `beaconnode` instances.