### PR TITLE
Next-generation feature-oriented PR CI

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -13,7 +13,7 @@ on:
         description: "Build selected representative examples"
         type: boolean
         required: false
-        default: true
+        default: false
       run-runtime-integration:
         description: "Run Docker runtime integration probes"
         type: boolean
@@ -103,7 +103,7 @@ jobs:
   example-build:
     name: Example Build
     needs: example-compile
-    if: ${{ github.event_name == 'pull_request' || github.event.inputs['run-example-build'] == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['run-example-build'] == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source repository
@@ -127,7 +127,7 @@ jobs:
 
   runtime-integration:
     name: Runtime Integration
-    needs: example-build
+    needs: example-compile
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['run-runtime-integration'] == 'true' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -9,160 +9,53 @@ on:
       - development-ipv6
   workflow_dispatch:
     inputs:
-      run-quick-tests:
-        description: "Run quick tests | ignores other options for testing (they still apply for compile/build)"
+      run-example-build:
+        description: "Build selected representative examples"
         type: boolean
         required: false
-        default: "false"
-      run-basic-tests:
-        description: "Run basic tests | Compile and builds all the basic examples - Runs basic tests"
+        default: true
+      run-runtime-integration:
+        description: "Run Docker runtime integration probes"
         type: boolean
         required: false
-        default: "true"
-      run-internet-tests:
-        description: "Run internet tests | Compile and builds all the internet examples - Runs internet tests"
-        type: boolean
-        required: false
-        default: "true"
-      run-blockchain-tests:
-        description: "Run blockchain tests | Compile and builds all the blockchain examples - Runs blockchain tests"
-        type: boolean
-        required: false
-        default: "false"
-      run-scion-tests:
-        description: "Run SCION tests | Compile and builds all the SCION examples - Runs SCION tests"
-        type: boolean
-        required: false
-        default: "false"
-      run-real-world-tests:
-        description: "Run tests that depend on real external network reachability"
-        type: boolean
-        required: false
-        default: "false"
+        default: false
 
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 jobs:
-  compile-examples:
-    name: Compile Examples
+  static:
+    name: Static
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      SCION_TESTS: ${{ github.event.inputs.run-scion-tests || 'false' }}
-      BASIC_TESTS: ${{ github.event.inputs.run-basic-tests || 'true' }}
-      INTERNET_TESTS: ${{ github.event.inputs.run-internet-tests || 'true' }}
-      BLOCKCHAIN_TESTS: ${{ github.event.inputs.run-blockchain-tests || 'false' }}
-      QUICK_TESTS: ${{ github.event.inputs.run-quick-tests || 'false' }}
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: "**/*requirements.txt"
-      - run: pip install -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
-      - name: Run control-plane unit tests
-        run: python -m pytest -q tests/control_plane/test_bgp_control_plane_extensions.py
-      - name: Get scion-pki
-        if: ${{ env.SCION_TESTS == 'true' }}
-        run: |
-          curl -fsSL -O https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz
-          mkdir bin
-          tar -C bin -xzf scion_0.12.0_amd64_linux.tar.gz scion-pki
-      - name: Compile Examples
-        run: |
-          source development.env
-          export PATH=$PATH:$PWD/bin
-          CMD="tests/compile-and-build-test/compile-test.py"
-          if [ "$BASIC_TESTS" == "true" ]; then
-            CMD+=" --basic"
-          fi
-          if [ "$INTERNET_TESTS" == "true" ]; then
-            CMD+=" --internet"
-          fi
-          if [ "$BLOCKCHAIN_TESTS" == "true" ]; then
-            CMD+=" --blockchain"
-          fi
-          if [ "$SCION_TESTS" == "true" ]; then
-            CMD+=" --scion"
-          fi
-          python $CMD
-
-  run-tests:
-    name: Run Tests
-    needs: compile-examples # Only run heavy tests if quick compile test succeeds
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      SCION_TESTS: ${{ github.event.inputs.run-scion-tests || 'false' }}
-      BASIC_TESTS: ${{ github.event.inputs.run-basic-tests || 'true' }}
-      INTERNET_TESTS: ${{ github.event.inputs.run-internet-tests || 'true' }}
-      BLOCKCHAIN_TESTS: ${{ github.event.inputs.run-blockchain-tests || 'false' }}
-      QUICK_TESTS: ${{ github.event.inputs.run-quick-tests || 'false' }}
-      SEED_EMU_RUN_REAL_WORLD_TESTS: ${{ github.event.inputs.run-real-world-tests || 'false' }}
-    steps:
-      - name: Check out the source repository
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: 'pip'
-          cache-dependency-path: "**/*requirements.txt"
-      - run: pip install -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
-      - name: Get scion-pki
-        if: ${{ env.SCION_TESTS == 'true' }}
-        run: |
-          curl -fsSL -O https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz
-          mkdir bin
-          tar -C bin -xzf scion_0.12.0_amd64_linux.tar.gz scion-pki
-      - name: Run tests
-        run: |
-          source development.env
-          export PATH=$PATH:$PWD/bin
-          CMD="tests/run-tests.py"
-          if [ "$QUICK_TESTS" == "true" ]; then
-            CMD+=" --ci"
-          fi
-          if [ "$BASIC_TESTS" == "true" ]; then
-            CMD+=" --basic"
-          fi
-          if [ "$INTERNET_TESTS" == "true" ]; then
-            CMD+=" --internet"
-          fi
-          if [ "$BLOCKCHAIN_TESTS" == "true" ]; then
-            CMD+=" --blockchain"
-          fi
-          if [ "$SCION_TESTS" == "true" ]; then
-            CMD+=" --scion"
-          fi
-          python $CMD
-      - name: Archive test results
+      - name: Install Python dependencies
+        run: python -m pip install "setuptools<81" -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
+      - name: Run static checks
+        run: python tests/ci/run_ci.py static --artifact-dir ci-artifacts/static
+      - name: Upload static artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test_result
-          path: |
-            tests/test_result.txt
-            tests/**/test_log
-      - name: Check for errors
-        shell: bash
-        run: set +e; grep -E "^score" tests/test_result.txt | grep -Eq '[1-9][0-9]* errors|[1-9][0-9]* failures'; test $? -eq 1
+          name: static-ci-artifacts
+          path: ci-artifacts/static
 
-  build-examples:
-    name: Build Examples
-    needs: compile-examples # Only run heavy tests if quick compile test succeeds
+  unit:
+    name: Unit
+    needs: static
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      SCION_TESTS: ${{ github.event.inputs.run-scion-tests || 'false' }}
-      BASIC_TESTS: ${{ github.event.inputs.run-basic-tests || 'true' }}
-      INTERNET_TESTS: ${{ github.event.inputs.run-internet-tests || 'true' }}
-      BLOCKCHAIN_TESTS: ${{ github.event.inputs.run-blockchain-tests || 'false' }}
-      QUICK_TESTS: ${{ github.event.inputs.run-quick-tests || 'false' }}
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4
@@ -170,41 +63,89 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: "**/*requirements.txt"
-      - run: pip install -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
-      - name: Get scion-pki
-        if: ${{ github.event.inputs.run-scion-tests == 'true' }}
-        run: |
-          curl -fsSL -O https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_amd64_linux.tar.gz
-          mkdir bin
-          tar -C bin -xzf scion_0.12.0_amd64_linux.tar.gz scion-pki
-      - name: Build Examples
-        run: |
-          source development.env
-          export PATH=$PATH:$PWD/bin
-          cd tests/compile-and-build-test
-          CMD="compile-and-build-test.py"
-          if [ "$BASIC_TESTS" == "true" ]; then
-            CMD+=" --basic"
-          fi
-          if [ "$INTERNET_TESTS" == "true" ]; then
-            CMD+=" --internet"
-          fi
-          if [ "$BLOCKCHAIN_TESTS" == "true" ]; then
-            CMD+=" --blockchain"
-          fi
-          if [ "$SCION_TESTS" == "true" ]; then
-            CMD+=" --scion"
-          fi
-          python $CMD
-      - name: Archive test results
+      - name: Install Python dependencies
+        run: python -m pip install "setuptools<81" -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
+      - name: Run unit checks
+        run: python tests/ci/run_ci.py unit --artifact-dir ci-artifacts/unit
+      - name: Upload unit artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test_log
-          path: |
-            tests/compile-and-build-test/test_log/build_log.txt
-            tests/compile-and-build-test/test_log/log.txt
-      - name: Check for errors
-        shell: bash
-        run: set +e; grep -E "^score" tests/compile-and-build-test/test_log/log.txt | grep -Eq '[1-9][0-9]* errors|[1-9][0-9]* failures'; test $? -eq 1
+          name: unit-ci-artifacts
+          path: ci-artifacts/unit
+
+  example-compile:
+    name: Example Compile
+    needs: static
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "**/*requirements.txt"
+      - name: Install Python dependencies
+        run: python -m pip install "setuptools<81" -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
+      - name: Compile representative examples
+        run: python tests/ci/run_ci.py example-compile --artifact-dir ci-artifacts/example-compile
+      - name: Upload example compile artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-compile-ci-artifacts
+          path: ci-artifacts/example-compile
+
+  example-build:
+    name: Example Build
+    needs: example-compile
+    if: ${{ github.event_name == 'pull_request' || github.event.inputs['run-example-build'] == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "**/*requirements.txt"
+      - name: Install Python dependencies
+        run: python -m pip install "setuptools<81" -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
+      - name: Build selected examples
+        run: python tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-build
+      - name: Upload example build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-build-ci-artifacts
+          path: ci-artifacts/example-build
+
+  runtime-integration:
+    name: Runtime Integration
+    needs: example-build
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['run-runtime-integration'] == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the source repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "**/*requirements.txt"
+      - name: Install Python dependencies
+        run: python -m pip install "setuptools<81" -r requirements.txt -r dev-requirements.txt -r tests/requirements.txt
+      - name: Run runtime integration probes
+        run: python tests/ci/run_ci.py runtime-integration --artifact-dir ci-artifacts/runtime-integration
+      - name: Upload runtime integration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-integration-ci-artifacts
+          path: ci-artifacts/runtime-integration

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ client/backend/node_modules
 client/backend/bin
 *.bin
 output*
+ci-artifacts/
 project-words.txt
 .venv
 **/.obsidian/**

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -27,9 +27,10 @@ python3 tests/ci/run_ci.py example-compile --artifact-dir ci-artifacts/example-c
 python3 tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-build
 ```
 
-Runtime integration is available as an explicit entry point, but it is not a
-default pull-request gate in this PR:
+Docker image builds and runtime integration are available as explicit entry
+points, but they are not default pull-request gates in this PR:
 
 ```bash
+python3 tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-build
 python3 tests/ci/run_ci.py runtime-integration --artifact-dir ci-artifacts/runtime-integration
 ```

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -1,0 +1,35 @@
+# Feature-Oriented CI
+
+The pull-request workflow is intentionally organized around SEED features rather
+than broad example buckets. The manifest in `feature_manifest.json` is the source
+of truth for which features are covered by unit tests, representative example
+compilation, selected Docker builds, and optional runtime integration probes.
+
+The CI runner writes both human-readable logs and machine-readable artifacts:
+
+- `ci-summary.json` records every command, return code, duration, and log path.
+- `junit.xml` records the same stage in a format GitHub and review tooling can
+  ingest.
+- `feature-coverage.json` records the manifest-derived coverage state, including
+  declared gaps such as IPv6 work that has not landed on this integration line.
+
+The static stage compiles importable Python source plus representative examples.
+It intentionally excludes embedded payload templates under
+`seedemu/services/EthereumService/EthTemplates/`, where some historical `.py`
+filenames contain shell script content copied into containers.
+
+Run stages locally from the repository root:
+
+```bash
+python3 tests/ci/run_ci.py static --artifact-dir ci-artifacts/static
+python3 tests/ci/run_ci.py unit --artifact-dir ci-artifacts/unit
+python3 tests/ci/run_ci.py example-compile --artifact-dir ci-artifacts/example-compile
+python3 tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-build
+```
+
+Runtime integration is available as an explicit entry point, but it is not a
+default pull-request gate in this PR:
+
+```bash
+python3 tests/ci/run_ci.py runtime-integration --artifact-dir ci-artifacts/runtime-integration
+```

--- a/tests/ci/__init__.py
+++ b/tests/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Feature-oriented CI helpers for SEED Emulator."""

--- a/tests/ci/feature_manifest.json
+++ b/tests/ci/feature_manifest.json
@@ -1,0 +1,145 @@
+{
+  "schema": 1,
+  "features": {
+    "ipv4-default": {
+      "status": "covered",
+      "description": "Legacy IPv4 examples continue to compile and build without requiring any new control-plane capability.",
+      "unit_groups": [],
+      "compile_examples": ["basic-a00-simple-as"],
+      "build_examples": ["basic-a00-simple-as"],
+      "runtime_groups": []
+    },
+    "ipv6-core": {
+      "status": "declared-gap",
+      "description": "Repository-level IPv6 readiness is tracked here, but this integration branch does not yet carry the IPv6 readiness examples or runtime probes.",
+      "unit_groups": [],
+      "compile_examples": [],
+      "build_examples": [],
+      "runtime_groups": [],
+      "notes": "Do not mark IPv6 as covered on this branch until the IPv6 readiness work is merged into this integration line."
+    },
+    "routing-bird-frr": {
+      "status": "covered",
+      "description": "Router-selected BIRD/FRR backends are rendered by Routing from protocol-layer intent.",
+      "unit_groups": ["control-plane-unit"],
+      "compile_examples": ["basic-a12-bgp-mixed-backend"],
+      "build_examples": ["basic-a12-bgp-mixed-backend"],
+      "runtime_groups": ["control-plane-runtime"]
+    },
+    "exabgp-service": {
+      "status": "covered",
+      "description": "ExaBGP is exercised only as ExaBgpService plus Binding, including the IX speaker example.",
+      "unit_groups": ["control-plane-unit"],
+      "compile_examples": [
+        "basic-a13-exabgp-control-plane",
+        "internet-b30-mini-internet-exabgp-ix"
+      ],
+      "build_examples": ["basic-a13-exabgp-control-plane"],
+      "runtime_groups": ["control-plane-runtime"]
+    },
+    "looking-glass": {
+      "status": "covered",
+      "description": "Looking Glass remains a route-state observer and is tested separately from ExaBGP event streams.",
+      "unit_groups": ["control-plane-unit"],
+      "compile_examples": ["basic-a14-bgp-event-looking-glass"],
+      "build_examples": ["basic-a14-bgp-event-looking-glass"],
+      "runtime_groups": ["control-plane-runtime"]
+    },
+    "dns-endpoint": {
+      "status": "covered",
+      "description": "DNS endpoint behavior is represented by the mini Internet plus DNS example.",
+      "unit_groups": [],
+      "compile_examples": ["internet-b02-mini-internet-with-dns"],
+      "build_examples": ["internet-b02-mini-internet-with-dns"],
+      "runtime_groups": []
+    },
+    "legacy-guard": {
+      "status": "covered",
+      "description": "Removed legacy control-plane APIs stay removed through explicit guard tests.",
+      "unit_groups": ["control-plane-unit"],
+      "compile_examples": [],
+      "build_examples": [],
+      "runtime_groups": []
+    }
+  },
+  "unit_groups": {
+    "control-plane-unit": {
+      "description": "Control-plane API, rendering, service, and legacy guard checks.",
+      "pytest_args": ["tests/control_plane/test_bgp_control_plane_extensions.py"]
+    }
+  },
+  "runtime_groups": {
+    "control-plane-runtime": {
+      "description": "Docker runtime probes for selected BIRD/FRR, ExaBGP, and Looking Glass examples.",
+      "pytest_args": ["-m", "integration", "tests/control_plane/test_bgp_runtime_matrix.py"],
+      "default": false,
+      "notes": "Manual workflow-dispatch entry for this PR. PR3 will make runtime evidence richer and artifact-indexed."
+    }
+  },
+  "examples": {
+    "basic-a00-simple-as": {
+      "description": "Small IPv4 default behavior smoke example.",
+      "script": "examples/basic/A00_simple_as/simple_as.py",
+      "args": ["amd"],
+      "clean": ["output"],
+      "expected": ["output/docker-compose.yml"],
+      "compile": true,
+      "build": true
+    },
+    "basic-a12-bgp-mixed-backend": {
+      "description": "Mixed BIRD/FRR routing backend example.",
+      "script": "examples/basic/A12_bgp_mixed_backend/bgp_mixed_backend.py",
+      "args": ["amd"],
+      "clean": ["output"],
+      "expected": ["output/docker-compose.yml"],
+      "compile": true,
+      "build": true
+    },
+    "basic-a13-exabgp-control-plane": {
+      "description": "ExaBGP service plus Binding control-plane speaker example.",
+      "script": "examples/basic/A13_exabgp_control_plane/exabgp_control_plane.py",
+      "args": ["amd"],
+      "env": {
+        "SEED_A13_EXABGP_PORT": "5101"
+      },
+      "clean": ["output"],
+      "expected": ["output/docker-compose.yml"],
+      "compile": true,
+      "build": true
+    },
+    "basic-a14-bgp-event-looking-glass": {
+      "description": "Looking Glass route-state observer plus separate ExaBGP event dashboard example.",
+      "script": "examples/basic/A14_bgp_event_looking_glass/bgp_event_looking_glass.py",
+      "args": ["amd"],
+      "env": {
+        "SEED_A14_LG_PORT": "5002",
+        "SEED_A14_EVENT_PORT": "5003"
+      },
+      "clean": ["output"],
+      "expected": ["output/docker-compose.yml"],
+      "compile": true,
+      "build": true
+    },
+    "internet-b02-mini-internet-with-dns": {
+      "description": "Mini Internet with DNS component and local DNS endpoints.",
+      "script": "examples/internet/B02_mini_internet_with_dns/mini_internet_with_dns.py",
+      "args": ["amd"],
+      "clean": ["output", "base_internet.bin", "dns_component.bin"],
+      "expected": ["output/docker-compose.yml"],
+      "compile": true,
+      "build": true
+    },
+    "internet-b30-mini-internet-exabgp-ix": {
+      "description": "Internet-scale ExaBGP IX speaker compile coverage.",
+      "script": "examples/internet/B30_mini_internet_exabgp_ix/mini_internet_exabgp_ix.py",
+      "args": ["amd"],
+      "env": {
+        "SEED_B30_EXABGP_PORT": "5130"
+      },
+      "clean": ["output", "base_internet.bin"],
+      "expected": ["output/docker-compose.yml"],
+      "compile": true,
+      "build": false
+    }
+  }
+}

--- a/tests/ci/run_ci.py
+++ b/tests/ci/run_ci.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = Path(__file__).with_name("feature_manifest.json")
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "check"
+
+
+def _json_dump(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _tail(text: str, limit: int = 4000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[-limit:]
+
+
+def load_manifest() -> dict[str, Any]:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _validate_manifest(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("schema") != 1:
+        errors.append("manifest schema must be 1")
+
+    features = manifest.get("features", {})
+    unit_groups = manifest.get("unit_groups", {})
+    runtime_groups = manifest.get("runtime_groups", {})
+    examples = manifest.get("examples", {})
+    required_features = {
+        "ipv4-default",
+        "ipv6-core",
+        "routing-bird-frr",
+        "exabgp-service",
+        "looking-glass",
+        "dns-endpoint",
+        "legacy-guard",
+    }
+    missing = sorted(required_features.difference(features))
+    if missing:
+        errors.append(f"missing required feature declarations: {', '.join(missing)}")
+
+    for feature_id, feature in features.items():
+        for group_id in feature.get("unit_groups", []):
+            if group_id not in unit_groups:
+                errors.append(f"feature {feature_id} references missing unit group {group_id}")
+        for group_id in feature.get("runtime_groups", []):
+            if group_id not in runtime_groups:
+                errors.append(f"feature {feature_id} references missing runtime group {group_id}")
+        for example_id in feature.get("compile_examples", []):
+            if example_id not in examples:
+                errors.append(f"feature {feature_id} references missing compile example {example_id}")
+        for example_id in feature.get("build_examples", []):
+            if example_id not in examples:
+                errors.append(f"feature {feature_id} references missing build example {example_id}")
+
+    for example_id, example in examples.items():
+        script = REPO_ROOT / example.get("script", "")
+        if not script.is_file():
+            errors.append(f"example {example_id} script does not exist: {_rel(script)}")
+        for expected in example.get("expected", []):
+            if Path(expected).is_absolute():
+                errors.append(f"example {example_id} expected path must be relative: {expected}")
+        for clean in example.get("clean", []):
+            if Path(clean).is_absolute():
+                errors.append(f"example {example_id} clean path must be relative: {clean}")
+    return errors
+
+
+def feature_coverage(manifest: dict[str, Any]) -> dict[str, Any]:
+    features = {}
+    for feature_id, feature in sorted(manifest["features"].items()):
+        features[feature_id] = {
+            "status": feature["status"],
+            "description": feature.get("description", ""),
+            "unit_groups": feature.get("unit_groups", []),
+            "compile_examples": feature.get("compile_examples", []),
+            "build_examples": feature.get("build_examples", []),
+            "runtime_groups": feature.get("runtime_groups", []),
+            "notes": feature.get("notes", ""),
+        }
+    return {
+        "schema": manifest["schema"],
+        "generated_by": "tests/ci/run_ci.py",
+        "features": features,
+    }
+
+
+def _write_junit(stage: str, checks: list[dict[str, Any]], path: Path) -> None:
+    tests = len(checks)
+    failures = sum(1 for check in checks if check["status"] == "failed")
+    skipped = sum(1 for check in checks if check["status"] == "skipped")
+    suite = ET.Element(
+        "testsuite",
+        {
+            "name": f"seedemu-ci-{stage}",
+            "tests": str(tests),
+            "failures": str(failures),
+            "errors": "0",
+            "skipped": str(skipped),
+            "time": f"{sum(float(check.get('duration_s', 0.0)) for check in checks):.3f}",
+        },
+    )
+    for check in checks:
+        case = ET.SubElement(
+            suite,
+            "testcase",
+            {
+                "classname": f"seedemu.ci.{stage}",
+                "name": check["name"],
+                "time": f"{float(check.get('duration_s', 0.0)):.3f}",
+            },
+        )
+        if check["status"] == "failed":
+            failure = ET.SubElement(
+                case,
+                "failure",
+                {
+                    "message": check.get("message", "check failed"),
+                    "type": "CommandFailure",
+                },
+            )
+            failure.text = check.get("details", "")
+        elif check["status"] == "skipped":
+            skipped_node = ET.SubElement(case, "skipped", {"message": check.get("message", "skipped")})
+            skipped_node.text = check.get("details", "")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def _stage_result(stage: str, checks: list[dict[str, Any]], artifact_dir: Path) -> int:
+    summary = {
+        "stage": stage,
+        "status": "failed" if any(check["status"] == "failed" for check in checks) else "passed",
+        "checks": checks,
+    }
+    _json_dump(artifact_dir / "ci-summary.json", summary)
+    _write_junit(stage, checks, artifact_dir / "junit.xml")
+
+    print(f"[seed-ci] stage={stage} status={summary['status']} artifact_dir={_rel(artifact_dir)}")
+    for check in checks:
+        print(
+            "[seed-ci] "
+            f"{check['status']}: {check['name']} "
+            f"log={check.get('log_path', '')}"
+        )
+        if check["status"] == "failed":
+            command = check.get("command")
+            if command:
+                print(f"[seed-ci] failed-command: {' '.join(command)}")
+            details = (check.get("stderr_tail") or check.get("details") or "").strip()
+            if details:
+                print("[seed-ci] failure-tail:")
+                print(_tail(details, limit=1200))
+    return 1 if summary["status"] == "failed" else 0
+
+
+def _run_command(
+    name: str,
+    cmd: list[str],
+    artifact_dir: Path,
+    *,
+    cwd: Path = REPO_ROOT,
+    env: dict[str, str] | None = None,
+    timeout: int | None = None,
+) -> dict[str, Any]:
+    start = time.monotonic()
+    log_path = artifact_dir / "logs" / f"{_slug(name)}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        duration = time.monotonic() - start
+        log_path.write_text(
+            "COMMAND: {}\nCWD: {}\nEXIT: {}\n\nSTDOUT:\n{}\n\nSTDERR:\n{}\n".format(
+                " ".join(cmd),
+                _rel(cwd),
+                result.returncode,
+                result.stdout,
+                result.stderr,
+            ),
+            encoding="utf-8",
+        )
+        status = "passed" if result.returncode == 0 else "failed"
+        return {
+            "name": name,
+            "status": status,
+            "command": cmd,
+            "cwd": _rel(cwd),
+            "returncode": result.returncode,
+            "duration_s": duration,
+            "log_path": _rel(log_path),
+            "stdout_tail": _tail(result.stdout),
+            "stderr_tail": _tail(result.stderr),
+            "message": "command failed" if status == "failed" else "command passed",
+            "details": _tail(result.stdout + "\n" + result.stderr),
+        }
+    except Exception as exc:  # pragma: no cover - defensive diagnostics for CI infrastructure failures.
+        duration = time.monotonic() - start
+        details = traceback.format_exc()
+        log_path.write_text(details, encoding="utf-8")
+        return {
+            "name": name,
+            "status": "failed",
+            "command": cmd,
+            "cwd": _rel(cwd),
+            "returncode": None,
+            "duration_s": duration,
+            "log_path": _rel(log_path),
+            "message": str(exc),
+            "details": details,
+        }
+
+
+def _git_diff_check_command() -> list[str]:
+    base_ref = os.environ.get("GITHUB_BASE_REF")
+    if base_ref:
+        candidates = [f"origin/{base_ref}", base_ref]
+        for candidate in candidates:
+            probe = subprocess.run(
+                ["git", "rev-parse", "--verify", candidate],
+                cwd=str(REPO_ROOT),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if probe.returncode == 0:
+                return ["git", "diff", "--check", f"{candidate}...HEAD"]
+    return ["git", "diff", "--check"]
+
+
+def _example_ids(manifest: dict[str, Any], key: str) -> list[str]:
+    ids: list[str] = []
+    for example_id, example in manifest["examples"].items():
+        if example.get(key):
+            ids.append(example_id)
+    return ids
+
+
+def _pythonpath_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(REPO_ROOT) if not existing else f"{REPO_ROOT}:{existing}"
+    env.setdefault("DOCKER_BUILDKIT", "0")
+    env.setdefault("COMPOSE_BAKE", "false")
+    env.setdefault("COMPOSE_PARALLEL_LIMIT", "1")
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _pytest_env() -> dict[str, str]:
+    return _pythonpath_env({"PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"})
+
+
+def _safe_clean(example_dir: Path, relative_paths: Iterable[str]) -> None:
+    base = example_dir.resolve()
+    for item in relative_paths:
+        target = (example_dir / item).resolve()
+        if target == base or base not in target.parents:
+            raise ValueError(f"refusing to clean path outside example directory: {target}")
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+
+
+def _compile_example(
+    example_id: str,
+    example: dict[str, Any],
+    artifact_dir: Path,
+    *,
+    clean: bool,
+    name_prefix: str = "compile",
+) -> dict[str, Any]:
+    script = REPO_ROOT / example["script"]
+    example_dir = script.parent
+    if clean:
+        _safe_clean(example_dir, example.get("clean", []))
+    cmd = [sys.executable, script.name] + list(example.get("args", []))
+    check = _run_command(
+        f"{name_prefix}:{example_id}",
+        cmd,
+        artifact_dir,
+        cwd=example_dir,
+        env=_pythonpath_env(example.get("env", {})),
+        timeout=int(example.get("timeout", 900)),
+    )
+    if check["status"] != "passed":
+        return check
+
+    missing = [item for item in example.get("expected", []) if not (example_dir / item).exists()]
+    if missing:
+        check["status"] = "failed"
+        check["message"] = "expected compile outputs are missing"
+        check["details"] = "Missing outputs: " + ", ".join(missing)
+    return check
+
+
+def run_static(artifact_dir: Path) -> int:
+    manifest = load_manifest()
+    checks: list[dict[str, Any]] = []
+
+    errors = _validate_manifest(manifest)
+    coverage = feature_coverage(manifest)
+    _json_dump(artifact_dir / "feature-coverage.json", coverage)
+    checks.append(
+        {
+            "name": "manifest",
+            "status": "failed" if errors else "passed",
+            "duration_s": 0.0,
+            "message": "manifest validation failed" if errors else "manifest validation passed",
+            "details": "\n".join(errors),
+            "log_path": _rel(artifact_dir / "feature-coverage.json"),
+        }
+    )
+
+    checks.append(_run_command("whitespace", _git_diff_check_command(), artifact_dir))
+
+    compile_targets = [
+        "seedemu",
+        "tests/control_plane",
+        "tests/ci",
+    ]
+    example_dirs = sorted(
+        {
+            str(Path(manifest["examples"][example_id]["script"]).parent)
+            for example_id in _example_ids(manifest, "compile")
+        }
+    )
+    compile_targets.extend(example_dirs)
+    checks.append(
+        _run_command(
+            "compileall",
+            [
+                sys.executable,
+                "-m",
+                "compileall",
+                "-q",
+                "-x",
+                "seedemu/services/EthereumService/EthTemplates/",
+            ]
+            + compile_targets,
+            artifact_dir,
+        )
+    )
+
+    smoke = (
+        "import seedemu; "
+        "from seedemu.layers import Base, Routing, Ebgp, Ibgp, Ospf; "
+        "from seedemu.services import ExaBgpService, BgpLookingGlassService; "
+        "from seedemu.compiler import Docker; "
+        "import tests.ci.run_ci"
+    )
+    checks.append(_run_command("import-smoke", [sys.executable, "-c", smoke], artifact_dir, env=_pythonpath_env()))
+    return _stage_result("static", checks, artifact_dir)
+
+
+def run_unit(artifact_dir: Path) -> int:
+    manifest = load_manifest()
+    checks: list[dict[str, Any]] = []
+    for group_id, group in manifest["unit_groups"].items():
+        junit_path = artifact_dir / f"pytest-{_slug(group_id)}.xml"
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            f"--junitxml={junit_path}",
+        ] + list(group["pytest_args"])
+        checks.append(_run_command(f"pytest:{group_id}", cmd, artifact_dir, env=_pytest_env(), timeout=900))
+    return _stage_result("unit", checks, artifact_dir)
+
+
+def run_example_compile(artifact_dir: Path) -> int:
+    manifest = load_manifest()
+    checks = [
+        _compile_example(example_id, manifest["examples"][example_id], artifact_dir, clean=True)
+        for example_id in _example_ids(manifest, "compile")
+    ]
+    return _stage_result("example-compile", checks, artifact_dir)
+
+
+def run_example_build(artifact_dir: Path) -> int:
+    manifest = load_manifest()
+    checks: list[dict[str, Any]] = []
+    for example_id in _example_ids(manifest, "build"):
+        example = manifest["examples"][example_id]
+        compile_check = _compile_example(
+            example_id,
+            example,
+            artifact_dir,
+            clean=True,
+            name_prefix="compile-before-build",
+        )
+        checks.append(compile_check)
+        if compile_check["status"] != "passed":
+            continue
+
+        script = REPO_ROOT / example["script"]
+        compose_file = script.parent / "output" / "docker-compose.yml"
+        checks.append(
+            _run_command(
+                f"docker-build:{example_id}",
+                ["docker", "compose", "-f", str(compose_file), "build"],
+                artifact_dir,
+                env=_pythonpath_env(example.get("env", {})),
+                timeout=int(example.get("build_timeout", 1800)),
+            )
+        )
+    return _stage_result("example-build", checks, artifact_dir)
+
+
+def run_runtime_integration(artifact_dir: Path) -> int:
+    manifest = load_manifest()
+    checks: list[dict[str, Any]] = []
+    for group_id, group in manifest["runtime_groups"].items():
+        junit_path = artifact_dir / f"pytest-{_slug(group_id)}.xml"
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            f"--junitxml={junit_path}",
+        ] + list(group["pytest_args"])
+        checks.append(_run_command(f"runtime:{group_id}", cmd, artifact_dir, env=_pytest_env(), timeout=7200))
+    return _stage_result("runtime-integration", checks, artifact_dir)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run feature-oriented SEED Emulator CI stages.")
+    parser.add_argument(
+        "stage",
+        choices=["static", "unit", "example-compile", "example-build", "runtime-integration"],
+    )
+    parser.add_argument("--artifact-dir", default="ci-artifacts", help="Directory for logs, JSON, and JUnit output.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    artifact_dir = (REPO_ROOT / args.artifact_dir).resolve()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    if args.stage == "static":
+        return run_static(artifact_dir)
+    if args.stage == "unit":
+        return run_unit(artifact_dir)
+    if args.stage == "example-compile":
+        return run_example_compile(artifact_dir)
+    if args.stage == "example-build":
+        return run_example_build(artifact_dir)
+    if args.stage == "runtime-integration":
+        return run_runtime_integration(artifact_dir)
+    raise AssertionError(f"unknown stage: {args.stage}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR replaces the legacy pull-request CI shape with a feature-oriented pipeline that is easier to diagnose, review, and extend for the expanded control-plane work.

It is intentionally scoped as the CI architecture PR in the three-step cleanup plan. It does not add the richer runtime probe/evidence layer from the next PR, and it does not claim IPv6 runtime coverage that has not landed on this integration line yet.

## What changed

- Replaced the old broad `compile-examples` / `run-tests` / `build-examples` PR workflow with explicit stages:
  - `static`
  - `unit`
  - `example-compile`
  - opt-in `example-build` for workflow dispatch
  - opt-in `runtime-integration` for workflow dispatch
- Added `tests/ci/feature_manifest.json` as the source of truth for feature coverage:
  - `ipv4-default`
  - `ipv6-core`
  - `routing-bird-frr`
  - `exabgp-service`
  - `looking-glass`
  - `dns-endpoint`
  - `legacy-guard`
- Added `tests/ci/run_ci.py`, a small CI runner that emits:
  - `ci-summary.json`
  - `junit.xml`
  - `feature-coverage.json` for the static stage
  - per-check command logs
- Removed the fragile grep-based `score` parsing from the pull-request gate.
- Pinned workflow dependency installation to `setuptools<81` because the repository still carries older `web3`/Ethereum dependencies that import `pkg_resources`.
- Disabled pytest third-party plugin autoload inside the CI runner so feature tests are not affected by unrelated plugins installed through transitive dependencies.

## Design notes

- The manifest explicitly marks `ipv6-core` as a `declared-gap` on this integration branch. That is deliberate: the CI architecture can represent IPv6 readiness, but this PR must not overstate runtime coverage before the IPv6 readiness work is synchronized into the branch.
- Control-plane coverage stays aligned with the accepted design boundary:
  - routers select BIRD/FRR backends;
  - protocol layers record intent;
  - `Routing` renders daemon configs;
  - ExaBGP remains `ExaBgpService + Binding`;
  - Looking Glass remains separate from ExaBGP event streams.
- Docker image builds and runtime integration remain available as explicit workflow-dispatch stages. The default PR gate stays fast and diagnostic; the next PR should expand runtime probes and artifact indexing instead of hiding that work in this CI architecture change.

## Validation

Local checks completed:

- `git diff --check`
- `python3 -m json.tool tests/ci/feature_manifest.json`
- `python3 -m compileall -q tests/ci`
- `python3 -m compileall -q -x 'seedemu/services/EthereumService/EthTemplates/' seedemu tests/control_plane tests/ci examples/basic/A00_simple_as examples/basic/A12_bgp_mixed_backend examples/basic/A13_exabgp_control_plane examples/basic/A14_bgp_event_looking_glass examples/internet/B02_mini_internet_with_dns examples/internet/B30_mini_internet_exabgp_ix`

Local environment note:

- The local machine only has Python 3.12, while the workflow intentionally runs Python 3.10.
- Running the new CI runner under Python 3.12 reaches existing dependency compatibility failures before SEED code executes, for example old `requests==2.22.0` / `urllib3==1.25.11` and old Ethereum/web3 dependencies.
- The workflow remains pinned to Python 3.10, matching the existing CI environment, and should be treated as the authoritative validation for these stages.

## Review focus

Please review:

- whether the feature manifest names and coverage boundaries are acceptable;
- whether the selected representative examples are the right PR gate set;
- whether `example-build` and `runtime-integration` should remain workflow-dispatch-only until the next runtime evidence PR;
- whether the CI artifacts are sufficient for human and future AI-assisted review.
