### PR TITLE
IPv6 readiness helper foundation

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,91 @@
+# IPv6 Branch Goal
+
+This file is the branch handoff contract for future agents working on
+`feat/ipv6-control-plane`. The goal is fixed; the implementation path may
+evolve as the repository reveals better integration points.
+
+## Final Objective
+
+Make IPv6 a repository-level optional capability of SEED Emulator.
+
+The branch should let users build existing IPv4 emulations exactly as before,
+while allowing new or migrated scenarios to opt into dual-stack IPv4/IPv6
+behavior through explicit topology and service APIs. IPv6 must become part of
+the simulator model, not a demo-only patch inside a few examples.
+
+In practice, the final state should support these observations:
+
+- Existing IPv4 examples, APIs, generated files, and runtime behavior remain
+  stable by default.
+- A scenario can explicitly enable IPv6 at the `Base`, network, interface, or
+  service boundary and receive deterministic IPv6 topology state.
+- Core topology objects own address state; layers own protocol intent; services
+  consume model state; compilers emit runnable artifacts.
+- BIRD, FRR, ExaBGP, and Looking Glass can prove dual-stack control-plane
+  behavior at runtime.
+- Repository services migrate incrementally through shared address-family and
+  endpoint helpers instead of each service inventing its own IPv6 conventions.
+- Documentation states what is supported, what is compatible but not migrated,
+  and what remains IPv4-only or requires a separate design.
+
+## Non-Negotiable Design Rules
+
+- IPv4 remains the default. Do not emit IPv6 state unless the topology or
+  service explicitly asked for it.
+- Keep old IPv4 public methods stable. `getAddress()` and `getPrefix()` retain
+  IPv4 semantics; IPv6 uses explicit accessors or family-aware helpers.
+- Do not move daemon syntax into protocol intent layers. `Ebgp`, `Ibgp`, and
+  `Ospf` record intent; `Routing` renders BIRD/FRR syntax.
+- Router backend selection belongs on `Router`, for example
+  `createRouter(..., routingBackend="bird|frr")`.
+- ExaBGP remains a service speaker installed with `ExaBgpService + Binding`,
+  not a full routing layer or transit-router backend.
+- Looking Glass remains a route-state observer service. Do not merge it with
+  ExaBGP event/dashboard semantics.
+- Do not claim full IPv6 support for a component until code, docs, examples,
+  and regression tests prove it.
+
+## Branch Scope
+
+This branch is for IPv6 control-plane and repository readiness. It includes:
+
+- Core optional IPv6 address state and deterministic allocation.
+- Docker dual-stack compilation for modeled IPv6 networks.
+- BIRD/FRR BGP and OSPFv3 rendering.
+- ExaBGP IPv6 announcements and live control-plane operations.
+- Looking Glass IPv4/IPv6 route-state observation.
+- Repository-wide migration rules, endpoint helpers, DNS and `/etc/hosts`
+  baseline dual-stack readiness.
+
+This branch should not silently absorb unrelated work. Keep these as separate
+designs unless the user explicitly changes scope:
+
+- email full IPv6 migration;
+- k8s;
+- internetmap2;
+- SCION underlay dual-stack redesign;
+- MPLS/EVPN redesign;
+- DHCPv6/SLAAC;
+- real-world connectivity/OpenVPN IPv6.
+
+## Completion Definition
+
+The branch is ready when all of the following are true:
+
+- Old IPv4 tests/examples still compile and do not gain unintended IPv6 output.
+- New IPv6 examples demonstrate real runtime behavior, not only generated
+  configuration.
+- Shared helpers exist for address-family selection and endpoint formatting.
+- Migrated services use those helpers and keep IPv4 behavior unchanged.
+- Design docs and user docs explain the model boundaries and readiness matrix.
+- Each commit is scoped, reviewable, and tied to a real capability or test.
+
+## Primary References
+
+- `docs/designs/ipv6-control-plane-design.md`
+- `docs/designs/ipv6-repository-readiness-design.md`
+- `docs/user_manual/ipv6.md`
+- `ai/design-principles.md`
+- `ai/skills/ipv6-control-plane/SKILL.md`
+- `test_bgp_control_plane_extensions.py`
+- `test_ipv6_repository_readiness.py`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,237 @@
+# IPv6 Branch Development Spec
+
+This file tells future agents how to continue the IPv6 branch without
+restarting the design or breaking existing SEED behavior.
+
+## Working Context
+
+- Work in `/home/zzw/seed-dev/worktrees/ipv6-control-plane`.
+- Stay on `feat/ipv6-control-plane` unless the user explicitly asks otherwise.
+- Do not switch to `master` for development.
+- The root `ai/` directory is project knowledge: principles, skills, and future
+  extension planning. It is not the Codex runtime root and should not be moved.
+- Before changing code, read the relevant design docs and the local skill:
+  `docs/designs/ipv6-control-plane-design.md`,
+  `docs/designs/ipv6-repository-readiness-design.md`,
+  `docs/user_manual/ipv6.md`, `ai/design-principles.md`, and
+  `ai/skills/ipv6-control-plane/SKILL.md`.
+
+## Architecture Contract
+
+SEED's existing separation of concerns must stay intact.
+
+| Layer | Responsibility | IPv6 rule |
+| --- | --- | --- |
+| core | topology objects, addresses, prefixes, bindings, endpoints | Store IPv6 beside IPv4; keep IPv4 APIs stable. |
+| layers | routing/system intent | Record address-family intent only. |
+| services | daemon/application configuration | Consume core state and helpers; do not invent topology state. |
+| compiler | runnable artifacts | Emit IPv6 only when model state contains IPv6. |
+| examples | user-visible proof | Add IPv6 variants; do not weaken old examples. |
+| docs/tests | contract and evidence | State support level and prove regressions. |
+
+Use this mental model when deciding where code belongs:
+
+```text
+Base / AS / IX / Network / Interface
+  -> carry IPv4 and optional IPv6 topology state
+Ebgp / Ibgp / Ospf
+  -> record backend-neutral protocol and family intent
+Routing
+  -> renders BIRD or FRR syntax
+Services
+  -> read addresses/endpoints and generate service config
+Docker
+  -> compiles modeled networks, addresses, sysctls, and files
+```
+
+## Address-Family API Rules
+
+- `Network.getPrefix()` returns IPv4 and must remain compatible.
+- `Interface.getAddress()` returns IPv4 and must remain compatible.
+- Use `Network.hasIpv6Prefix()` and `Network.getIpv6Prefix()` for IPv6
+  prefixes.
+- Use `Interface.hasIpv6Address()` and `Interface.getIpv6Address()` for IPv6
+  addresses.
+- Use family-aware helpers from `seedemu.core` when formatting endpoints:
+  `AddressFamily`, `getInterfaceAddress`, `formatHostPort`, `formatUrl`, and
+  `formatMultiaddr`.
+- Do not manually concatenate IPv6 `host:port` strings. IPv6 literals need
+  bracket handling in URLs and socket-like strings.
+- A service must explicitly choose IPv4, IPv6, or dual-stack. It must not assume
+  that the first interface's `getAddress()` is the only address.
+
+## IPv6 Addressing Rules
+
+- Default root prefix: `2000::/12`.
+- Reserved infrastructure prefix: `2000:ffff::/48`.
+- Automatic AS allocation: stable `/48` per AS.
+- Automatic local network allocation: stable `/64` per AS network.
+- Automatic IX LAN allocation: stable `/64` per Internet Exchange.
+- Explicit IPv6 prefixes under the configured root must be claimed so later
+  automatic allocation cannot collide.
+- Per-network opt-out must remain available with `ipv6Prefix=None`.
+- Per-interface opt-out must remain available with `ipv6Address=None`.
+- Do not change the old `10.0.0.0/8` style IPv4 examples as part of IPv6 work
+  unless a test requires it.
+
+## Routing and Control Plane Rules
+
+- Router daemon selection belongs on `Router`, not a new layer.
+- `Ebgp`, `Ibgp`, and `Ospf` are intent layers. They may record families,
+  peers, areas, relationships, and policy, but they should not write BIRD/FRR
+  daemon syntax.
+- `Routing` is the backend renderer for BIRD and FRR.
+- BIRD IPv4 and IPv6 tables must stay separate where daemon semantics require
+  it.
+- OSPFv2 and OSPFv3 must stay separate. Do not reuse an IPv4 OSPF table for
+  IPv6.
+- FRR IPv6 BGP belongs in `address-family ipv6 unicast`.
+- ExaBGP is a service speaker. It should peer on an explicit shared network and
+  render family-aware ExaBGP config.
+- Looking Glass observes route state. It should expose IPv4 and IPv6 outputs
+  clearly without mixing with ExaBGP event streams.
+
+## Service Migration Rules
+
+Migrate services incrementally. A service is not "IPv6 supported" until it has
+implementation, docs, and verification.
+
+Recommended service tiers:
+
+| Tier | Area | Rule |
+| --- | --- | --- |
+| 1 | `EtcHosts`, DNS, DNS cache, Web/CA, Traffic | Prefer early migration because many other services depend on endpoints. |
+| 2 | ExaBGP, Looking Glass | Keep tightening tests and docs around the control plane. |
+| 3 | Email, Kubo, Tor, Ethereum, Monero, Chainlink | Migrate one service at a time through endpoint helpers. |
+| 4 | SCION, MPLS/EVPN, DHCP, RealWorldRouter, OpenVPN, k8s | Require separate designs before broad IPv6 claims. |
+
+Service migration checklist:
+
+1. Preserve the old IPv4 path.
+2. Add explicit address-family selection or dual-stack generation only when the
+   target node/network has IPv6 state.
+3. Use shared endpoint helpers for URL, socket, host-port, and multiaddr text.
+4. Add a minimal IPv6 or dual-stack test/example.
+5. Update readiness docs without overstating support.
+
+## Testing Rules
+
+Generated files are not enough. Control-plane work needs runtime evidence when
+the changed behavior affects daemons or services.
+
+Minimum static checks for most IPv6 branch changes:
+
+```bash
+python3 -m compileall seedemu examples/basic/A15_bgp_ipv6_dual_stack examples/basic/A16_exabgp_ipv6_control_plane examples/basic/A17_ipv6_looking_glass
+python3 -m pytest -q test_ipv6_repository_readiness.py test_bgp_control_plane_extensions.py
+git diff --check
+```
+
+When touching examples, regenerate the relevant `output` directory and inspect
+generated Compose/config files. For old IPv4 examples, verify that default
+output does not contain unintended IPv6 fields such as `enable_ipv6`,
+`ipv6_address`, or IPv6 IPAM.
+
+Runtime checks should use a unique Compose project name to avoid stale
+containers:
+
+```bash
+cd examples/basic/A15_bgp_ipv6_dual_stack
+rm -rf output
+python3 ./bgp.py
+cd output
+COMPOSE_PROJECT_NAME=seedemu_a15_ipv6 docker compose up -d
+docker compose ps
+```
+
+Typical runtime evidence:
+
+```bash
+docker exec <router-or-host> ip -6 addr
+docker exec <bird-router> birdc show protocols
+docker exec <bird-router> birdc show route all
+docker exec <frr-router> vtysh -c 'show bgp ipv6 unicast'
+docker exec <frr-router> vtysh -c 'show ipv6 ospf6 neighbor'
+docker exec <frr-router> vtysh -c 'show ipv6 route bgp'
+```
+
+ExaBGP IPv6 evidence:
+
+```bash
+docker exec <exabgp-node> grep -n 'ipv6 unicast' /etc/exabgp/exabgp.conf
+docker exec <exabgp-node> sh -lc "printf 'announce route 2001:db8:100::/64 next-hop self\n' > /run/exabgp/live.in"
+docker exec <peer-router> vtysh -c 'show bgp ipv6 unicast'
+docker exec <exabgp-node> sh -lc "printf 'withdraw route 2001:db8:100::/64 next-hop self\n' > /run/exabgp/live.in"
+```
+
+Looking Glass evidence:
+
+```bash
+curl -fsS http://127.0.0.1:<published-port>/api/state
+```
+
+The expected observation is not just "the API returns JSON"; it must include
+IPv4/IPv6 route-state for registered routers when the example is dual-stack.
+
+Clean up between runtime checks:
+
+```bash
+docker compose down -v
+```
+
+## Git Discipline
+
+- Do not commit unrelated generated output, temporary logs, caches, or ad-hoc
+  demo notes.
+- Keep commits scoped by capability: core API, compiler, routing renderer,
+  service migration, docs, tests, examples.
+- Before committing, run the smallest meaningful test set plus `git diff
+  --check`.
+- Inspect `git diff --stat` and `git status --short` before commit.
+- Commit messages should explain the capability, not the implementation noise.
+  Good shape: `ipv6: add repository readiness contract`.
+- Do not rewrite or reset user changes. If the worktree is dirty, identify what
+  belongs to the current task and leave unrelated changes alone.
+- Do not push unless the user explicitly asks to push.
+
+## Documentation Rules
+
+- Keep design docs precise and honest. Do not market unfinished services as
+  IPv6-supported.
+- Put branch design in `docs/designs/`.
+- Put user-facing behavior in `docs/user_manual/ipv6.md`.
+- Put future-agent principles and reusable skills under `ai/`.
+- If code behavior changes, update docs in the same commit or an adjacent
+  commit before handing off.
+
+## How to Start a New Development Session
+
+Use this sequence before coding:
+
+```bash
+cd /home/zzw/seed-dev/worktrees/ipv6-control-plane
+git status --short --branch
+git diff --stat
+sed -n '1,220p' GOAL.md
+sed -n '1,260p' SPEC.md
+sed -n '1,260p' TASKS.md
+sed -n '1,220p' ai/skills/ipv6-control-plane/SKILL.md
+```
+
+Then inspect the specific files for the task. Do not begin by searching the
+whole repository for every IPv6 string unless the task truly requires a broad
+audit.
+
+## How to Decide Whether a Change Belongs Here
+
+A change belongs on this branch when it advances optional repository-level IPv6
+readiness without changing default IPv4 behavior.
+
+A change probably does not belong here when it:
+
+- changes a service's application semantics without IPv6 necessity;
+- rewrites examples for presentation only;
+- introduces a new daemon family unrelated to IPv6 readiness;
+- changes k8s, email, internetmap2, or SCION behavior without a dedicated
+  design and user approval;
+- makes IPv6 mandatory for old examples.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,331 @@
+# IPv6 Branch Task Map
+
+This is an initial task map for future agents. It is intentionally not a rigid
+ticket list. The goal in `GOAL.md` is fixed; the order here may change when
+tests or code review reveal a better path.
+
+## Current Baseline
+
+Already established in this branch:
+
+- optional IPv6 core state for networks and interfaces;
+- deterministic IPv6 allocation under default `2000::/12`;
+- Docker dual-stack output for IPv6-enabled networks;
+- BIRD/FRR IPv6 BGP and OSPFv3 rendering;
+- ExaBGP IPv6 control-plane announcements;
+- Looking Glass IPv6 route-state observation;
+- repository readiness design and user manual updates;
+- shared endpoint/address helpers in `seedemu.core`;
+- baseline dual-stack DNS and `/etc/hosts` behavior;
+- IPv6-aware `Filter` / `Binding` matching;
+- optional IPv6 service network and custom container attachment support.
+
+Before adding more work, verify the baseline still passes:
+
+```bash
+python3 -m pytest -q test_ipv6_repository_readiness.py test_bgp_control_plane_extensions.py
+git diff --check
+```
+
+## Phase 1: Stabilize the Current Branch State
+
+- Review the current uncommitted diff and split it into clean commit groups.
+- Confirm docs, tests, and code describe the same IPv6 contract.
+- Run the static validation suite.
+- Regenerate A15-A17 output only when the examples or compiler behavior changed.
+- Confirm old IPv4 examples do not gain IPv6 Compose fields by default.
+- Commit only clean source/docs/tests. Avoid generated output unless the repo
+  convention for that example requires it.
+
+Suggested commit groups:
+
+- core address-family helpers and Binding/Filter readiness;
+- Docker compiler and attachment IPv6 support;
+- DNS and `/etc/hosts` baseline dual-stack readiness;
+- repository design/user docs;
+- tests.
+
+## Phase 2: Core Contract Gaps
+
+- Audit remaining core APIs that carry endpoints or addresses.
+- Add family-aware helpers only where repeated service logic would otherwise
+  duplicate formatting or selection.
+- Extend tests for IPv4/IPv6 prefix conflict detection.
+- Add or tighten tests for `Filter`/`Binding` IPv4 and IPv6 matching.
+- Verify service network IPv4-only and dual-stack compile paths.
+- Verify `attachCustomContainer` and `attachInternetMap` IPv4-only and
+  dual-stack compile paths.
+- Decide whether `crossConnect(...)` needs a separate design doc before any
+  implementation. Do not casually add dual-stack cross-connect behavior because
+  SCION and legacy examples depend on it.
+
+Current readiness coverage added in `test_ipv6_repository_readiness.py`:
+
+- explicit IPv6 local prefixes are claimed and automatic `/64` allocation skips
+  them;
+- explicit IPv6 prefixes that overlap the configured root without being a root
+  subnet are rejected, while fully disjoint prefixes outside the root remain
+  user-managed;
+- reserved infrastructure prefixes and explicit IX prefixes are claimed so
+  automatic AS allocation cannot collide with them;
+- late `Base.enableIpv6()` rejects overlapping explicit AS/IX IPv6 prefixes;
+- late `Base.enableIpv6()` claims existing explicit prefixes before future
+  automatic allocation;
+- explicit IPv6 root, AS/IX network, route-server, service-network, and
+  interface topology inputs tolerate padded literals, bracketed IPv6 literals,
+  and CIDRs through shared normalization helpers;
+- explicit IPv4/IPv6 interface address inputs route through shared address
+  literal normalization while keeping `getAddress()` as IPv4 and
+  `getIpv6Address()` as IPv6;
+- `Filter` / `Binding` can require explicit IPv4 and IPv6 matches together;
+- `Filter` / `Binding` candidate matching uses shared interface address
+  helpers and preserves mixed legacy `ip` / explicit IPv4/IPv6 prefix AND
+  matching semantics;
+- node address/prefix matching helpers are shared by `Binding` and CA
+  certificate-install filters instead of duplicating address-family logic;
+- `Filter` / `Binding` address and prefix selectors tolerate padded IPv4/IPv6
+  literals, bracketed IPv6 literals, and CIDRs without changing their match
+  semantics;
+- explicit-family `Filter` selectors such as `ipv4`, `ipv6`, `ipv4Prefix`, and
+  `ipv6Prefix` use shared node match helpers with a family guard so wrong-family
+  literals do not accidentally match;
+- shared prefix normalization canonicalizes IPv4/IPv6 CIDR inputs for
+  `Binding`, node prefix matching, and ExaBGP announcements without changing
+  IPv4 defaults;
+- service network compile output remains IPv4-only by default, becomes
+  dual-stack only when `serviceNetworkIpv6Prefix` is set, and emits
+  per-node `ipv6_address` only for interfaces carrying IPv6 state;
+- `attachCustomContainer(...)` and `attachInternetMap(...)` cover explicit
+  IPv6 addresses without changing their IPv4-only default, and neither
+  attachment path invents a per-container IPv6 address on a dual-stack network
+  unless one is provided explicitly. Explicit static IPv4/IPv6 attachment
+  addresses now route through shared address-literal normalization before
+  compose fields and metadata labels are generated, and mismatched address
+  families are rejected.
+
+## Phase 3: Endpoint and DNS Foundation
+
+- Make `EtcHosts` output stable for dual-stack nodes.
+- Keep authoritative DNS A records unchanged for IPv4-only scenarios.
+- Generate AAAA records only when node/interface IPv6 state exists.
+- Confirm DNS cache/root-hint behavior stays compatible with old IPv4 flows.
+- Add focused tests for helper formatting:
+  `formatHostPort`, `formatUrl`, and `formatMultiaddr`.
+- Document endpoint helper rules in service-author docs.
+
+Current readiness coverage added in `test_ipv6_repository_readiness.py`:
+
+- endpoint helper tests cover `formatHost`, IPv4, IPv6, padded host literals,
+  DNS names, URL paths, bracketed IPv6 host inputs, bracketed IPv6 authorities
+  with ports, explicit-port override for legacy IPv4, DNS-name, and bracketed
+  IPv6 authorities, malformed bracketed IPv6 authority rejection, query-only
+  and fragment-only URL components, padded explicit ports for host-port, URL,
+  and multiaddr helpers, empty/non-numeric explicit port rejection, and padded
+  multiaddr formatting;
+- service-author documentation now records the IPv4-first address API contract
+  and the shared helper rule for URL, host-port, multiaddr, and node-address
+  selection; Kubo and Traffic developer notes align with their current explicit
+  address-family APIs;
+- shared prefix helper tests cover padded and bracketed IPv4/IPv6 CIDR inputs;
+- shared DNS-style address-record normalization covers manual A/AAAA literals,
+  including bracketed IPv6 literals, without changing non-address record
+  handling, and rejects manual A/AAAA records whose address literal does not
+  match the requested record family;
+- address-family normalization accepts common user-facing and socket-family
+  spellings such as `ipv4`, `ip6`, `inet`, and `AF_INET6`;
+- migrated service endpoint address-family APIs reuse the shared normalizer
+  for padded aliases instead of interpreting family strings locally;
+- authoritative DNS and `/etc/hosts` keep IPv4-only defaults and emit AAAA only
+  when IPv6 interface state exists; manual authoritative A/AAAA records
+  normalize explicit IPv4/IPv6 address literals on add/delete;
+- `/etc/hosts` intentionally keeps Bridge/service-network addresses so
+  service-only nodes remain resolvable, while continuing to skip IX peering
+  addresses that should not become host aliases;
+- reverse DNS keeps the existing IPv4 `in-addr.arpa.` PTR generation and adds
+  `ip6.arpa.` PTR records only for interfaces carrying IPv6 state;
+- DNS cache root hints and forward zones preserve IPv4 while accepting IPv6
+  authoritative records; manual root hints normalize A/AAAA address literals,
+  and imported forwarder addresses normalize padded records;
+- DNS cache address selection is Local IPv4 first, then Local IPv6, then first
+  available interface fallback for compatibility with service-network-only
+  nodes.
+- explicit Base/AS/Node resolver nameserver inputs normalize padded IPv4/IPv6
+  literals before writing `resolv.conf` commands.
+- `ResolvConfHook` and `ResolvConfHookByAs` resolver nameserver inputs reuse
+  shared address-list normalization before writing `resolv.conf` commands.
+- DNS authoritative and cache service address selection and A/AAAA record
+  literal/address-list normalization now route through shared core helpers
+  instead of service-local duplication.
+- DNS glue records and manual master IPs normalize explicit IPv4/IPv6 address
+  literals, including bracketed IPv6 literals, before generating A/AAAA records,
+  slave master lists, or forwarder lists; manual and imported master-IP zone
+  keys are normalized to canonical DNS zone names before lookup/output; authoritative
+  zone creation and hosting inputs are normalized to the same canonical zone
+  names so padded zone strings do not leak into zone files, BIND zone names, or
+  cache fallback lookups.
+- Domain Registrar dynamic DNS updates preserve A as the default record type
+  and allow users to explicitly submit AAAA records while rejecting A/AAAA
+  updates whose submitted IP address does not match the selected record family,
+  without changing DNS server placement or runtime assumptions.
+- DNS cache forward-zone fallback now resolves canonical zone-server names
+  through shared node-address helpers, preserving IPv4 defaults while adding
+  IPv6 forwarders only when authoritative zone-server nodes carry IPv6 state.
+  Forward-zone names are normalized to canonical DNS zone names before master
+  lookups and BIND forward-zone output are generated.
+
+## Phase 4: Control-Plane Runtime Proof
+
+- Keep A15 as the mixed BIRD/FRR dual-stack BGP plus OSPFv2/OSPFv3 proof.
+- Keep A16 as the ExaBGP IPv6 static/live announce/withdraw proof.
+- Keep A17 as the Looking Glass IPv4/IPv6 route-state proof.
+- For each runtime example, record the exact observation commands in the
+  example README or user manual.
+- Validate neighbors and routes, not only generated config.
+- Keep ExaBGP event streams separate from Looking Glass route-state views.
+- Looking Glass frontend-to-proxy URLs now route through shared URL helpers,
+  default to IPv4, and explicitly select bracketed IPv6 proxy URLs with
+  `setProxyAddressFamily(AddressFamily.IPv6)`; proxy address-family parsing
+  reuses the shared core normalizer for padded aliases.
+- BGP and OSPF intent address-family parsing now reuses the shared core
+  address-family normalizer, keeping protocol layers backend-neutral while
+  accepting the same explicit IPv4/IPv6 family aliases as services; manual BGP
+  session address literals also route through shared address normalization so
+  padded and bracketed IPv6 inputs do not leak into rendered daemon config.
+
+Useful runtime checks:
+
+```bash
+docker exec <node> ip -6 addr
+docker exec <bird-router> birdc show protocols
+docker exec <bird-router> birdc show route all
+docker exec <frr-router> vtysh -c 'show bgp ipv6 unicast'
+docker exec <frr-router> vtysh -c 'show ipv6 ospf6 neighbor'
+curl -fsS http://127.0.0.1:<lg-port>/api/state
+```
+
+## Phase 5: Service Migration Candidates
+
+Move one service at a time. Each migration needs code, docs, and a regression
+test or minimal example.
+
+Priority candidates:
+
+- Web/CA endpoint formatting through shared helpers.
+- Traffic service address-family selection.
+- Kubo/IPFS multiaddr generation through `formatMultiaddr`.
+- Email design audit before implementation; do not migrate casually because
+  gateway/provider behavior needs careful endpoint decisions.
+- Tor design audit for listeners, authorities, and generated configs.
+- Ethereum/Monero/Chainlink endpoint audit for RPC, peer discovery, and
+  generated URLs.
+
+For each service:
+
+1. Identify where it calls `getAddress()`, formats `host:port`, or writes URLs.
+2. Preserve the IPv4 path.
+3. Add explicit family selection or dual-stack output only when IPv6 exists.
+4. Add tests proving old behavior and the new IPv6 path.
+5. Update the readiness matrix.
+
+Current readiness coverage added in `test_ipv6_repository_readiness.py`:
+
+- Traffic generator raw receiver target lists remain unchanged.
+- Traffic generator receiver vnode targets can be resolved through shared core
+  node-address helpers, default to IPv4, and explicitly select IPv6 when
+  requested; generated reachability probes select IPv6 ping for IPv6 literal
+  targets while preserving the existing IPv4/hostname ping path.
+- Kubo bootstrap RPC URLs, peer multiaddrs, and the legacy `getIP` utility now
+  route through shared endpoint helpers with Local-network-first,
+  service-network fallback address selection, default to IPv4, and explicitly
+  select IPv6 when requested; generated bootstrap helper probes use the same
+  explicit address family as the selected bootstrap endpoints.
+- Botnet C2/dropper URLs now route through shared node-address and URL helpers,
+  preserve the existing first-interface IPv4 default, and explicitly select
+  bracketed IPv6 URLs when requested; the legacy dropper fallback brackets bare
+  IPv6 host arguments, and DGA dropper runners preserve preformatted HTTP(S)
+  URLs and existing `host:port` authority outputs while bracketing bare IPv6
+  host fallbacks before generating dropper URLs, but BYOB client/server runtime
+  behavior and DGA endpoint handling still need validation before a support
+  claim.
+- CA `installCACert(Filter(...))` target selection now matches IPv4 and IPv6
+  address/prefix filters through shared node address/prefix helpers while
+  keeping the existing default of installing on all nodes; CA IP/network helper
+  parsing also reuses shared address and prefix normalization for padded and
+  bracketed IPv6 literals.
+- Web/CA CA domain inputs trim DNS names and normalize padded or bracketed
+  IPv4/IPv6 endpoint literals before ACME directory URLs route through shared
+  URL helpers; explicit IPv6 CA endpoint literals are bracketed, and Web HTTPS
+  and ACME runtime behavior still need validation before a support claim.
+- Cymru IP origin mapping remains IPv4-only but now routes accepted IPv4 prefix
+  inputs through shared prefix normalization, including padded or bracketed
+  literals, and rejects IPv6 prefixes explicitly.
+- Monero seed and full-node RPC endpoint lists now route through shared
+  address-family and host-port helpers with Local-network-first,
+  service-network fallback address selection, default to IPv4, and explicitly
+  select bracketed IPv6 endpoints when requested; generated seed wait probes
+  use the endpoint address family, but Monero daemon runtime behavior still
+  needs validation before a support claim.
+- Chainlink generated RPC, faucet, utility, and WebSocket/HTTP node URLs now
+  route through shared address-family and URL helpers with Local-network-first,
+  service-network fallback address selection, default to IPv4, and explicitly
+  select bracketed IPv6 URLs when requested; Ethereum/Chainlink runtime
+  behavior still needs validation before a support claim.
+- Ethereum faucet/utility HTTP URLs, faucet-user request URLs, faucet
+  funding-script server URLs, and generated bootnode/beacon helper fetch URLs
+  now route through shared
+  address-family and URL helpers with
+  Local-network-first, service-network fallback address selection, default to
+  IPv4, and explicitly select bracketed IPv6 URLs when requested; the
+  Lighthouse validator beacon-node URL template now accepts a preformatted
+  helper URL so IPv6 literals are bracketed when supplied, while the current
+  PoS validator install path remains IPv4-first and Ethereum ENR content, peer
+  discovery, bootnode bind/listener, and daemon runtime behavior still need
+  validation before a support claim.
+- Tor directory-authority fingerprint downloader URLs and hidden-service
+  backend targets now route through shared endpoint helpers, preserving IPv4
+  defaults, normalizing and bracketing explicit IPv6 literals without
+  bracketing DNS names, and resolving `linkByVnode(...,
+  family=AddressFamily.IPv6)` targets with Local-network-first,
+  service-network fallback address selection; the entrypoint hidden-service
+  fallback brackets bare IPv6 `TOR_HS_ADDR` values when no preformatted target
+  is provided, but Tor bind/listener, directory authority, consensus, and
+  daemon runtime behavior remain IPv4-first and need a separate migration
+  before any support claim.
+
+## Phase 6: Separate Designs Before Code
+
+Do not implement these as quick patches. Start with a design doc and ask for
+review when scope is unclear.
+
+- SCION underlay and `crossConnect(...)` dual-stack behavior.
+- DHCPv6 or SLAAC.
+- MPLS/EVPN IPv6 semantics.
+- RealWorldRouter/OpenVPN IPv6 behavior.
+- k8s IPv6 support.
+- internetmap2 IPv6 visualization/runtime integration.
+- Full email IPv6 delivery/provider model.
+
+## Phase 7: Repository Documentation
+
+- Keep `README.md` high-level: SEED supports optional dual-stack emulation, not
+  every service is fully migrated.
+- Keep `docs/user_manual/ipv6.md` user-facing and operational.
+- Keep `docs/designs/ipv6-control-plane-design.md` focused on control-plane
+  architecture and class relationships.
+- Keep `docs/designs/ipv6-repository-readiness-design.md` focused on the
+  repository migration contract and service readiness matrix.
+- Keep `ai/design-principles.md` short enough for future agents to actually
+  read before coding.
+- Update this file when major milestones are completed.
+
+## Stop Conditions
+
+Pause and ask for review before continuing if:
+
+- a change would alter default IPv4 output;
+- a service appears to require a new public API rather than helper usage;
+- generated runtime behavior differs between BIRD and FRR in a way the design
+  docs do not explain;
+- a migration touches SCION, k8s, internetmap2, OpenVPN, or email delivery
+  semantics;
+- tests pass statically but runtime daemon state cannot prove the feature.

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,9 @@
+# AI Workspace Assets
+
+This directory stores project-local AI assets for SEED Emulator work.
+
+- `design-principles.md`: branch-level control-plane and addressing design rules.
+- `skills/`: local skill drafts that can be promoted into a Codex skill directory later.
+- `mcp/`: reserved for future MCP server notes or schemas.
+
+The Codex runtime root for this branch remains the repository root, not this directory.

--- a/ai/design-principles.md
+++ b/ai/design-principles.md
@@ -1,0 +1,32 @@
+# SEED Control Plane Design Principles
+
+This file records the branch-level design rules we want future SEED Emulator control-plane work to follow.
+
+## Boundaries
+
+- Keep topology construction in `Base`, `AutonomousSystem`, `InternetExchange`, `Network`, `Node`, and `Interface`.
+- Keep routing daemon selection on `Router`; use `createRouter(..., routingBackend="bird|frr")`.
+- Keep protocol layers as intent recorders. `Ebgp`, `Ibgp`, and `Ospf` should describe peers, relationships, address families, export policy, and active/passive interfaces.
+- Keep daemon syntax in `Routing`. BIRD and FRR config templates should be rendered from the same intent model.
+- Keep ExaBGP as a `Service + Binding` control-plane speaker, not as a full transit router backend.
+- Keep Looking Glass as a route-state observer service. Do not mix it with ExaBGP event-stream semantics.
+
+## Compatibility
+
+- Preserve IPv4 defaults. New IPv6 work must be opt-in unless a later design explicitly changes the default.
+- Preserve old public methods where possible. Add IPv6-specific accessors instead of changing IPv4 return values.
+- Keep examples additive when testing a new branch-level capability. Do not weaken existing A12-A14 regression examples.
+
+## Addressing
+
+- Treat IPv6 as topology state owned by `Base` and core objects, not as example-local configuration.
+- Keep IPv6 root prefixes explicit and inspectable. The default root is `2000::/12`; the reserved infrastructure prefix is `2000:ffff::/48`.
+- Keep automatic IPv6 allocation deterministic: `/48` per AS, `/64` per local network, `/64` per IX LAN.
+- Track explicit IPv6 prefixes that fall under the configured root so later automatic allocation cannot collide with them.
+- Keep per-network opt-out (`ipv6Prefix=None`) and per-interface opt-out (`ipv6Address=None`) available for mixed migration scenarios.
+
+## Validation
+
+- Generated config is not enough. Runtime evidence must include daemon processes, neighbor state, learned routes, and observable route-state/event surfaces.
+- Validate mixed backends. A control-plane feature should prove BIRD and FRR can coexist in one topology.
+- Validate service boundaries. ExaBGP must show speaker config and live announce/withdraw; Looking Glass must show router route-state.

--- a/ai/mcp/README.md
+++ b/ai/mcp/README.md
@@ -1,0 +1,9 @@
+# MCP Planning
+
+Reserved for future MCP integrations around SEED Emulator design review, topology inspection, and runtime validation.
+
+Initial direction:
+
+- expose topology metadata as read-only resources;
+- expose generated router configs as inspection resources;
+- expose validated runbook commands as explicit tools with project-scoped safety guards.

--- a/ai/skills/ipv6-control-plane/SKILL.md
+++ b/ai/skills/ipv6-control-plane/SKILL.md
@@ -1,0 +1,24 @@
+# IPv6 Control Plane Skill
+
+Use this skill when designing, implementing, or reviewing IPv6 control-plane support in SEED Emulator.
+
+## Rules
+
+- Default behavior must remain IPv4-only unless `Base(enableIpv6=True)` or `base.enableIpv6(...)` is used.
+- `Network.getPrefix()` and `Interface.getAddress()` remain IPv4 APIs. Use `getIpv6Prefix()` and `getIpv6Address()` for IPv6.
+- IPv6 auto allocation starts from the configured root prefix, default `2000::/12`, with `/48` per AS and `/64` per local or IX network.
+- The reserved infrastructure prefix is `2000:ffff::/48`; do not allocate customer or IX LAN prefixes from it.
+- Explicit IPv6 prefixes under the configured root must be claimed before later auto allocation.
+- Protocol layers record address-family intent; `Routing` renders BIRD and FRR syntax.
+- OSPFv3 uses a separate IPv6 table from OSPFv2.
+- ExaBGP IPv6 support belongs in `ExaBgpService`; it should peer on a shared IX/router-facing network and produce `ipv6 unicast` config.
+- Looking Glass shows route-state for both families and must stay separate from ExaBGP event dashboards.
+
+## Evidence Checklist
+
+- Compose networks include IPv6 IPAM and `enable_ipv6`.
+- Containers show expected `ip -6 addr`.
+- BIRD shows IPv6 routes through `birdc show route all`.
+- FRR shows IPv6 BGP and OSPFv3 with `vtysh`.
+- ExaBGP accepts IPv6 static and live announce/withdraw.
+- Looking Glass `/api/state` includes IPv6 route-state for observed routers.

--- a/docs/designs/ipv6-control-plane-design.md
+++ b/docs/designs/ipv6-control-plane-design.md
@@ -1,0 +1,242 @@
+# IPv6 Addressing and Control Plane Design
+
+This design promotes IPv6 from example-specific wiring to a project-level
+optional dual-stack capability. IPv4 remains the default behavior. The target
+API enables IPv6 explicitly through `Base(enableIpv6=True,
+ipv6RootPrefix="2000::/12")` or by calling `base.enableIpv6(...)` before
+rendering.
+
+The design follows SEED's existing model: `Base` owns topology and addressing,
+protocol layers record intent, `Routing` renders daemon configuration, and
+compilers translate the rendered model into runnable artifacts.
+
+## 中文摘要
+
+本设计把 IPv6 提升为仿真器级别的可选能力，而不是 A15-A17 的局部演示
+逻辑。默认行为仍然是 IPv4-only；只有用户在 `Base` 层显式开启 IPv6，
+拓扑对象、控制面渲染和 Docker 编译结果才会进入双栈模式。这样既保留
+旧示例和旧 API 的稳定性，也给后续 IPv6 场景、服务和实验分支留下统一
+入口。
+
+核心边界是：
+
+- `Base`、`AutonomousSystem`、`InternetExchange`、`Network` 和
+  `Interface` 负责拓扑与地址状态；
+- `Ebgp`、`Ibgp`、`Ospf` 只记录协议意图和 address-family 信息；
+- `Routing` 统一把意图渲染成 BIRD/FRR 配置；
+- `ExaBgpService` 和 Looking Glass 仍然是服务，不改造成路由层；
+- Docker 编译器只把已经带 IPv6 前缀的网络编译为双栈网络。
+
+## Current Landing Status
+
+This PR lands the repository contract and shared helper foundation on top of
+`development2`. It does not yet claim that the topology, compiler, routing,
+ExaBGP, Looking Glass, DNS, or example runtime paths have been re-integrated on
+this branch. Those pieces should be ported in follow-up PRs against this design
+without reintroducing removed legacy control-plane shims.
+
+## Design Position
+
+- Keep IPv4 API compatibility. Existing calls to `getPrefix()`,
+  `getAddress()`, and `joinNetwork(..., address="auto")` remain IPv4-oriented.
+- Add IPv6 state beside IPv4 state instead of changing return types.
+- Make IPv6 opt-in at the `Base` layer, but allow per-network and per-interface
+  overrides.
+- Keep routing semantics address-family aware without moving daemon syntax into
+  `Ebgp`, `Ibgp`, or `Ospf`.
+- Treat IPv6 as emulator addressing state, not as a separate feature bolted onto
+  A15-A17.
+
+## Core API Shape
+
+| Concern | IPv4 API kept | IPv6 API added |
+| --- | --- | --- |
+| Global switch | `Base()` | `Base(enableIpv6=True)`, `base.enableIpv6(...)` |
+| Network prefix | `Network.getPrefix()` | `Network.getIpv6Prefix()`, `Network.hasIpv6Prefix()` |
+| Interface address | `Interface.getAddress()` | `Interface.getIpv6Address()`, `Interface.hasIpv6Address()` |
+| Node attachment | `joinNetwork(net, address="auto")` | optional `ipv6Address="auto"|None|explicit` |
+| AS network | `createNetwork(..., prefix="auto")` | optional `ipv6Prefix="auto"|None|explicit` |
+| IX network | `createInternetExchange(..., prefix="auto")` | optional `ipv6Prefix`, `rsIpv6Address` |
+
+`Base.enableIpv6()` also applies to existing AS and IX networks that were
+created with the default IPv6 intent. This supports the common migration path:
+build an IPv4 topology first, then make the same topology dual stack before
+rendering.
+
+## Prefix Plan
+
+`Ipv6Addressing` owns automatic IPv6 allocation.
+
+- Default root prefix: `2000::/12`.
+- Reserved infrastructure prefix: `2000:ffff::/48`.
+- AS allocation: stable `/48` prefixes under the root.
+- AS local network allocation: stable `/64` prefixes under the AS `/48`.
+- IX peering LAN allocation: stable `/64` prefixes under the root, collision
+  checked against AS and reserved prefixes.
+- Interface IDs reuse the existing `AddressAssignmentConstraint` offsets, so
+  host/router intent stays recognizable across IPv4 and IPv6.
+- IX participants still prefer ASN-derived host offsets. If an offset is out of
+  range or collides, the allocator advances deterministically and asserts only
+  when exhausted.
+
+`2000::/12` is a public-style emulation prefix. It is not a claim that generated
+routes are globally reachable. Users can override it with another root prefix
+when a scenario needs a different address plan.
+
+The reserved infrastructure prefix is deliberately outside automatic AS and IX
+allocation. `Routing` uses it as the default IPv6 loopback pool, so routing
+infrastructure does not collide with customer or IX LAN prefixes.
+
+Explicit user prefixes are claimed by the allocator when they fall under the
+configured IPv6 root. Later automatic allocations must avoid them. Prefixes
+outside the root are treated as user-managed and are not rewritten by the
+allocator. A prefix that overlaps the configured root but is not a subnet of it
+is rejected because it would make later automatic allocation ambiguous.
+
+## Core Change Map
+
+| File | Role |
+| --- | --- |
+| `seedemu/core/Ipv6Addressing.py` | Owns the default root prefix, reserved infrastructure prefix, AS `/48`, local `/64`, IX `/64`, and collision checks. |
+| `seedemu/layers/Base.py` | Exposes the global IPv6 switch, root prefix accessor, reserved-prefix accessor, and late enablement backfill for AS/IX networks. |
+| `seedemu/core/AutonomousSystem.py` | Carries the IPv6 allocator into local networks and preserves per-network `ipv6Prefix` intent. |
+| `seedemu/core/InternetExchange.py` | Carries IX IPv6 prefix intent and route-server IPv6 address intent. |
+| `seedemu/core/Network.py` | Stores optional IPv6 prefix and prefix intent beside the existing IPv4 prefix. |
+| `seedemu/core/Node.py` | Stores optional interface IPv6 addresses through `joinNetwork(..., ipv6Address=...)`. |
+| `seedemu/layers/Routing.py` | Renders BIRD/FRR address-family syntax, IPv6 loopbacks, IPv6 BGP, and OSPFv3. |
+| `seedemu/compiler/Docker.py` | Emits IPv6 compose networks, service IPv6 addresses, forwarding sysctls, metadata labels, and self-managed dummy IPv6 replacement. |
+
+## Class Relationship
+
+```text
+Base(enableIpv6=True, ipv6RootPrefix)
+  owns Ipv6Addressing(root, reserved infra prefix)
+  -> AutonomousSystem.setIpv6Addressing(...)
+       -> createNetwork(..., ipv6Prefix)
+       -> Network(ipv6Prefix, ipv6PrefixIntent)
+  -> createInternetExchange(..., ipv6Prefix, rsIpv6Address)
+       -> InternetExchange
+       -> Network(type=InternetExchange, ipv6PrefixIntent)
+  -> Node.joinNetwork(..., ipv6Address)
+       -> Interface(address, ipv6Address)
+
+Ebgp / Ibgp / Ospf
+  -> record backend-neutral address-family intent
+  -> Routing renders BIRD or FRR
+  -> Docker compiles runtime networks and container addresses
+```
+
+This keeps the original layer model intact: topology construction does not know
+daemon syntax, protocol layers do not write config files, and compilers do not
+invent routing semantics.
+
+## Per-Topology Control
+
+Global dual stack:
+
+```python
+base = Base(enableIpv6=True)
+```
+
+Late enablement before render:
+
+```python
+base = Base()
+as150 = base.createAutonomousSystem(150)
+as150.createNetwork("net0")
+base.createInternetExchange(100)
+
+base.enableIpv6()
+```
+
+Per-network override:
+
+```python
+as150.createNetwork("net0", ipv6Prefix="2000:0:150::/64")
+as150.createNetwork("v4only", ipv6Prefix=None)
+```
+
+Per-interface override:
+
+```python
+as150.createHost("web").joinNetwork("net0", ipv6Address="2000:0:150::71")
+as150.createHost("legacy").joinNetwork("v4only", ipv6Address=None)
+```
+
+## Render Flow
+
+```text
+Base / AS / IX
+-> Network + Interface carry optional IPv6 state
+-> Ebgp / Ibgp / Ospf record address-family intent
+-> _bgp_metadata normalizes BGP sessions and OSPF interface intent
+-> Routing renders BIRD or FRR syntax
+-> Docker compiler emits dual-stack compose networks and container addresses
+```
+
+Protocol layers do not write daemon-specific IPv6 syntax. BIRD and FRR syntax
+stays in `Routing`. Manual BGP session intent still goes through shared
+address-family and address-literal normalization, so padded or bracketed IPv6
+inputs are canonicalized before `Routing` renders daemon config.
+
+## Docker Compiler
+
+The regular Docker compiler emits `enable_ipv6: true`, IPv6 IPAM subnets, and
+service-level `ipv6_address` only for networks that actually have IPv6 prefixes.
+
+For `selfManagedNetwork=True`, the compiler now creates dummy IPv6 subnets from
+`dummyIpv6NetworksPool` and records replacement mappings in
+`/dummy_addr_map.txt`, matching the existing IPv4 self-managed behavior.
+
+Router, border-router, openvpn-router, and route-server containers get IPv6
+forwarding sysctls when they have IPv6 interfaces. Host containers remain
+ordinary IPv6 hosts.
+
+## BIRD and FRR Rendering
+
+BIRD:
+
+- keeps IPv4 `t_direct`, `t_ospf`, and `t_bgp`;
+- adds IPv6 `t_direct6`, `t_ospf6`, and `t_bgp6` only when IPv6 is present;
+- renders BGP family blocks from the same session intent;
+- renders OSPFv3 as a separate IPv6 OSPF protocol/table.
+
+FRR:
+
+- keeps OSPFv2 and IPv4 BGP behavior;
+- enables `ospf6d` for IPv6 routers;
+- renders `address-family ipv6 unicast`;
+- renders OSPFv3 interface commands for IPv6-capable interfaces.
+
+## Services
+
+ExaBGP remains a service speaker. It resolves the shared network with the peer
+router, installs router-side BGP intent, and writes `/etc/exabgp/exabgp.conf`
+with `ipv6 unicast` when IPv6 is available or IPv6 prefixes are announced.
+
+Looking Glass remains a route-state observer. The proxy queries BIRD route
+state through `birdc` and FRR route state through `vtysh`, including IPv6 BGP
+and OSPFv3 commands. Frontend-to-proxy traffic keeps an IPv4 endpoint by
+default; scenarios that explicitly select IPv6 proxy endpoints use shared URL
+helpers so IPv6 literals are bracketed correctly.
+
+Other services remain compatible with IPv4 defaults. A service that wants IPv6
+should read IPv6 through `Interface.hasIpv6Address()` and
+`Interface.getIpv6Address()` instead of changing existing IPv4 code paths.
+
+## Examples and Validation
+
+| Example | Purpose | Evidence |
+| --- | --- | --- |
+| `A15_bgp_ipv6_dual_stack` | BIRD/FRR mixed dual-stack BGP with OSPFv2/OSPFv3 | IPv6 compose IPAM, `ip -6 addr`, `birdc show route all`, FRR `show bgp ipv6 unicast`, `show ipv6 ospf6 neighbor` |
+| `A16_exabgp_ipv6_control_plane` | ExaBGP IPv6 static/live announce | `exabgp.conf` has `ipv6 unicast`, peer learns and withdraws IPv6 prefixes |
+| `A17_ipv6_looking_glass` | IPv6 route-state observability | Looking Glass `/api/state` includes BIRD and FRR IPv6 route-state |
+
+Existing A12-A14 remain the IPv4 regression baseline.
+
+## Repository-Level Follow-Up
+
+This document focuses on the control-plane foundation. The repository-wide
+migration contract for services, endpoint formatting, DNS, `/etc/hosts`,
+custom containers, service network IPv6, and IPv4-first components is tracked
+in [Repository-Wide IPv6 Readiness Design](./ipv6-repository-readiness-design.md).

--- a/docs/designs/ipv6-repository-readiness-design.md
+++ b/docs/designs/ipv6-repository-readiness-design.md
@@ -1,0 +1,176 @@
+# Repository-Wide IPv6 Readiness Design
+
+This document defines how SEED Emulator should evolve from IPv4-first
+examples to optional dual-stack capability across the repository. It is the
+migration contract for incremental IPv6 work on top of `development2`.
+
+## 中文摘要
+
+IPv6 不应该被理解成几个示例的局部能力，而是仿真器级别的可选能力。
+默认仍然是 IPv4-only；旧示例、旧 API、旧输出都应保持稳定。只有用户在
+`Base`、网络、接口或相关 service API 中显式启用 IPv6，编译结果才进入
+双栈状态。
+
+全仓库迁移遵守下面的边界：
+
+- core 保存拓扑、地址、前缀、绑定和 endpoint 的通用语义；
+- layer 只表达协议或系统 intent；
+- service 读取地址族能力并生成自身配置；
+- compiler 把已经存在的模型状态编译成运行制品；
+- examples 用新增 IPv6 variant 展示新能力，不改旧示例含义。
+
+## Current Landing Status
+
+This PR lands the contract and shared helper foundation only:
+
+- shared address-family and endpoint formatting helpers in `seedemu.core`;
+- deterministic IPv6 prefix allocation helper;
+- design, user, and agent-facing migration documents.
+
+It intentionally does not claim that Docker, Routing, ExaBGP, Looking Glass,
+DNS, `/etc/hosts`, or repository services are already dual-stack on
+`development2`. Their rows below describe the target migration contract and
+must be treated as implemented only after follow-up PRs add code and tests.
+
+## Address-Family Contract
+
+Existing IPv4 APIs remain IPv4 APIs:
+
+- `Network.getPrefix()` returns the IPv4 prefix.
+- `Interface.getAddress()` returns the IPv4 address.
+- `Filter(ip=...)` and `Filter(prefix=...)` remain accepted and now parse either
+  IPv4 or IPv6 literals; bracketed IPv6 address literals are normalized when a
+  helper accepts address literals. Explicit-family selectors such as
+  `Filter(ipv4=...)`, `Filter(ipv6=...)`, `Filter(ipv4Prefix=...)`, and
+  `Filter(ipv6Prefix=...)` require the literal to match the selected family.
+
+Dual-stack aware code should use the explicit IPv6 APIs or the shared helpers:
+
+- `Network.hasIpv6Prefix()` / `Network.getIpv6Prefix()`.
+- `Interface.hasIpv6Address()` / `Interface.getIpv6Address()`.
+- `AddressFamily`, `getInterfaceAddress(...)`, `formatHost(...)`,
+  `formatHostPort(...)`,
+  `getNodeAddress(...)`, `getNodeAddresses(...)`, `getNodePreferredAddress(...)`,
+  `nodeHasAddress(...)`, `nodeHasAddressInPrefix(...)`, `formatUrl(...)`,
+  `formatMultiaddr(...)`, `normalizeAddressList(...)`, `normalizePrefix(...)`, and
+  `normalizeAddressRecord(...)` from `seedemu.core`.
+
+Services must not assume that the first interface address is the only usable
+address. A service should either select IPv4 explicitly, select IPv6
+explicitly, or generate both families when its daemon supports dual stack. When
+a legacy API already carries a bracketed IPv6 authority such as
+`[2000::1]:8443`, shared URL helpers preserve that authority and canonicalize
+the IPv6 literal instead of treating it as an unparsed hostname. If the caller
+also supplies a separate port, the separate port overrides the port embedded in
+a legacy IPv4, DNS-name, or bracketed IPv6 authority, and padded explicit port
+values are trimmed before `host:port`, URL, or multiaddr output is generated.
+Malformed bracketed IPv6 authorities, such as `[2000::1]:bad`, are rejected
+instead of being emitted as ambiguous endpoints. Explicit port arguments must
+be non-empty decimal strings, so helpers reject invalid socket-like endpoints
+before a service writes them into config. URL components beginning with `?` or
+`#` are preserved as query or fragment components rather than being rewritten
+as path segments.
+
+## Core Readiness
+
+Target foundation:
+
+- Optional IPv6 root prefix and deterministic AS/IX `/64` allocation.
+- IPv6 state on `Network` and `Interface`.
+- IPv6-aware BGP/OSPF intent rendering for BIRD and FRR.
+- IPv6-aware ExaBGP speaker service and Looking Glass route-state queries.
+- Docker Compose dual-stack network/IPAM and service `ipv6_address` output.
+- IPv6-aware `Filter` / `Binding` matching and `Action.NEW` placement.
+- Optional IPv6 service network prefix, with per-node `ipv6_address` emitted
+  only for service-network attachments that carry IPv6 state.
+- Optional IPv6 address on `attachCustomContainer(...)` and
+  `attachInternetMap(...)`; explicit static IPv4/IPv6 attachment addresses are
+  normalized before compose fields and metadata labels are emitted, and
+  mismatched address-family inputs are rejected.
+
+Deferred core items:
+
+- `crossConnect(...)` remains IPv4-only in this branch. It is used heavily by
+  SCION and legacy examples, so dual-stack cross-connect links need a separate
+  design rather than an implicit API change.
+- Real-world connectivity and OpenVPN remain IPv4-oriented.
+- DHCP remains IPv4-only; DHCPv6/SLAAC behavior should be designed separately.
+
+## Service Readiness Matrix
+
+| Area | Status | Migration rule |
+| --- | --- | --- |
+| Routing control plane | Supported | Keep protocol intent family-aware; render backend syntax only in `Routing`. |
+| ExaBGP | Supported | Service speaker may use IPv4 or IPv6 shared peer address; static announcement prefixes use shared prefix normalization before rendering. |
+| Looking Glass | Supported | Route-state views separate IPv4/IPv6 output; frontend-to-proxy URLs use shared URL helpers, default to IPv4, and may explicitly select bracketed IPv6 proxy endpoints. |
+| Docker compiler | Supported | Emit IPv6 only for networks/interfaces carrying IPv6 state. |
+| `/etc/hosts` | Baseline dual-stack | Generate IPv4 and IPv6 entries when available; keep service-network Bridge addresses for service-only nodes, and skip IX peering addresses. |
+| DNS authoritative | Baseline dual-stack | Generate A and AAAA for node-backed records; manual A/AAAA and glue record literals use shared normalization, including bracketed IPv6 literals, and reject address-family mismatches such as A-with-IPv6 or AAAA-with-IPv4; authoritative zone inputs and master-IP zone keys are normalized to canonical DNS zone names, and masters may include both address families; reverse DNS keeps IPv4 `in-addr.arpa.` PTR records and adds `ip6.arpa.` PTR records only when interfaces carry IPv6 state. |
+| Domain Registrar | Compatible | Dynamic DNS updates preserve A as the default record type, allow explicit AAAA submissions, and reject submitted IP addresses whose family does not match the selected A/AAAA record type; TLD placement and runtime behavior remain the existing Domain Registrar model. |
+| DNS cache | Compatible | Prefer IPv4 for old resolver behavior; accept IPv6 forwarders/root hints, normalize manual A/AAAA root-hint literals through the shared helper, normalize forward-zone names to canonical DNS zone names, and use shared node-address helpers for forward-zone fallback to authoritative zone servers. |
+| Web/CA | Compatible | Existing IPv4 behavior preserved; CA certificate-install filters match IPv4/IPv6 address and prefix selectors through shared node address/prefix helpers; CA IP/network helper parsing uses shared address and prefix normalization; CA domain inputs trim DNS names and normalize padded or bracketed IPv4/IPv6 endpoint literals before ACME directory URLs use shared URL helpers, but Web HTTPS and ACME runtime behavior still need validation before a full support claim. |
+| Cymru IP origin | IPv4-first | Origin ASN TXT mapping remains IPv4-only; accepted IPv4 prefix inputs use shared prefix normalization, and IPv6 prefixes are rejected explicitly rather than partially mapped. |
+| Traffic services | Compatible | Raw receiver targets are unchanged; receiver vnodes can be resolved to IPv4 or IPv6 targets through shared node-address helpers, and generated reachability probes select IPv6 ping for IPv6 literal targets, but each tool still needs runtime validation before a full support claim. |
+| Kubo/IPFS | Compatible | Bootstrap RPC URLs, bootstrap helper probes, peer multiaddrs, and the legacy `getIP` utility use shared endpoint helpers with Local-network-first, service-network fallback address selection, default to IPv4, and may explicitly select IPv6; broader Kubo runtime behavior still needs validation before a full support claim. |
+| Botnet | Compatible | Binding-based C2/dropper URLs use shared node-address and URL helpers, preserve the first-interface IPv4 default, and may explicitly select bracketed IPv6 URLs; legacy fallbacks bracket bare IPv6 host arguments, and DGA dropper runners preserve preformatted HTTP(S) URLs and existing `host:port` authority outputs while bracketing bare IPv6 host fallbacks, but BYOB client/server runtime behavior and DGA endpoints still need validation before a full support claim. |
+| Monero | Compatible | Seed and full-node RPC endpoint lists and seed wait probes use shared address-family and host-port helpers with Local-network-first, service-network fallback address selection, default to IPv4, and may explicitly select IPv6; daemon listener/runtime behavior still needs validation before a full support claim. |
+| Chainlink | Compatible | Generated Chainlink RPC, faucet, utility, and node WebSocket/HTTP URLs use shared endpoint helpers with Local-network-first, service-network fallback address selection, default to IPv4, and may explicitly select bracketed IPv6 URLs; Ethereum/Chainlink runtime behavior still needs validation before a full support claim. |
+| Email | IPv4-first | Provider/gateway/default-route logic must be redesigned before IPv6 claim. |
+| Tor | IPv4-first | Directory-authority downloader URLs and hidden-service backend target formatting are helper-ready; explicit IP literals are normalized and IPv6 literals are bracketed without bracketing DNS names; `linkByVnode(..., family=AddressFamily.IPv6)` resolves backend vnodes with Local-network-first, service-network fallback address selection; the entrypoint hidden-service fallback brackets bare IPv6 `TOR_HS_ADDR` values when no preformatted target is provided, but bind/listener, directory authority addressing, consensus, and daemon runtime need a separate migration before an IPv6 support claim. |
+| Ethereum | Compatible | Faucet/utility HTTP URLs, faucet-user request URLs, faucet funding-script server URLs, and generated bootnode/beacon helper fetch URLs use shared endpoint helpers with Local-network-first, service-network fallback address selection, default to IPv4, and may explicitly select bracketed IPv6; the Lighthouse validator beacon-node URL template accepts preformatted helper URLs so IPv6 literals are bracketed when supplied, but the current PoS validator install path remains IPv4-first, and ENR content, peer discovery, bootnode bind/listener, and daemon runtime behavior still need validation before a full support claim. |
+| SCION | Separate design | Underlay, crossConnect, and SCION control tooling currently assume IPv4. |
+| MPLS/EVPN | Separate design | Routing identifiers and dataplane assumptions need dedicated validation. |
+| k8s/internetmap2 | Out of this branch | Do not claim IPv6 support until their own branch validates it. |
+
+## Migration Pattern for Services
+
+A service migration should follow this order:
+
+1. Keep the old IPv4 path unchanged.
+2. Add explicit address-family selection or generate both families only when
+   the target node/interface has IPv6 state.
+3. Use shared endpoint helpers for URLs, `host:port`, and multiaddr strings.
+4. Add a minimal IPv6 example or test without changing old examples.
+5. Document unsupported daemon features clearly instead of generating partial
+   IPv6 config.
+
+The acceptance rule is simple: enabling IPv6 must not make an IPv4-only service
+silently wrong. It may continue using IPv4, or it may clearly expose dual-stack
+support after tests prove it.
+
+## Validation Baseline
+
+Repository-level IPv6 work should keep these checks green:
+
+- Existing IPv4 examples compile without IPv6 Compose fields.
+- A15-A17 keep proving the control-plane path.
+- `Filter` / `Binding` match IPv4 and IPv6 addresses/prefixes.
+  Explicit-family selectors reject wrong-family literals instead of falling
+  back to the literal's parsed family.
+- IPv6 prefix allocation rejects reserved infrastructure reuse and overlapping
+  explicit AS/IX prefixes, including late `Base.enableIpv6()` migration paths;
+  explicit root, AS/IX, and service-network IPv6 prefixes use shared prefix
+  normalization so padded and bracketed CIDR inputs behave consistently.
+  Explicit prefixes that overlap the configured root without being root subnets
+  are rejected, while fully disjoint prefixes outside the root remain
+  user-managed.
+- Explicit interface IPv4/IPv6 address inputs use shared address literal
+  normalization while preserving `getAddress()` as IPv4 and
+  `getIpv6Address()` as IPv6.
+- Service network and custom containers compile as IPv4-only by default and
+  dual-stack only when IPv6 is provided; service-network interface opt-out,
+  custom container attachments, and custom Internet Map attachments without an
+  explicit IPv6 address suppress per-node `ipv6_address` even on a dual-stack
+  network. Explicit static attachment addresses normalize padded or bracketed
+  IPv4/IPv6 literals before compose and metadata output, and reject IPv4/IPv6
+  field mismatches.
+- DNS and `/etc/hosts` emit stable A/AAAA and hosts entries when IPv6 exists,
+  and manual A/AAAA records reject mismatched address families.
+- DNS address selection uses shared core helpers so service code does not
+  duplicate Local-vs-service-network fallback rules.
+- Explicit resolver nameserver inputs, including `ResolvConfHook` and
+  `ResolvConfHookByAs`, use shared address-list normalization before writing
+  `resolv.conf` commands.
+- Authoritative DNS and DNS cache forward-zone fallback resolve canonical
+  zone names, normalize zone inputs before lookup/output, and emit IPv6
+  forwarders only for zone-server nodes with IPv6 state.

--- a/docs/designs/readme.md
+++ b/docs/designs/readme.md
@@ -37,6 +37,10 @@ See [design.md](design.md)
 
 Control-plane extension design: [control-plane-extension-design.md](control-plane-extension-design.md)
 
+IPv6 control-plane/readiness designs:
+[ipv6-control-plane-design.md](ipv6-control-plane-design.md) and
+[ipv6-repository-readiness-design.md](ipv6-repository-readiness-design.md)
+
 ## Case study
 
 ### BGP peering

--- a/docs/user_manual/README.md
+++ b/docs/user_manual/README.md
@@ -15,6 +15,7 @@ This document provides a portal to those examples.
   - [Component and Binding](./component.md): bind virtual nodes in component 
            to physical nodes, filters  
   - [Compilation](./compiler.md): generate emulation files (docker files)
+  - [IPv6 readiness](./ipv6.md): optional dual-stack design and helper APIs
   - [Visualization](./visualization.md): visualize the emulated Internet
   - [Docker image](./docker.md): generate images for AMD and ARM platforms, 
            use custom images 

--- a/docs/user_manual/ipv6.md
+++ b/docs/user_manual/ipv6.md
@@ -1,0 +1,368 @@
+# IPv6 Readiness
+
+IPv6 support is being added as an optional repository-level capability. The
+current `development2` landing provides the shared address-family helpers,
+deterministic IPv6 prefix allocation helper, and migration contract. Topology,
+Docker compiler, routing, ExaBGP, Looking Glass, DNS, and service runtime
+support are staged for follow-up PRs and should not be treated as fully
+available until their code, examples, and tests land.
+
+Existing emulations remain IPv4-only by default. New IPv6 work must preserve
+the existing IPv4 APIs and add IPv6 state beside them instead of changing old
+return values.
+
+```python
+base = Base(enableIpv6=True)
+```
+
+The target topology API also allows enabling IPv6 after building the base
+topology, as long as this is done before rendering:
+
+```python
+base = Base()
+as150 = base.createAutonomousSystem(150)
+as150.createNetwork("net0")
+base.createInternetExchange(100)
+
+base.enableIpv6()
+```
+
+## Address Plan
+
+The shared IPv6 allocator uses `2000::/12` as the default root prefix. It is a
+public-style emulation prefix; it does not claim that generated routes are
+globally reachable outside the emulator. The target `Base` API can override
+the root prefix:
+
+```python
+base = Base(enableIpv6=True, ipv6RootPrefix="2000::/12")
+```
+
+Automatic allocation uses the following plan:
+
+- one stable `/48` per AS;
+- one stable `/64` per AS local network;
+- one stable `/64` per Internet Exchange peering LAN;
+- `2000:ffff::/48` is reserved for routing infrastructure, such as loopback
+  addresses used by the `Routing` layer.
+
+User-provided IPv6 prefixes under the root are normalized and reserved before
+later automatic allocation. Padded CIDR strings and bracketed IPv6 literals are
+accepted consistently across root, AS network, IX LAN, and service-network
+prefix inputs. Overlapping explicit AS/IX prefixes are rejected, and automatic
+allocation skips claimed prefixes instead of reusing them. Prefixes outside the
+configured root may be used as user-managed prefixes when they are fully
+disjoint from the root. Prefixes that overlap the root without being subnets of
+it are rejected because automatic allocation could otherwise collide with them.
+
+IPv6 address assignment follows the existing `AddressAssignmentConstraint`
+intent. Hosts use the host offset range, routers use the router offset range,
+and IX participants prefer ASN-derived offsets.
+
+## Network and Interface APIs
+
+The existing IPv4 accessors remain IPv4-only:
+
+```python
+network.getPrefix()
+interface.getAddress()
+```
+
+Follow-up topology PRs will add explicit IPv6 accessors for dual-stack state:
+
+```python
+network.hasIpv6Prefix()
+network.getIpv6Prefix()
+interface.hasIpv6Address()
+interface.getIpv6Address()
+```
+
+## Per-Network Control
+
+The following API is the target shape for follow-up topology integration.
+
+With global IPv6 enabled, local AS networks and IX peering LANs use automatic
+IPv6 prefixes by default.
+
+```python
+as150.createNetwork("net0")
+base.createInternetExchange(100)
+```
+
+Users can override or disable IPv6 on a specific network:
+
+```python
+as150.createNetwork("explicit", ipv6Prefix="2000:0:150::/64")
+as150.createNetwork("v4only", ipv6Prefix=None)
+base.createInternetExchange(200, ipv6Prefix="2000:8:0:200::/64")
+```
+
+## Per-Interface Control
+
+The following API is the target shape for follow-up topology integration.
+
+`joinNetwork()` also accepts an IPv6 address intent. The default is `"auto"`.
+Use `None` for an IPv4-only attachment on a dual-stack network, or provide an
+explicit IPv6 address.
+
+```python
+as150.createHost("web").joinNetwork("net0")
+as150.createHost("legacy").joinNetwork("net0", ipv6Address=None)
+as150.createHost("fixed").joinNetwork("net0", ipv6Address="2000:0:150::71")
+```
+
+Explicit IPv4 and IPv6 interface address literals are normalized before being
+stored. Padded values and bracketed IPv6 literals such as
+`ipv6Address="[2000:0:150::71]"` are accepted, while `getAddress()` remains the
+IPv4 accessor and `getIpv6Address()` remains the IPv6 accessor.
+
+## Routing
+
+The routing behavior described here is the target control-plane migration
+contract. It is not claimed as fully re-landed on `development2` until the
+Routing, ExaBGP, Looking Glass, examples, and runtime checks land in follow-up
+PRs.
+
+The routing layers remain intent based. `Ebgp`, `Ibgp`, and `Ospf` record
+peering and interface intent. The `Routing` layer renders address-family
+specific BIRD or FRR configuration.
+
+When IPv6 is present:
+
+- BIRD receives IPv6 routing tables and IPv6 BGP/OSPFv3 blocks as needed;
+- FRR receives `address-family ipv6 unicast` and OSPFv3 configuration as
+  needed;
+- OSPFv2 and OSPFv3 stay separate;
+- ExaBGP can announce IPv6 prefixes when the speaker and peer share IPv6 on the
+  peering network;
+- Looking Glass can report IPv4 and IPv6 route-state separately.
+
+Manual BGP session intent accepts the same address-family aliases and address
+literal normalization as services. Padded IPv4/IPv6 values and bracketed IPv6
+literals are canonicalized before BIRD/FRR/ExaBGP config is rendered.
+
+See [routing.md](./routing.md) for backend selection and
+[IPv6 Addressing and Control Plane Design](../designs/ipv6-control-plane-design.md)
+for the design boundary.
+
+## Docker Compiler
+
+The compiler behavior described here is the target migration contract. It is
+not enabled by this helper-foundation PR alone.
+
+The Docker compiler emits IPv6 runtime configuration only for networks that
+have IPv6 prefixes. Dual-stack networks include `enable_ipv6: true`, IPv6 IPAM,
+and service-level `ipv6_address` entries only for interfaces carrying IPv6
+state. Interfaces that opt out with `ipv6Address=None` remain IPv4-only even on
+a dual-stack service network. Custom container and Internet Map attachments
+follow the same explicit-address rule: a dual-stack network does not imply a
+static per-container `ipv6_address` unless `ipv6_address` is provided.
+Explicit static `ip_address` and `ipv6_address` values on those attachment
+APIs are normalized before compose and metadata output, including padded values
+and bracketed IPv6 literals. The IPv4 field rejects IPv6 literals, and the IPv6
+field rejects IPv4 literals.
+
+For `selfManagedNetwork=True`, the compiler uses dummy IPv6 subnets and rewrites
+container addresses at startup, matching the existing IPv4 self-managed network
+behavior.
+
+## Repository Readiness
+
+IPv6 support is being expanded as a repository-level contract. This PR lands
+the helper foundation and documentation boundary. Later PRs must update this
+section as each feature is implemented and verified on `development2`.
+
+Target categories:
+
+- supported: core addressing, Docker dual-stack networks, BIRD/FRR BGP,
+  OSPFv3, ExaBGP, Looking Glass;
+- baseline dual-stack: DNS authoritative and reverse records, and `/etc/hosts`;
+- compatible but not fully migrated: DNS cache, Domain Registrar dynamic A/AAAA
+  updates, Web/CA, traffic wrappers, Kubo bootstrap endpoints, Botnet
+  C2/dropper endpoint formatting, Monero seed/RPC endpoint formatting,
+  Chainlink generated URL formatting, Ethereum faucet/utility, faucet-user,
+  and bootnode/beacon helper HTTP URL formatting;
+- IPv4-first pending design: Email; Cymru IP origin ASN mapping remains
+  IPv4-only with normalized IPv4 prefix inputs; Tor remains IPv4-first with
+  directory-authority downloader and hidden-service backend target formatting
+  guarded by shared endpoint helpers;
+- separate design required: SCION underlay, cross-connect, DHCPv6, MPLS/EVPN,
+  real-world connectivity, OpenVPN, k8s, internetmap2.
+
+Reverse DNS preserves existing IPv4 `in-addr.arpa.` PTR generation. When
+interfaces carry IPv6 state, `ReverseDomainNameService` also populates
+`ip6.arpa.` PTR records; IPv4-only topologies do not create the IPv6 reverse
+zone. Manual DNS A/AAAA records use shared normalization and reject mismatched
+address families, such as an A record with an IPv6 literal or an AAAA record
+with an IPv4 literal. Manual and imported authoritative master-IP zone keys are
+normalized to canonical DNS zone names before slave or cache forwarder
+configuration is generated. Authoritative zone creation and hosting APIs use
+the same canonical zone-name normalization, so padded zone inputs do not change
+generated BIND zone names or zone file paths.
+
+`EtcHosts` writes IPv4 and IPv6 entries for node interfaces that carry those
+addresses. Service-network Bridge addresses are intentionally kept so
+service-only nodes remain resolvable. IX peering addresses are skipped, matching
+the existing rule that peering LAN addresses should not become host aliases.
+
+Domain Registrar dynamic updates preserve A as the default record type. The
+registration page also allows users to explicitly choose AAAA records for IPv6
+addresses, and rejects submitted IP addresses whose family does not match the
+selected A/AAAA record type. The registrar still follows the existing
+TLD/master-DNS placement model; this is not a broader DNS workflow redesign.
+
+DNS cache forward zones preserve IPv4 defaults. When a forward zone falls back
+to authoritative zone-server bindings instead of explicit master IPs, the cache
+normalizes the forward-zone name, uses the same node-address helpers as
+authoritative DNS, and adds IPv6 forwarders only for zone-server nodes that
+actually have IPv6 state. Explicit resolver nameserver inputs, including
+`Base`, AS, node, `ResolvConfHook`, and `ResolvConfHookByAs` paths, normalize
+padded IPv4/IPv6 literals before writing `resolv.conf` commands.
+
+Traffic generators preserve existing raw receiver target lists. For explicit
+address-family selection, use `addReceiverVnodes(..., family=AddressFamily.IPv6)`
+to resolve receiver virtual nodes through the shared node-address helpers. The
+generated reachability probe uses IPv6 ping for IPv6 literal targets while
+preserving the existing IPv4/hostname ping path. Individual traffic tools still
+need runtime validation before a full IPv6 support claim.
+
+Kubo bootstrap endpoints preserve IPv4 defaults and select bootstrap node
+addresses through the shared Local-network-first helper, falling back to the
+service network when a bootstrap node has no Local interface. The generated
+bootstrap helper probes use the same address family as the selected bootstrap
+endpoints. The legacy Kubo `getIP` utility follows the same rule: IPv4 remains
+the default, and callers may explicitly request IPv6. For explicit IPv6
+bootstrap RPC URLs and peer multiaddrs, use
+`KuboService(bootstrapAddressFamily=AddressFamily.IPv6)` or
+`setBootstrapAddressFamily(AddressFamily.IPv6)`.
+
+Botnet C2/dropper endpoints preserve the existing first-interface IPv4
+default. In a dual-stack emulation, call
+`BotnetServer.setEndpointAddressFamily(AddressFamily.IPv6)` to generate a
+bracketed IPv6 dropper URL for binding-based clients. DGA dropper runners
+preserve preformatted HTTP(S) URLs and existing `host:port` authority outputs
+without adding their own host/path wrapper, while DGA and legacy non-DGA
+fallbacks bracket bare IPv6 host arguments if no preformatted URL is provided.
+BYOB client/server runtime behavior and DGA endpoints have not been validated
+as full IPv6 support.
+
+Looking Glass route-state observation remains separate from ExaBGP event
+dashboards. Its frontend-to-proxy traffic preserves the IPv4 default. In a
+dual-stack emulation, call
+`BgpLookingGlassServer.setProxyAddressFamily(AddressFamily.IPv6)` to generate
+bracketed IPv6 proxy URLs for the frontend; this selects only the management
+endpoint family, not the set of route families queried from the router.
+
+CA certificate installation filters accept IPv4 and IPv6 address/prefix
+selectors. For example, `installCACert(Filter(ipv6="2000:0:3::72"))` installs
+the root CA certificate only on nodes with that IPv6 address; CA address and
+prefix matching, including helper utilities, normalize padded and bracketed
+IPv6 literals through the shared address helpers. CA domain inputs trim DNS
+names and normalize padded or bracketed IPv4/IPv6 endpoint literals before Web
+HTTPS ACME directory URLs use shared URL helpers, but Web HTTPS and ACME runtime
+behavior remain compatible and not fully migrated.
+
+Monero seed and full-node RPC endpoint lists preserve IPv4 defaults and select
+node addresses through the shared Local-network-first helper, falling back to
+the service network when a node has no Local interface. In a dual-stack
+emulation, call `blockchain.setEndpointAddressFamily(AddressFamily.IPv6)` to
+generate bracketed IPv6 `host:port` endpoints for those lists; generated seed
+wait probes use the same endpoint address family. Monero daemon listener
+behavior has not been runtime-validated as full IPv6 support.
+
+Chainlink generated URLs preserve IPv4 defaults and select referenced Ethereum,
+faucet, and utility endpoints through the shared Local-network-first helper,
+falling back to the service network when a referenced node has no Local
+interface. In a dual-stack emulation, call
+`chainlink.setEndpointAddressFamily(AddressFamily.IPv6)` or pass
+`endpointAddressFamily=AddressFamily.IPv6` to generate bracketed IPv6 RPC,
+faucet, utility, and WebSocket/HTTP node URLs. The underlying Ethereum and
+Chainlink runtime path has not been validated as full IPv6 support.
+
+Ethereum faucet/utility generated URLs, faucet-user request URLs, faucet
+funding-script server URLs, and bootnode/beacon helper fetch URLs preserve IPv4
+defaults and select referenced nodes through the shared Local-network-first
+helper, falling back to the service network when a referenced node has no Local
+interface. In a dual-stack emulation, call
+`blockchain.setEndpointAddressFamily(AddressFamily.IPv6)` or
+`faucetUserService.setEndpointAddressFamily(AddressFamily.IPv6)` to generate
+bracketed IPv6 HTTP RPC, faucet, enode-fetch, beacon-identity, and beacon-setup
+helper URLs. The Lighthouse validator beacon-node URL template accepts a
+preformatted helper URL so IPv6 literals are bracketed when supplied, but the
+current PoS validator install path remains IPv4-first. Ethereum ENR content,
+peer discovery, bootnode bind/listener, and daemon runtime behavior have not
+been runtime-validated as full IPv6 support.
+
+Tor remains IPv4-first. Directory-authority fingerprint downloader URLs and
+hidden-service backend targets use shared endpoint helpers so explicit IPv6
+literals are normalized and bracketed correctly without bracketing DNS names.
+Hidden-service backends linked with `linkByVnode(...,
+family=AddressFamily.IPv6)` resolve through the shared Local-network-first
+helper and fall back to the service network when the backend node has no Local
+interface. If no preformatted hidden-service target is provided, the entrypoint
+fallback brackets bare IPv6 `TOR_HS_ADDR` values before writing
+`HiddenServicePort`. Tor bind/listener, directory authority, consensus, and
+daemon runtime behavior still require a separate migration.
+
+See
+[Repository-Wide IPv6 Readiness Design](../designs/ipv6-repository-readiness-design.md)
+for the migration contract.
+
+## Service Author Rules
+
+Keep `getAddress()` and `getPrefix()` as IPv4-only APIs. A service that needs
+IPv6 should use `hasIpv6Address()`, `getIpv6Address()`, or the shared helpers in
+`seedemu.core`:
+
+```python
+from seedemu.core import (
+    AddressFamily,
+    getInterfaceAddress,
+    getNodeAddress,
+    getNodeAddresses,
+    getNodePreferredAddress,
+    nodeHasAddress,
+    nodeHasAddressInPrefix,
+    formatHost,
+    formatHostPort,
+    formatUrl,
+    formatMultiaddr,
+    normalizeAddressList,
+    normalizePrefix,
+    normalizeAddressRecord,
+)
+```
+
+Use `formatHost()`, `formatHostPort()`, or `formatUrl()` instead of manually
+concatenating host strings or `host:port`, because IPv6 literals need brackets
+in URLs. Use `formatUrl()` with separate host and port arguments when possible;
+if a legacy path already passes a bracketed IPv6 authority such as
+`[2000::1]:8443`, the helper preserves the authority and canonicalizes the
+literal. When a caller also supplies a separate port, that separate port is
+used instead of any port embedded in a legacy IPv4, DNS-name, or bracketed IPv6
+authority. Padded explicit port values are trimmed before `host:port`, URL, or
+multiaddr output is generated. Malformed bracketed IPv6 authorities, such as
+`[2000::1]:bad`, are rejected instead of being emitted as ambiguous endpoints.
+Explicit port arguments must be non-empty decimal strings, so invalid
+socket-like endpoints fail before a service writes them into config.
+URL paths that start with `?` or `#` are treated as query or fragment
+components instead of being rewritten as path segments. Use
+`formatMultiaddr()` when generating IPFS/libp2p multiaddrs. Use
+`getNodeAddress()`, `getNodePreferredAddress()`, or `getNodeAddresses()` when a
+service needs stable Local-network-first address selection with service-network
+fallback. Use `nodeHasAddress()` and `nodeHasAddressInPrefix()` when matching a
+node against IPv4 or IPv6 address/prefix selectors. Pass an explicit
+`AddressFamily` to those match helpers when implementing family-specific
+selectors such as `Filter(ipv4=...)` or `Filter(ipv6Prefix=...)`, so
+wrong-family literals do not accidentally match. Use
+`normalizeAddressList()` when a service accepts a list of IPv4/IPv6 literals,
+including bracketed IPv6 address literals. Use `normalizePrefix()` when a
+service accepts IPv4/IPv6 CIDR prefixes, and use `normalizeAddressRecord()` when
+a service accepts DNS-style manual A/AAAA records and needs canonical IPv4/IPv6
+literals without changing other record types. `normalizeAddressRecord()` also
+rejects A/AAAA records whose address literal does not match the requested
+record family.
+
+Do not claim service-level IPv6 support until the service has a minimal IPv6 or
+dual-stack example and a regression check showing that old IPv4 behavior is
+unchanged.

--- a/seedemu/core/Addressing.py
+++ b/seedemu/core/Addressing.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from enum import Enum
+from ipaddress import ip_address, ip_network
+from typing import Iterable, List, Optional, TYPE_CHECKING, Tuple, Union
+
+from .enums import NetworkType
+
+if TYPE_CHECKING:
+    from .Node import Interface, Node
+
+
+class AddressFamily(Enum):
+    """Address-family selector used by dual-stack aware services."""
+
+    IPv4 = "ipv4"
+    IPv6 = "ipv6"
+
+
+def normalizeAddressFamily(family: Union[AddressFamily, str, int]) -> AddressFamily:
+    """Normalize common address-family spellings to AddressFamily."""
+
+    if isinstance(family, AddressFamily):
+        return family
+
+    value = str(family).strip().lower()
+    if value in ("2", "4", "af_inet", "inet", "ip4", "ipv4", "v4"):
+        return AddressFamily.IPv4
+    if value in ("6", "10", "af_inet6", "inet6", "ip6", "ipv6", "v6"):
+        return AddressFamily.IPv6
+
+    raise ValueError("unsupported address family {}".format(family))
+
+
+def _parseIpLiteral(value: Union[str, object]):
+    candidate = str(value).strip()
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1].strip()
+    return ip_address(candidate)
+
+
+def normalizeAddressList(addrs: Iterable[Union[str, object]]) -> List[str]:
+    """Normalize IPv4/IPv6 address literals while preserving list order."""
+
+    return [str(_parseIpLiteral(addr)) for addr in addrs]
+
+
+def normalizePrefix(prefix: Union[str, object], strict: bool = True) -> str:
+    """Normalize an IPv4/IPv6 CIDR prefix literal."""
+
+    value = str(prefix).strip()
+    if "/" in value:
+        addr, slash, prefix_len = value.partition("/")
+        value = "{}{}{}".format(normalizeAddressList([addr])[0], slash, prefix_len.strip())
+    return str(ip_network(value, strict=strict))
+
+
+def normalizeAddressRecord(record: Union[str, object], trimNonAddressRecord: bool = False) -> str:
+    """Normalize DNS-style A/AAAA record address literals.
+
+    Non-address records are returned unchanged unless trimNonAddressRecord is
+    set for callers whose historical API already trimmed those records.
+    """
+
+    value = str(record)
+    parts = value.strip().split()
+    if len(parts) >= 3 and parts[-2].upper() in ("A", "AAAA"):
+        parts[-2] = parts[-2].upper()
+        parsed = _parseIpLiteral(parts[-1])
+        if parts[-2] == "A" and parsed.version != 4:
+            raise ValueError("A record must use an IPv4 address: {}".format(record))
+        if parts[-2] == "AAAA" and parsed.version != 6:
+            raise ValueError("AAAA record must use an IPv6 address: {}".format(record))
+        parts[-1] = str(parsed)
+        return " ".join(parts)
+    return value.strip() if trimNonAddressRecord else value
+
+
+def _parseHostIpLiteral(host: Union[str, object]):
+    try:
+        return _parseIpLiteral(host)
+    except ValueError:
+        return None
+
+
+def _formatBracketedIpv6Authority(value: str):
+    if not value.startswith("["):
+        return None
+
+    end = value.find("]")
+    if end < 0:
+        raise ValueError("malformed bracketed IPv6 authority: {}".format(value))
+
+    try:
+        parsed = ip_address(value[1:end].strip())
+    except ValueError:
+        return None
+
+    if parsed.version != 6:
+        return None
+
+    suffix = value[end + 1 :].strip()
+    if suffix == "":
+        return "[{}]".format(parsed)
+    if suffix.startswith(":") and len(suffix) > 1 and suffix[1:].isdigit():
+        return "[{}]{}".format(parsed, suffix)
+    raise ValueError("malformed bracketed IPv6 authority: {}".format(value))
+
+
+def _formatBracketedIpv6Host(value: str):
+    if not value.startswith("["):
+        return None
+
+    end = value.find("]")
+    if end < 0:
+        raise ValueError("malformed bracketed IPv6 authority: {}".format(value))
+
+    try:
+        parsed = ip_address(value[1:end].strip())
+    except ValueError:
+        return None
+
+    if parsed.version != 6:
+        return None
+
+    suffix = value[end + 1 :].strip()
+    if suffix == "" or (suffix.startswith(":") and len(suffix) > 1 and suffix[1:].isdigit()):
+        return "[{}]".format(parsed)
+    raise ValueError("malformed bracketed IPv6 authority: {}".format(value))
+
+
+def _formatHostWithExplicitPort(value: str):
+    bracketed_host = _formatBracketedIpv6Host(value)
+    if bracketed_host is not None:
+        return bracketed_host
+
+    if value.count(":") == 1:
+        host, _old_port = value.rsplit(":", 1)
+        if host.strip() and _old_port.strip():
+            return formatHost(host)
+
+    return formatHost(value)
+
+
+def _formatTcpPort(port: Union[str, int]) -> str:
+    value = str(port).strip()
+    if value == "":
+        raise ValueError("endpoint port must not be empty")
+    if not value.isdigit():
+        raise ValueError("endpoint port must be numeric: {}".format(port))
+    return value
+
+
+def getInterfaceAddress(iface: "Interface", family: Union[AddressFamily, str, int] = AddressFamily.IPv4):
+    """Return an interface address for the requested address family."""
+
+    selected = normalizeAddressFamily(family)
+    if selected == AddressFamily.IPv4:
+        return iface.getAddress()
+    return iface.getIpv6Address() if iface.hasIpv6Address() else None
+
+
+def hasInterfaceAddress(iface: "Interface", family: Union[AddressFamily, str, int] = AddressFamily.IPv4) -> bool:
+    """Check if an interface has an address for the requested address family."""
+
+    return getInterfaceAddress(iface, family) is not None
+
+
+def nodeHasAddress(
+    node: "Node",
+    address: Union[str, object],
+    family: Union[AddressFamily, str, int, None] = None,
+) -> bool:
+    """Check whether a node has an IPv4 or IPv6 address literal."""
+
+    requested = _parseIpLiteral(address)
+    if family is None:
+        selected_family = AddressFamily.IPv4 if requested.version == 4 else AddressFamily.IPv6
+    else:
+        selected_family = normalizeAddressFamily(family)
+        expected_version = 4 if selected_family == AddressFamily.IPv4 else 6
+        if requested.version != expected_version:
+            return False
+    for iface in node.getInterfaces():
+        iface_addr = getInterfaceAddress(iface, selected_family)
+        if iface_addr is not None and str(iface_addr) == str(requested):
+            return True
+    return False
+
+
+def nodeHasAddressInPrefix(
+    node: "Node",
+    prefix: Union[str, object],
+    family: Union[AddressFamily, str, int, None] = None,
+) -> bool:
+    """Check whether any node address is inside an IPv4 or IPv6 prefix."""
+
+    network = ip_network(normalizePrefix(prefix))
+    if family is None:
+        selected_family = AddressFamily.IPv4 if network.version == 4 else AddressFamily.IPv6
+    else:
+        selected_family = normalizeAddressFamily(family)
+        expected_version = 4 if selected_family == AddressFamily.IPv4 else 6
+        if network.version != expected_version:
+            return False
+    for iface in node.getInterfaces():
+        iface_addr = getInterfaceAddress(iface, selected_family)
+        if iface_addr is not None and iface_addr in network:
+            return True
+    return False
+
+
+def _getNodeAddressCandidates(node: "Node"):
+    ifaces = node.getInterfaces()
+    assert len(ifaces) > 0, "Node {} has no IP address.".format(node.getName())
+
+    local_ipv4 = None
+    local_ipv6 = None
+    fallback_ipv4 = None
+    fallback_ipv6 = None
+
+    for iface in ifaces:
+        ipv4_addr = getInterfaceAddress(iface, AddressFamily.IPv4)
+        ipv6_addr = getInterfaceAddress(iface, AddressFamily.IPv6)
+
+        if fallback_ipv4 is None and ipv4_addr is not None:
+            fallback_ipv4 = ipv4_addr
+        if fallback_ipv6 is None and ipv6_addr is not None:
+            fallback_ipv6 = ipv6_addr
+
+        if iface.getNet().getType() == NetworkType.Local:
+            if local_ipv4 is None and ipv4_addr is not None:
+                local_ipv4 = ipv4_addr
+            if local_ipv6 is None and ipv6_addr is not None:
+                local_ipv6 = ipv6_addr
+
+    return {
+        "local": {
+            AddressFamily.IPv4: local_ipv4,
+            AddressFamily.IPv6: local_ipv6,
+        },
+        "fallback": {
+            AddressFamily.IPv4: fallback_ipv4,
+            AddressFamily.IPv6: fallback_ipv6,
+        },
+    }
+
+
+def getNodeAddresses(node: "Node", preferLocal: bool = True) -> Tuple[object, object]:
+    """Return preferred IPv4 and IPv6 addresses for a node.
+
+    Local-network interfaces are preferred by default. When a requested family
+    has no local address, the first address from any interface is returned.
+    """
+
+    candidates = _getNodeAddressCandidates(node)
+    if not preferLocal:
+        return (
+            candidates["fallback"][AddressFamily.IPv4],
+            candidates["fallback"][AddressFamily.IPv6],
+        )
+
+    local_ipv4 = candidates["local"][AddressFamily.IPv4]
+    local_ipv6 = candidates["local"][AddressFamily.IPv6]
+    fallback_ipv4 = candidates["fallback"][AddressFamily.IPv4]
+    fallback_ipv6 = candidates["fallback"][AddressFamily.IPv6]
+    return (local_ipv4 or fallback_ipv4, local_ipv6 or fallback_ipv6)
+
+
+def getNodeAddress(
+    node: "Node",
+    family: Union[AddressFamily, str, int] = AddressFamily.IPv4,
+    preferLocal: bool = True,
+):
+    """Return the node address for one address family."""
+
+    selected = normalizeAddressFamily(family)
+    candidates = _getNodeAddressCandidates(node)
+    if not preferLocal:
+        return candidates["fallback"][selected]
+    return candidates["local"][selected] or candidates["fallback"][selected]
+
+
+def getNodePreferredAddress(
+    node: "Node",
+    families: Iterable[Union[AddressFamily, str, int]] = (AddressFamily.IPv4, AddressFamily.IPv6),
+    preferLocal: bool = True,
+):
+    """Return the first available node address in the requested family order."""
+
+    selected_families = [normalizeAddressFamily(family) for family in families]
+    candidates = _getNodeAddressCandidates(node)
+    scopes = ("local", "fallback") if preferLocal else ("fallback",)
+    for scope in scopes:
+        for family in selected_families:
+            address = candidates[scope][family]
+            if address is not None:
+                return address
+    return None
+
+
+def formatHost(host: Union[str, object]) -> str:
+    """Format a host/address for endpoint strings, bracketing IPv6 literals."""
+
+    value = str(host).strip()
+    authority = _formatBracketedIpv6Authority(value)
+    if authority is not None:
+        return authority
+
+    parsed = _parseHostIpLiteral(value)
+    if parsed is None:
+        return value
+
+    if parsed.version == 6:
+        return "[{}]".format(parsed)
+    return str(parsed)
+
+
+def formatHostPort(host: Union[str, object], port: Union[str, int]) -> str:
+    """Format host:port with RFC 3986 brackets for IPv6 literals."""
+
+    return "{}:{}".format(_formatHostWithExplicitPort(str(host).strip()), _formatTcpPort(port))
+
+
+def formatUrl(
+    scheme: str,
+    host: Union[str, object],
+    port: Optional[Union[str, int]] = None,
+    path: str = "",
+) -> str:
+    """Format a URL from address-family neutral pieces."""
+
+    authority = formatHost(host) if port is None else formatHostPort(host, port)
+    if path and not path.startswith(("/", "?", "#")):
+        path = "/" + path
+    return "{}://{}{}".format(scheme, authority, path)
+
+
+def formatMultiaddr(host: Union[str, object], tcpPort: Union[str, int], peerId: str = None) -> str:
+    """Format an IPFS/libp2p style multiaddr for IPv4 or IPv6 literals."""
+
+    parsed = _parseHostIpLiteral(host)
+    if parsed is None:
+        raise ValueError("multiaddr host must be an IPv4/IPv6 literal: {}".format(host))
+
+    proto = "ip6" if parsed.version == 6 else "ip4"
+    out = "/{}/{}/tcp/{}".format(proto, parsed, _formatTcpPort(tcpPort))
+    if peerId is not None:
+        out += "/p2p/{}".format(peerId)
+    return out

--- a/seedemu/core/Ipv6Addressing.py
+++ b/seedemu/core/Ipv6Addressing.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from ipaddress import IPv6Network
+from typing import Dict, Iterable, List, Set, Union
+
+from .Addressing import normalizePrefix
+
+
+DEFAULT_IPV6_ROOT_PREFIX = "2000::/12"
+DEFAULT_IPV6_INFRA_PREFIX = "2000:ffff::/48"
+
+
+class Ipv6Addressing:
+    """Deterministic IPv6 prefix allocator for optional dual-stack emulations."""
+
+    def __init__(self, rootPrefix: str = DEFAULT_IPV6_ROOT_PREFIX, reservedPrefixes: Iterable[str] = None):
+        self.__root = IPv6Network(normalizePrefix(rootPrefix))
+        assert self.__root.prefixlen <= 48, "IPv6 root prefix must be /48 or shorter"
+        self.__used_as_indices: Set[int] = set()
+        self.__as_prefixes: Dict[int, IPv6Network] = {}
+        self.__as_net_indices: Dict[int, int] = {}
+        self.__as_net_used: Dict[int, Set[int]] = {}
+        self.__ix_prefixes: Dict[int, IPv6Network] = {}
+        self.__ix_indices: Set[int] = set()
+        self.__allocated_prefixes: Set[IPv6Network] = set()
+        self.__as_prefix_bits = 48 - self.__root.prefixlen
+        self.__network_bits = 16
+        self.__ix_base = 1 << max(self.__as_prefix_bits - 1, 0)
+        self.__reserved_prefixes: List[IPv6Network] = []
+
+        if reservedPrefixes is None:
+            reservedPrefixes = [DEFAULT_IPV6_INFRA_PREFIX]
+        for prefix in reservedPrefixes:
+            self.reservePrefix(prefix)
+
+    def getRootPrefix(self) -> IPv6Network:
+        return self.__root
+
+    def getReservedPrefixes(self) -> List[IPv6Network]:
+        return list(self.__reserved_prefixes)
+
+    def __is_outside_root(self, prefix: IPv6Network) -> bool:
+        if prefix.subnet_of(self.__root):
+            return False
+        assert not prefix.overlaps(self.__root), "IPv6 prefix {} overlaps root prefix {}".format(prefix, self.__root)
+        return True
+
+    def claimPrefix(self, prefix: Union[str, IPv6Network]) -> Ipv6Addressing:
+        claimed = prefix if isinstance(prefix, IPv6Network) else IPv6Network(normalizePrefix(prefix))
+        if self.__is_outside_root(claimed):
+            return self
+        assert self.__is_available(claimed), "IPv6 prefix {} overlaps an allocated prefix".format(claimed)
+        self.__allocated_prefixes.add(claimed)
+        return self
+
+    def reservePrefix(self, prefix: Union[str, IPv6Network]) -> Ipv6Addressing:
+        reserved = prefix if isinstance(prefix, IPv6Network) else IPv6Network(normalizePrefix(prefix))
+        if self.__is_outside_root(reserved):
+            return self
+        self.claimPrefix(reserved)
+        self.__reserved_prefixes.append(reserved)
+        return self
+
+    def reserveAsNetworkPrefix(self, asn: int, prefix: Union[str, IPv6Network]) -> Ipv6Addressing:
+        network = prefix if isinstance(prefix, IPv6Network) else IPv6Network(normalizePrefix(prefix))
+        if self.__is_outside_root(network):
+            return self
+
+        as_prefix = self.assignAsPrefix(asn)
+        if network.subnet_of(as_prefix):
+            self.__claim_as_network_prefix(asn, as_prefix, network)
+            return self
+
+        return self.claimPrefix(network)
+
+    def __prefix_from_index(self, index: int, prefixlen: int) -> IPv6Network:
+        child_bits = prefixlen - self.__root.prefixlen
+        assert child_bits >= 0, "child prefix must be within IPv6 root"
+        assert index >= 0 and index < (1 << child_bits), "IPv6 prefix index out of root range"
+        base = int(self.__root.network_address)
+        shift = 128 - prefixlen
+        return IPv6Network((base + (index << shift), prefixlen))
+
+    def __is_available(self, prefix: IPv6Network) -> bool:
+        return all(not prefix.overlaps(used) for used in self.__allocated_prefixes)
+
+    def __claim_as_network_prefix(self, asn: int, as_prefix: IPv6Network, prefix: IPv6Network) -> None:
+        assert prefix.prefixlen >= 64, "AS IPv6 network prefix {} must be /64 or longer".format(prefix)
+        base = int(as_prefix.network_address)
+        first = (int(prefix.network_address) - base) >> 64
+        last = (int(prefix.broadcast_address) - base) >> 64
+        used = self.__as_net_used.setdefault(asn, set())
+        for index in range(first, last + 1):
+            assert index not in used, "IPv6 AS{} network prefix {} overlaps an allocated /64".format(asn, prefix)
+        used.update(range(first, last + 1))
+
+    def __claim_index(self, preferred: int, used: Set[int], limit: int, prefixlen: int) -> int:
+        assert limit > 0, "IPv6 root prefix does not have enough allocation space"
+        index = preferred % limit
+        while index in used or not self.__is_available(self.__prefix_from_index(index, prefixlen)):
+            index = (index + 1) % limit
+            assert index != preferred % limit, "IPv6 prefix allocation exhausted"
+        used.add(index)
+        return index
+
+    def assignAsPrefix(self, asn: int) -> IPv6Network:
+        if asn not in self.__as_prefixes:
+            limit = 1 << self.__as_prefix_bits
+            preferred = int(asn)
+            index = self.__claim_index(preferred, self.__used_as_indices, limit, 48)
+            self.__as_prefixes[asn] = self.__prefix_from_index(index, 48)
+            self.__allocated_prefixes.add(self.__as_prefixes[asn])
+            self.__as_net_indices[asn] = 0
+            self.__as_net_used.setdefault(asn, set())
+        return self.__as_prefixes[asn]
+
+    def nextAsNetworkPrefix(self, asn: int) -> IPv6Network:
+        as_prefix = self.assignAsPrefix(asn)
+        index = self.__as_net_indices.get(asn, 0)
+        used = self.__as_net_used.setdefault(asn, set())
+        while index in used:
+            index += 1
+            assert index < (1 << self.__network_bits), "IPv6 /64 network allocation exhausted for AS{}".format(asn)
+        used.add(index)
+        self.__as_net_indices[asn] = index + 1
+        base = int(as_prefix.network_address)
+        return IPv6Network((base + (index << 64), 64))
+
+    def assignIxPrefix(self, ixid: int) -> IPv6Network:
+        if ixid not in self.__ix_prefixes:
+            child_bits = 64 - self.__root.prefixlen
+            limit = 1 << child_bits
+            preferred = (self.__ix_base + int(ixid)) % limit
+            index = self.__claim_index(preferred, self.__ix_indices, limit, 64)
+            self.__ix_prefixes[ixid] = self.__prefix_from_index(index, 64)
+            self.__allocated_prefixes.add(self.__ix_prefixes[ixid])
+        return self.__ix_prefixes[ixid]

--- a/seedemu/core/__init__.py
+++ b/seedemu/core/__init__.py
@@ -1,8 +1,10 @@
 from .AddressAssignmentConstraint import AddressAssignmentConstraint, Assigner
+from .Addressing import AddressFamily, formatHost, formatHostPort, formatMultiaddr, formatUrl, getInterfaceAddress, getNodeAddress, getNodeAddresses, getNodePreferredAddress, hasInterfaceAddress, nodeHasAddress, nodeHasAddressInPrefix, normalizeAddressFamily, normalizeAddressList, normalizeAddressRecord, normalizePrefix
 from .AutonomousSystem import AutonomousSystem
 from .ScionAutonomousSystem import ScionAutonomousSystem
 from .IsolationDomain import IsolationDomain
 from .InternetExchange import InternetExchange
+from .Ipv6Addressing import DEFAULT_IPV6_INFRA_PREFIX, DEFAULT_IPV6_ROOT_PREFIX, Ipv6Addressing
 from .Network import Network
 from .Node import Node, File, Interface, Router, promote_to_real_world_router, promote_to_scion_router
 from .Printable import Printable

--- a/test_ipv6_repository_readiness.py
+++ b/test_ipv6_repository_readiness.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent
+CORE = ROOT / "seedemu" / "core"
+
+
+def _load_core_module(name: str, filename: str):
+    """Load a core module without importing top-level seedemu optional deps."""
+
+    package_name = "seedemu"
+    core_name = "seedemu.core"
+    if package_name not in sys.modules:
+        package_spec = importlib.util.spec_from_loader(package_name, loader=None, is_package=True)
+        package = importlib.util.module_from_spec(package_spec)
+        package.__path__ = [str(ROOT / "seedemu")]
+        sys.modules[package_name] = package
+
+    if core_name not in sys.modules:
+        core_spec = importlib.util.spec_from_loader(core_name, loader=None, is_package=True)
+        core = importlib.util.module_from_spec(core_spec)
+        core.__path__ = [str(CORE)]
+        sys.modules[core_name] = core
+
+    module_name = "{}.{}".format(core_name, name)
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, CORE / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+Addressing = _load_core_module("Addressing", "Addressing.py")
+Ipv6AddressingModule = _load_core_module("Ipv6Addressing", "Ipv6Addressing.py")
+
+AddressFamily = Addressing.AddressFamily
+Ipv6Addressing = Ipv6AddressingModule.Ipv6Addressing
+
+
+def test_endpoint_helpers_preserve_ipv4_and_bracket_ipv6():
+    assert Addressing.formatHost(" 10.0.0.1 ") == "10.0.0.1"
+    assert Addressing.formatHost(" example.test ") == "example.test"
+    assert Addressing.formatHost(" 2000:0:0::1 ") == "[2000::1]"
+    assert Addressing.formatHost(" [2000:0:0::1]:8443 ") == "[2000::1]:8443"
+
+    assert Addressing.formatHostPort("10.0.0.1", 80) == "10.0.0.1:80"
+    assert Addressing.formatHostPort("2000::1", " 80 ") == "[2000::1]:80"
+    assert Addressing.formatHostPort("[2000:0:0::1]:8443", 9443) == "[2000::1]:9443"
+
+    assert Addressing.formatUrl("http", "10.0.0.1", 8080, "api") == "http://10.0.0.1:8080/api"
+    assert Addressing.formatUrl("http", "2000::1", 8080, "?ready=1") == "http://[2000::1]:8080?ready=1"
+
+    assert Addressing.formatMultiaddr("10.0.0.1", 4001) == "/ip4/10.0.0.1/tcp/4001"
+    assert Addressing.formatMultiaddr("2000::1", " 4001 ", "peer") == "/ip6/2000::1/tcp/4001/p2p/peer"
+
+
+def test_endpoint_helpers_reject_ambiguous_ports_and_authorities():
+    with pytest.raises(ValueError):
+        Addressing.formatHost("[2000::1]:bad")
+    with pytest.raises(ValueError):
+        Addressing.formatHostPort("2000::1", "")
+    with pytest.raises(ValueError):
+        Addressing.formatHostPort("2000::1", "http")
+    with pytest.raises(ValueError):
+        Addressing.formatMultiaddr("example.test", 4001)
+
+
+def test_address_normalization_contracts():
+    assert Addressing.normalizeAddressFamily(" ipv4 ") == AddressFamily.IPv4
+    assert Addressing.normalizeAddressFamily(" IP6 ") == AddressFamily.IPv6
+    assert Addressing.normalizeAddressFamily("inet") == AddressFamily.IPv4
+    assert Addressing.normalizeAddressFamily("AF_INET6") == AddressFamily.IPv6
+    assert Addressing.normalizeAddressFamily(socket.AF_INET) == AddressFamily.IPv4
+    assert Addressing.normalizeAddressFamily(socket.AF_INET6) == AddressFamily.IPv6
+
+    assert Addressing.normalizeAddressList([" 10.2.0.71 ", " [2000:0:2:0:0:0:0:71] "]) == [
+        "10.2.0.71",
+        "2000:0:2::71",
+    ]
+    assert Addressing.normalizePrefix(" [2000:0:2:0:0:0:0:0] / 64 ") == "2000:0:2::/64"
+    assert Addressing.normalizePrefix(" 10.2.0.71/24 ", strict=False) == "10.2.0.0/24"
+
+    assert Addressing.normalizeAddressRecord(" web a 10.2.0.71 ") == "web A 10.2.0.71"
+    assert Addressing.normalizeAddressRecord(" web6 aaaa [2000:0:2:0:0:0:0:71] ") == "web6 AAAA 2000:0:2::71"
+    assert Addressing.normalizeAddressRecord(" ns1. NS a.root.example. ", trimNonAddressRecord=True) == "ns1. NS a.root.example."
+    with pytest.raises(ValueError):
+        Addressing.normalizeAddressRecord("web A 2000:0:2::71")
+    with pytest.raises(ValueError):
+        Addressing.normalizeAddressRecord("web AAAA 10.2.0.71")
+
+
+def test_ipv6_allocator_is_deterministic_and_avoids_claimed_prefixes():
+    allocator = Ipv6Addressing(rootPrefix="2000::/12")
+
+    assert str(allocator.getRootPrefix()) == "2000::/12"
+    assert "2000:ffff::/48" in [str(prefix) for prefix in allocator.getReservedPrefixes()]
+    assert str(allocator.assignAsPrefix(150)) == "2000:0:96::/48"
+    assert str(allocator.nextAsNetworkPrefix(150)) == "2000:0:96::/64"
+    assert str(allocator.assignIxPrefix(100)) == "2000:8:0:64::/64"
+
+    claimed = Ipv6Addressing(rootPrefix="2000::/12")
+    claimed.claimPrefix("2000:0:97::/48")
+    assert str(claimed.assignAsPrefix(151)) != "2000:0:97::/48"
+
+
+def test_ipv6_allocator_rejects_root_overlap_but_allows_disjoint_user_prefixes():
+    allocator = Ipv6Addressing(rootPrefix="2000::/12")
+    allocator.claimPrefix("fd00:1::/64")
+
+    with pytest.raises(AssertionError):
+        allocator.claimPrefix("2000::/11")
+
+    with pytest.raises(AssertionError):
+        allocator.claimPrefix("2000:ffff::/64")


### PR DESCRIPTION
## Summary

This PR starts the IPv6 readiness re-landing onto `development2` after the control-plane legacy cleanup. It intentionally keeps the scope narrow and reviewable: repository contracts, shared address-family helpers, deterministic IPv6 prefix allocation, and focused tests.

It does **not** reintroduce the removed legacy control-plane paths:

- no `FrrBgp` layer
- no `routingBackend="exabgp"` or `routingBackend="external"`
- no ExaBGP-as-router rendering path
- no Routing/ExaBGP/Looking Glass runtime migration in this PR

## What lands here

- Adds branch-level handoff contracts:
  - `GOAL.md`
  - `SPEC.md`
  - `TASKS.md`
- Adds AI/design guidance for future IPv6 control-plane work under `ai/`.
- Adds IPv6 control-plane and repository-readiness design docs.
- Adds user-facing IPv6 readiness documentation, explicitly marked as staged/foundation-only for this PR.
- Adds shared core helpers in `seedemu.core.Addressing`:
  - `AddressFamily`
  - address-family normalization
  - IPv4/IPv6 endpoint formatting for host, host:port, URL, and multiaddr output
  - literal/prefix/DNS A/AAAA record normalization
  - node/interface address selection helpers for future migrations
- Adds `seedemu.core.Ipv6Addressing` deterministic prefix allocator:
  - default root `2000::/12`
  - reserved infra prefix `2000:ffff::/48`
  - stable AS `/48`, AS network `/64`, and IX `/64` allocation
  - collision checks for explicit claimed/reserved prefixes
- Exports the helper API from `seedemu.core`.
- Adds focused helper tests in `test_ipv6_repository_readiness.py`.

## Design boundary

This is the first staged PR for the IPv6 readiness re-landing. The docs describe the target repository contract, but they now explicitly state that Docker, Routing, ExaBGP, Looking Glass, DNS, `/etc/hosts`, examples, and runtime probes are **not** claimed as re-integrated on `development2` by this PR alone.

Follow-up PRs should port those areas incrementally and keep the same design rules:

- IPv4 remains the default.
- `getAddress()` and `getPrefix()` remain IPv4 APIs.
- services use shared helpers instead of hand-building IPv6 URLs/host:port/multiaddr strings.
- protocol layers record intent; Routing renders BIRD/FRR.
- ExaBGP stays Service + Binding.
- Looking Glass stays a route-state observer.

## Validation

Ran locally:

```bash
git diff --check HEAD~1..HEAD
/tmp/seedemu-ipv6-foundation-venv/bin/python -m pytest -q test_ipv6_repository_readiness.py
python3 -m compileall seedemu/core
```

Results:

- `git diff --check HEAD~1..HEAD`: passed
- `pytest test_ipv6_repository_readiness.py`: `5 passed`
- `compileall seedemu/core`: passed

## Notes for reviewers

The test file deliberately loads the new core helper modules without importing top-level `seedemu`, because the local Python 3.12 environment does not have all optional repository dependencies installed. The PR CI should still exercise the normal repository environment once the feature-oriented CI PR is merged.

No generated output, runtime examples, Docker compose output, or cache files are included.
