### PR TITLE
IPv6 core topology state

### DIFF
--- a/docs/designs/ipv6-control-plane-design.md
+++ b/docs/designs/ipv6-control-plane-design.md
@@ -29,11 +29,14 @@ compilers translate the rendered model into runnable artifacts.
 
 ## Current Landing Status
 
-This PR lands the repository contract and shared helper foundation on top of
-`development2`. It does not yet claim that the topology, compiler, routing,
-ExaBGP, Looking Glass, DNS, or example runtime paths have been re-integrated on
-this branch. Those pieces should be ported in follow-up PRs against this design
-without reintroducing removed legacy control-plane shims.
+The first PR landed the repository contract and shared helper foundation on top
+of `development2`. The core-topology PR adds optional IPv6 state to
+`Base`, `AutonomousSystem`, `InternetExchange`, `Network`, `Node`, and
+`Interface`, including late enablement and per-network/per-interface opt-out.
+It still does not claim that compiler output, Routing, ExaBGP, Looking Glass,
+DNS, or example runtime paths have been re-integrated. Those pieces should be
+ported in follow-up PRs against this design without reintroducing removed
+legacy control-plane shims.
 
 ## Design Position
 

--- a/docs/designs/ipv6-repository-readiness-design.md
+++ b/docs/designs/ipv6-repository-readiness-design.md
@@ -21,16 +21,18 @@ IPv6 不应该被理解成几个示例的局部能力，而是仿真器级别的
 
 ## Current Landing Status
 
-This PR lands the contract and shared helper foundation only:
+The first PR landed the contract and shared helper foundation:
 
 - shared address-family and endpoint formatting helpers in `seedemu.core`;
 - deterministic IPv6 prefix allocation helper;
 - design, user, and agent-facing migration documents.
 
-It intentionally does not claim that Docker, Routing, ExaBGP, Looking Glass,
-DNS, `/etc/hosts`, or repository services are already dual-stack on
-`development2`. Their rows below describe the target migration contract and
-must be treated as implemented only after follow-up PRs add code and tests.
+The core-topology PR adds optional IPv6 model state to `Base`, AS networks, IX
+LANs, node interfaces, and route-server attachments. It intentionally does not
+claim that Docker, Routing, ExaBGP, Looking Glass, DNS, `/etc/hosts`, or
+repository services are already dual-stack on `development2`. Their rows below
+describe the target migration contract and must be treated as implemented only
+after follow-up PRs add code and tests.
 
 ## Address-Family Contract
 
@@ -73,10 +75,13 @@ as path segments.
 
 ## Core Readiness
 
-Target foundation:
+Landing foundation:
 
 - Optional IPv6 root prefix and deterministic AS/IX `/64` allocation.
 - IPv6 state on `Network` and `Interface`.
+
+Target follow-up foundation:
+
 - IPv6-aware BGP/OSPF intent rendering for BIRD and FRR.
 - IPv6-aware ExaBGP speaker service and Looking Glass route-state queries.
 - Docker Compose dual-stack network/IPAM and service `ipv6_address` output.

--- a/docs/user_manual/ipv6.md
+++ b/docs/user_manual/ipv6.md
@@ -1,11 +1,11 @@
 # IPv6 Readiness
 
 IPv6 support is being added as an optional repository-level capability. The
-current `development2` landing provides the shared address-family helpers,
-deterministic IPv6 prefix allocation helper, and migration contract. Topology,
-Docker compiler, routing, ExaBGP, Looking Glass, DNS, and service runtime
-support are staged for follow-up PRs and should not be treated as fully
-available until their code, examples, and tests land.
+current `development2` landing provides shared address-family helpers,
+deterministic IPv6 prefix allocation, optional topology IPv6 state, and the
+migration contract. Docker compiler output, routing, ExaBGP, Looking Glass,
+DNS, and service runtime support are staged for follow-up PRs and should not be
+treated as fully available until their code, examples, and tests land.
 
 Existing emulations remain IPv4-only by default. New IPv6 work must preserve
 the existing IPv4 APIs and add IPv6 state beside them instead of changing old
@@ -15,8 +15,8 @@ return values.
 base = Base(enableIpv6=True)
 ```
 
-The target topology API also allows enabling IPv6 after building the base
-topology, as long as this is done before rendering:
+The topology API also allows enabling IPv6 after building the base topology, as
+long as this is done before rendering:
 
 ```python
 base = Base()
@@ -31,8 +31,7 @@ base.enableIpv6()
 
 The shared IPv6 allocator uses `2000::/12` as the default root prefix. It is a
 public-style emulation prefix; it does not claim that generated routes are
-globally reachable outside the emulator. The target `Base` API can override
-the root prefix:
+globally reachable outside the emulator. `Base` can override the root prefix:
 
 ```python
 base = Base(enableIpv6=True, ipv6RootPrefix="2000::/12")
@@ -68,7 +67,7 @@ network.getPrefix()
 interface.getAddress()
 ```
 
-Follow-up topology PRs will add explicit IPv6 accessors for dual-stack state:
+Use the explicit IPv6 accessors for dual-stack state:
 
 ```python
 network.hasIpv6Prefix()
@@ -78,8 +77,6 @@ interface.getIpv6Address()
 ```
 
 ## Per-Network Control
-
-The following API is the target shape for follow-up topology integration.
 
 With global IPv6 enabled, local AS networks and IX peering LANs use automatic
 IPv6 prefixes by default.
@@ -98,8 +95,6 @@ base.createInternetExchange(200, ipv6Prefix="2000:8:0:200::/64")
 ```
 
 ## Per-Interface Control
-
-The following API is the target shape for follow-up topology integration.
 
 `joinNetwork()` also accepts an IPv6 address intent. The default is `"auto"`.
 Use `None` for an IPv4-only attachment on a dual-stack network, or provide an

--- a/seedemu/core/AutonomousSystem.py
+++ b/seedemu/core/AutonomousSystem.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from .Graphable import Graphable
 from .Printable import Printable
 from .Network import Network
+from .Ipv6Addressing import Ipv6Addressing
+from .Addressing import normalizeAddressList, normalizePrefix
 from .AddressAssignmentConstraint import AddressAssignmentConstraint
 from .enums import NetworkType, NodeRole
 from .Node import Node, Router
@@ -10,7 +12,7 @@ from .Emulator import Emulator
 from .Configurable import Configurable
 from .Customizable import Customizable
 from .Node import promote_to_real_world_router
-from ipaddress import IPv4Network
+from ipaddress import IPv4Network, IPv6Network
 from typing import Dict, List
 import requests
 
@@ -25,12 +27,13 @@ class AutonomousSystem(Printable, Graphable, Configurable, Customizable):
 
     __asn: int
     __subnets: List[IPv4Network]
+    __ipv6_addressing: Ipv6Addressing
     __routers: Dict[str, Node]
     __hosts: Dict[str, Node]
     __nets: Dict[str, Network]
     __name_servers: List[str]
 
-    def __init__(self, asn: int, subnetTemplate: str = "10.{}.0.0/16"):
+    def __init__(self, asn: int, subnetTemplate: str = "10.{}.0.0/16", ipv6Addressing: Ipv6Addressing = None):
         """!
         @brief AutonomousSystem constructor.
 
@@ -42,8 +45,27 @@ class AutonomousSystem(Printable, Graphable, Configurable, Customizable):
         self.__routers = {}
         self.__nets = {}
         self.__asn = asn
+        self.__ipv6_addressing = ipv6Addressing
         self.__subnets = None if asn > 255 else list(IPv4Network(subnetTemplate.format(asn)).subnets(new_prefix = 24))
         self.__name_servers = []
+
+    def setIpv6Addressing(self, ipv6Addressing: Ipv6Addressing) -> AutonomousSystem:
+        """!
+        @brief Set optional IPv6 addressing allocator for this AS.
+
+        @param ipv6Addressing IPv6 addressing allocator.
+
+        @returns self, for chaining API calls.
+        """
+        self.__ipv6_addressing = ipv6Addressing
+        if self.__ipv6_addressing is not None:
+            for net in self.__nets.values():
+                if net.hasIpv6Prefix() and net.getIpv6PrefixIntent() != "auto":
+                    self.__ipv6_addressing.reserveAsNetworkPrefix(self.__asn, net.getIpv6Prefix())
+            for net in self.__nets.values():
+                if net.getIpv6PrefixIntent() == "auto" and not net.hasIpv6Prefix():
+                    net.setIpv6Prefix(self.__ipv6_addressing.nextAsNetworkPrefix(self.__asn))
+        return self
 
 
 
@@ -58,7 +80,7 @@ class AutonomousSystem(Printable, Graphable, Configurable, Customizable):
 
         @returns self, for chaining API calls.
         """
-        self.__name_servers = servers
+        self.__name_servers = normalizeAddressList(servers)
 
         return self
 
@@ -168,7 +190,7 @@ class AutonomousSystem(Printable, Graphable, Configurable, Customizable):
         """
         return self.__asn
 
-    def createNetwork(self, name: str, prefix: str = "auto", direct: bool = True, aac: AddressAssignmentConstraint = None) -> Network:
+    def createNetwork(self, name: str, prefix: str = "auto", direct: bool = True, aac: AddressAssignmentConstraint = None, ipv6Prefix: str = "auto") -> Network:
         """!
         @brief Create a new network.
 
@@ -187,8 +209,17 @@ class AutonomousSystem(Printable, Graphable, Configurable, Customizable):
         assert prefix != "auto" or self.__asn <= 255, "can't use auto: asn > 255"
 
         network = IPv4Network(prefix) if prefix != "auto" else self.__subnets.pop(0)
+        ipv6_network = None
+        if ipv6Prefix is not None:
+            if ipv6Prefix == "auto":
+                ipv6_network = self.__ipv6_addressing.nextAsNetworkPrefix(self.__asn) if self.__ipv6_addressing is not None else None
+            else:
+                ipv6_network = IPv6Network(normalizePrefix(ipv6Prefix))
+                if self.__ipv6_addressing is not None:
+                    self.__ipv6_addressing.reserveAsNetworkPrefix(self.__asn, ipv6_network)
         assert name not in self.__nets, 'Network with name {} already exist.'.format(name)
-        self.__nets[name] = Network(name, NetworkType.Local, network, aac, direct)
+        ipv6_intent = ipv6Prefix if ipv6Prefix in ("auto", None) else "explicit"
+        self.__nets[name] = Network(name, NetworkType.Local, network, aac, direct, ipv6_network, ipv6_intent)
 
         return self.__nets[name]
 

--- a/seedemu/core/InternetExchange.py
+++ b/seedemu/core/InternetExchange.py
@@ -5,7 +5,8 @@ from .Network import Network
 from .AddressAssignmentConstraint import AddressAssignmentConstraint
 from .Emulator import Emulator
 from .Configurable import Configurable
-from ipaddress import IPv4Network
+from .Addressing import normalizePrefix
+from ipaddress import IPv4Network, IPv6Network
 
 class InternetExchange(Printable, Configurable):
     """!
@@ -19,7 +20,7 @@ class InternetExchange(Printable, Configurable):
     __rs: Node
     __name: str
 
-    def __init__(self, id: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs = True, rsAddress = None):
+    def __init__(self, id: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs = True, rsAddress = None, ipv6Prefix = None, rsIpv6Address = "auto", ipv6PrefixIntent = None):
         """!
         @brief InternetExchange constructor.
 
@@ -36,16 +37,26 @@ class InternetExchange(Printable, Configurable):
 
         assert prefix != "auto" or self.__id <= 255, "can't use auto: id > 255"
         network = IPv4Network(prefix) if prefix != "auto" else IPv4Network("10.{}.0.0/24".format(self.__id))
+        ipv6_network = None
+        if ipv6Prefix is not None:
+            ipv6_network = ipv6Prefix if isinstance(ipv6Prefix, IPv6Network) else IPv6Network(normalizePrefix(ipv6Prefix))
 
         self.__name = 'ix{}'.format(str(self.__id))
-        self.__net = Network(self.__name, NetworkType.InternetExchange, network, aac, False)
+        if ipv6PrefixIntent is not None:
+            ipv6_intent = ipv6PrefixIntent
+        elif ipv6Prefix is None:
+            ipv6_intent = None
+        else:
+            ipv6_intent = "explicit"
+
+        self.__net = Network(self.__name, NetworkType.InternetExchange, network, aac, False, ipv6_network, ipv6_intent)
 
         if create_rs:
             self.__rs = Router(self.__name, NodeRole.RouteServer, self.__id) 
             if rsAddress == None: 
-                self.__rs.joinNetwork(self.__name)
+                self.__rs.joinNetwork(self.__name, ipv6Address=rsIpv6Address)
             else:
-                self.__rs.joinNetwork(self.__name, rsAddress)
+                self.__rs.joinNetwork(self.__name, rsAddress, rsIpv6Address)
         else:
             self.__rs = None
 
@@ -97,5 +108,8 @@ class InternetExchange(Printable, Configurable):
         indent += 4
         out += ' ' * indent
         out += 'Peering LAN Prefix: {}\n'.format(self.__net.getPrefix())
+        if self.__net.hasIpv6Prefix():
+            out += ' ' * indent
+            out += 'Peering LAN IPv6 Prefix: {}\n'.format(self.__net.getIpv6Prefix())
 
         return out

--- a/seedemu/core/Network.py
+++ b/seedemu/core/Network.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from ipaddress import IPv4Network, IPv4Address
+from ipaddress import IPv4Network, IPv4Address, IPv6Network, IPv6Address
 from .RemoteAccessProvider import RemoteAccessProvider
 from .ExternalConnectivityProvider import ExternalConnectivityProvider
 from .Printable import Printable
@@ -7,7 +7,7 @@ from .enums import NetworkType, NodeRole
 from .Registry import Registrable
 from .AddressAssignmentConstraint import AddressAssignmentConstraint, Assigner
 from .Visualization import Vertex
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Set
 
 class Network(Printable, Registrable, Vertex):
     """!
@@ -17,10 +17,15 @@ class Network(Printable, Registrable, Vertex):
     """
     __type: NetworkType
     __prefix: IPv4Network
+    __ipv6_prefix: IPv6Network
+    __ipv6_prefix_intent: str
     __name: str
     __scope: str
     __aac: AddressAssignmentConstraint
     __assigners: Dict[NodeRole, Assigner]
+    __ipv6_assigners: Dict[NodeRole, Assigner]
+    __ipv6_ix_assignments: Dict[int, int]
+    __ipv6_ix_offsets: Set[int]
 
     __connected_nodes: List['Node']
 
@@ -36,7 +41,7 @@ class Network(Printable, Registrable, Vertex):
     __rap: RemoteAccessProvider
     __ecp: ExternalConnectivityProvider
 
-    def __init__(self, name: str, type: NetworkType, prefix: IPv4Network, aac: AddressAssignmentConstraint = None, direct: bool = False):
+    def __init__(self, name: str, type: NetworkType, prefix: IPv4Network, aac: AddressAssignmentConstraint = None, direct: bool = False, ipv6Prefix: IPv6Network = None, ipv6PrefixIntent: str = None):
         """!
         @brief Network constructor.
 
@@ -54,8 +59,13 @@ class Network(Printable, Registrable, Vertex):
         self.__name = name
         self.__type = type
         self.__prefix = prefix
+        self.__ipv6_prefix = ipv6Prefix
+        self.__ipv6_prefix_intent = ipv6PrefixIntent
         self.__aac = aac if aac != None else AddressAssignmentConstraint()
         self.__assigners = {}
+        self.__ipv6_assigners = {}
+        self.__ipv6_ix_assignments = {}
+        self.__ipv6_ix_offsets = set()
 
         self.__connected_nodes = []
 
@@ -66,6 +76,11 @@ class Network(Printable, Registrable, Vertex):
         self.__assigners[ NodeRole.OpenVpnRouter ] = arouter
         self.__assigners[ NodeRole.Host ] = ahost
         self.__assigners[ NodeRole.ControlService ] = ahost
+        self.__ipv6_assigners[ NodeRole.BorderRouter ] = self.__aac.getOffsetAssigner(NodeRole.Router)
+        self.__ipv6_assigners[ NodeRole.Router ] = self.__ipv6_assigners[ NodeRole.BorderRouter ]
+        self.__ipv6_assigners[ NodeRole.OpenVpnRouter ] = self.__ipv6_assigners[ NodeRole.BorderRouter ]
+        self.__ipv6_assigners[ NodeRole.Host ] = self.__aac.getOffsetAssigner(NodeRole.Host)
+        self.__ipv6_assigners[ NodeRole.ControlService ] = self.__ipv6_assigners[ NodeRole.Host ]
 
         self.__d_latency = 0
         self.__d_bandwidth = 0
@@ -188,6 +203,40 @@ class Network(Printable, Registrable, Vertex):
         """
         return self.__prefix
 
+    def hasIpv6Prefix(self) -> bool:
+        """!
+        @brief Check if this network has an IPv6 prefix.
+
+        @returns true if an IPv6 prefix is configured.
+        """
+        return self.__ipv6_prefix is not None
+
+    def getIpv6Prefix(self) -> IPv6Network:
+        """!
+        @brief Get IPv6 prefix of this network.
+
+        @returns IPv6 prefix, or None when IPv6 is disabled.
+        """
+        return self.__ipv6_prefix
+
+    def setIpv6Prefix(self, prefix: IPv6Network) -> Network:
+        """!
+        @brief Set IPv6 prefix of this network.
+
+        @param prefix IPv6 prefix.
+        @returns self, for chaining API calls.
+        """
+        self.__ipv6_prefix = prefix
+        return self
+
+    def getIpv6PrefixIntent(self) -> str:
+        """!
+        @brief Get IPv6 prefix intent used by the Base layer.
+
+        @returns auto, explicit, or None.
+        """
+        return self.__ipv6_prefix_intent
+
     def setHostIpRange(self, hostStart:int , hostEnd: int, hostStep: int):
         """!
         @brief Set IP Range for host nodes
@@ -199,6 +248,8 @@ class Network(Printable, Registrable, Vertex):
 
         self.__aac.setHostIpRange(hostStart, hostEnd, hostStep)
         self.__assigners[NodeRole.Host] = self.__aac.getOffsetAssigner(NodeRole.Host)
+        self.__ipv6_assigners[NodeRole.Host] = self.__aac.getOffsetAssigner(NodeRole.Host)
+        self.__ipv6_assigners[NodeRole.ControlService] = self.__ipv6_assigners[NodeRole.Host]
 
         return self
 
@@ -226,6 +277,9 @@ class Network(Printable, Registrable, Vertex):
         self.__aac.setRouterIpRange(routerStart, routerEnd, routerStep)
         self.__assigners[NodeRole.Router] = self.__aac.getOffsetAssigner(NodeRole.Router)
         self.__assigners[NodeRole.OpenVpnRouter] = self.__aac.getOffsetAssigner(NodeRole.OpenVpnRouter)
+        self.__ipv6_assigners[NodeRole.Router] = self.__aac.getOffsetAssigner(NodeRole.Router)
+        self.__ipv6_assigners[NodeRole.BorderRouter] = self.__ipv6_assigners[NodeRole.Router]
+        self.__ipv6_assigners[NodeRole.OpenVpnRouter] = self.__ipv6_assigners[NodeRole.Router]
         return self
 
     def getDhcpIpRange(self) -> list:
@@ -242,10 +296,47 @@ class Network(Printable, Registrable, Vertex):
         @param asn optional. If interface type is InternetExchange, the asn for
         IP address mapping.
         """
-        assert not (nodeRole == nodeRole.Host and self.__type == NetworkType.InternetExchange), 'trying to assign IX network to non-router node'
+        assert not (nodeRole == NodeRole.Host and self.__type == NetworkType.InternetExchange), 'trying to assign IX network to non-router node'
 
         if self.__type == NetworkType.InternetExchange: return self.__prefix[self.__aac.mapIxAddress(asn)]
         return self.__prefix[self.__assigners[nodeRole].next()]
+
+    def assignIpv6(self, nodeRole: NodeRole, asn: int = -1) -> IPv6Address:
+        """!
+        @brief Assign IPv6 for interface.
+
+        @param nodeRole role of the node getting this assignment.
+        @param asn optional. If interface type is InternetExchange, the asn for
+        IP address mapping.
+        """
+        assert self.__ipv6_prefix is not None, 'IPv6 is not enabled on network {}'.format(self.__name)
+        assert not (nodeRole == NodeRole.Host and self.__type == NetworkType.InternetExchange), 'trying to assign IX network to non-router node'
+
+        if self.__type == NetworkType.InternetExchange:
+            return self.__ipv6_prefix[self.__mapIxIpv6Offset(asn)]
+        return self.__ipv6_prefix[self.__ipv6_assigners[nodeRole].next()]
+
+    def __mapIxIpv6Offset(self, asn: int) -> int:
+        """Map an IX participant ASN into IPv6 host bits with collision handling."""
+        assert self.__ipv6_prefix is not None, 'IPv6 is not enabled on network {}'.format(self.__name)
+        if asn in self.__ipv6_ix_assignments:
+            return self.__ipv6_ix_assignments[asn]
+
+        limit = self.__ipv6_prefix.num_addresses
+        assert limit > 2, 'IPv6 IX prefix {} is too small'.format(self.__ipv6_prefix)
+        preferred = int(asn)
+        if preferred <= 1 or preferred >= limit:
+            preferred = (abs(preferred) % (limit - 2)) + 2
+        offset = preferred
+        while offset in self.__ipv6_ix_offsets or offset <= 1 or offset >= limit:
+            offset += 1
+            if offset >= limit:
+                offset = 2
+            assert offset != preferred, 'IPv6 IX address allocation exhausted for {}'.format(self.__name)
+
+        self.__ipv6_ix_assignments[asn] = offset
+        self.__ipv6_ix_offsets.add(offset)
+        return offset
 
     def associate(self, node: 'Node'):
         """!
@@ -330,6 +421,26 @@ class Network(Printable, Registrable, Vertex):
 
         return None
 
+    def getDefaultRouterIpv6(self) -> IPv6Address:
+        """!
+        @brief Get default IPv6 router for this network.
+
+        @returns default IPv6 router.
+        """
+        for __node in self.getAssociations():
+            if __node.getRole() == NodeRole.BorderRouter:
+                for __interface in __node.getInterfaces():
+                    if __interface.getNet() == self:
+                        return __interface.getIpv6Address()
+
+        for __node in self.getAssociations():
+            if __node.getRole() == NodeRole.Router:
+                for __interface in __node.getInterfaces():
+                    if __interface.getNet() == self:
+                        return __interface.getIpv6Address()
+
+        return None
+
     def hasDHCPService(self) -> bool:
         """!
         @brief Check if this network has DHCP service.
@@ -350,6 +461,9 @@ class Network(Printable, Registrable, Vertex):
         indent += 4
         out += ' ' * indent
         out += 'Prefix: {}\n'.format(self.__prefix)
+        if self.__ipv6_prefix is not None:
+            out += ' ' * indent
+            out += 'IPv6 Prefix: {}\n'.format(self.__ipv6_prefix)
         out += self.__aac.print(indent)
 
         if self.__rap != None:

--- a/seedemu/core/Node.py
+++ b/seedemu/core/Node.py
@@ -12,11 +12,12 @@ from .Volume import BaseVolume
 from .Configurable import Configurable
 from .enums import NetworkType
 from .Visualization import Vertex
-from ipaddress import IPv4Address, IPv4Interface
+from ipaddress import IPv4Address, IPv4Interface, IPv6Address
 from typing import List, Dict, Set, Tuple, Optional
 from string import ascii_letters
 from random import choice
 from .BaseSystem import BaseSystem
+from .Addressing import normalizeAddressList
 
 DEFAULT_SOFTWARE: List[str] = ['zsh', 'curl', 'nano', 'vim-nox', 'mtr-tiny', 'iproute2', 'iputils-ping', 'tcpdump', 'termshark', 'dnsutils', 'jq', 'ipcalc', 'netcat-openbsd']
 
@@ -107,6 +108,7 @@ class Interface(Printable):
 
     __network: Network
     __address: IPv4Address
+    __ipv6_address: IPv6Address
 
     __latency: int       # in ms
     __bandwidth: int     # in bps
@@ -119,6 +121,7 @@ class Interface(Printable):
         @param net network to connect to.
         """
         self.__address = None
+        self.__ipv6_address = None
         self.__network = net
         (l, b, d) = net.getDefaultLinkProperties()
         self.__latency = l
@@ -182,6 +185,34 @@ class Interface(Printable):
         """
         return self.__address
 
+    def setIpv6Address(self, address: IPv6Address) -> Interface:
+        """!
+        @brief Set IPv6 address of this interface.
+
+        @param address address.
+
+        @returns self, for chaining API calls.
+        """
+        self.__ipv6_address = address
+
+        return self
+
+    def getIpv6Address(self) -> IPv6Address:
+        """!
+        @brief Get IPv6 address of this interface.
+
+        @returns address, or None when IPv6 is disabled.
+        """
+        return self.__ipv6_address
+
+    def hasIpv6Address(self) -> bool:
+        """!
+        @brief Check if this interface has an IPv6 address.
+
+        @returns true if an IPv6 address is configured.
+        """
+        return self.__ipv6_address is not None
+
     def print(self, indent: int) -> str:
         out = ' ' * indent
         out += 'Interface:\n'
@@ -191,6 +222,9 @@ class Interface(Printable):
         out += 'Connected to: {}\n'.format(self.__network.getName())
         out += ' ' * indent
         out += 'Address: {}\n'.format(self.__address)
+        if self.__ipv6_address is not None:
+            out += ' ' * indent
+            out += 'IPv6 Address: {}\n'.format(self.__ipv6_address)
         out += ' ' * indent
         out += 'Link Properties: {}\n'.format(self.__address)
 
@@ -229,7 +263,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
     __privileged: bool
 
     __configured: bool
-    __pending_nets: List[Tuple[str, str]]
+    __pending_nets: List[Tuple[str, str, str]]
 
     # Dict of (peername, peerasn) -> (localaddr, netname, netProperties) -- netProperties = (latency, bandwidth, packetDrop, MTU)
     __xcs: Dict[Tuple[str, int], Tuple[IPv4Interface, str, Tuple[int,int,float,int]]]
@@ -316,23 +350,28 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         self.__configured = True
         reg = emulator.getRegistry()
 
-        for (netname, address) in self.__pending_nets:
+        for pending in self.__pending_nets:
+            if len(pending) == 2:
+                netname, address = pending
+                ipv6Address = "auto"
+            else:
+                netname, address, ipv6Address = pending
 
             hit = False
 
             if reg.has(self.__scope, "net", netname):
                 hit = True
-                self.__joinNetwork(reg.get(self.__scope, "net", netname), address)
+                self.__joinNetwork(reg.get(self.__scope, "net", netname), address, ipv6Address)
 
             if not hit and reg.has("ix", "net", netname):
                 hit = True
-                self.__joinNetwork(reg.get("ix", "net", netname), address)
+                self.__joinNetwork(reg.get("ix", "net", netname), address, ipv6Address)
                 if issubclass(self.__class__, Router):
                     self.setBorderRouter(True)
 
             if not hit and reg.has("seedemu", "net", netname):
                 hit = True
-                self.__joinNetwork(reg.get("seedemu", "net", netname), address)
+                self.__joinNetwork(reg.get("seedemu", "net", netname), address, ipv6Address)
 
             assert hit, 'no network matched for name {}'.format(netname)
 
@@ -383,7 +422,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         """
         assert not self.__asn == 0, 'This API is only available on a real physical node.'
 
-        self.__name_servers = servers
+        self.__name_servers = normalizeAddressList(servers)
 
         return self
 
@@ -507,7 +546,7 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         """
         return self.__base_system
 
-    def __joinNetwork(self, net: Network, address: str = "auto"):
+    def __joinNetwork(self, net: Network, address: str = "auto", ipv6Address: str = "auto"):
         """!
         @brief Connect the node to a network.
         @param net network to connect.
@@ -537,16 +576,26 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
             '''.format(iface=net.getName()))
             self.appendStartCommand('chmod +x dhclient.sh; ./dhclient.sh')
 
-        else: _addr = IPv4Address(address)
+        else: _addr = IPv4Address(normalizeAddressList([address])[0])
+
+        if ipv6Address == None:
+            _ipv6_addr = None
+        elif ipv6Address == "auto":
+            _ipv6_addr = net.assignIpv6(self.__role, self.__asn) if net.hasIpv6Prefix() else None
+        else:
+            assert net.hasIpv6Prefix(), "can't assign IPv6 address on network {} without an IPv6 prefix".format(net.getName())
+            _ipv6_addr = IPv6Address(normalizeAddressList([ipv6Address])[0])
+            assert _ipv6_addr in net.getIpv6Prefix(), "IPv6 address {} is not in network {}".format(_ipv6_addr, net.getIpv6Prefix())
 
         _iface = Interface(net)
         _iface.setAddress(_addr)
+        _iface.setIpv6Address(_ipv6_addr)
 
         self.__interfaces.append(_iface)
 
         net.associate(self)
 
-    def joinNetwork(self, netname: str, address: str = "auto") -> Node:
+    def joinNetwork(self, netname: str, address: str = "auto", ipv6Address: str = "auto") -> Node:
         """!
         @brief Connect the node to a network.
         @param netname name of the network.
@@ -559,11 +608,11 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         assert not self.__asn == 0, 'This API is only available on a real physical node.'
         assert not self.__configured, 'Node already configured.'
 
-        self.__pending_nets.append((netname, address))
+        self.__pending_nets.append((netname, address, ipv6Address))
 
         return self
 
-    def updateNetwork(self, netname:str, address: str= "auto") -> Node:
+    def updateNetwork(self, netname:str, address: str= "auto", ipv6Address: str = "auto") -> Node:
         """!
         @brief Update connection of the node to a network.
         @param netname name of the network.
@@ -575,11 +624,12 @@ class Node(Printable, Registrable, Configurable, Vertex, Customizable):
         """
         assert not self.__asn == 0, 'This API is only available on a real physical node.'
 
-        for pending_netname, pending_address in self.__pending_nets:
+        for pending in list(self.__pending_nets):
+            pending_netname = pending[0]
             if pending_netname == netname:
-                self.__pending_nets.remove((pending_netname, pending_address))
+                self.__pending_nets.remove(pending)
 
-        self.__pending_nets.append((netname, address))
+        self.__pending_nets.append((netname, address, ipv6Address))
 
         return self
 
@@ -1134,6 +1184,7 @@ class Router(Node):
     """
 
     __loopback_address: str
+    __loopback_ipv6_address: str
     __is_border_router: bool
     __routing_backend: str
     __bgp_announcements: List[str]
@@ -1143,6 +1194,7 @@ class Router(Node):
     def __init__(self, name: str, role: NodeRole, asn: int, scope: str = None, routingBackend: str = "bird"):
         self.__is_border_router = False
         self.__loopback_address = None
+        self.__loopback_ipv6_address = None
         self.__routing_backend = "bird"
         self.__bgp_announcements = []
         self.__extensions = {}
@@ -1245,6 +1297,22 @@ class Router(Node):
         @returns address.
         """
         return self.__loopback_address
+
+    def setLoopbackIpv6Address(self, address: str):
+        """!
+        @brief Set IPv6 loopback address.
+
+        @param address address.
+        """
+        self.__loopback_ipv6_address = address
+
+    def getLoopbackIpv6Address(self) -> str:
+        """!
+        @brief Get IPv6 loopback address.
+
+        @returns address.
+        """
+        return self.__loopback_ipv6_address
 
     def addProtocol(self, protocol: str, name: str, body: str) -> Router:
         """!

--- a/seedemu/layers/Base.py
+++ b/seedemu/layers/Base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from seedemu.core import AutonomousSystem, InternetExchange, AddressAssignmentConstraint, Node, Graphable, Emulator, Layer
+from seedemu.core import AutonomousSystem, InternetExchange, AddressAssignmentConstraint, DEFAULT_IPV6_ROOT_PREFIX, Ipv6Addressing, Node, Graphable, Emulator, Layer, normalizeAddressList, normalizePrefix
+from ipaddress import IPv6Network
 from typing import Dict, List
 from seedemu.options.Sysctl import SysctlOpts
 BaseFileTemplates: Dict[str, str] = {}
@@ -41,6 +42,7 @@ class Base(Layer, Graphable):
 
     __ases: Dict[int, AutonomousSystem]
     __ixes: Dict[int, InternetExchange]
+    __ipv6_addressing: Ipv6Addressing
 
     __name_servers: List[str]
 
@@ -49,13 +51,14 @@ class Base(Layer, Graphable):
         opt_keys = [ o.fullname() for o in SysctlOpts().components_recursive()]
         return [OptionRegistry().getOption(o) for o in opt_keys]
 
-    def __init__(self):
+    def __init__(self, enableIpv6: bool = False, ipv6RootPrefix: str = DEFAULT_IPV6_ROOT_PREFIX):
         """!
         @brief Base layer constructor.
         """
         super().__init__()
         self.__ases = {}
         self.__ixes = {}
+        self.__ipv6_addressing = Ipv6Addressing(ipv6RootPrefix) if enableIpv6 else None
         self.__name_servers = []
 
     def getName(self) -> str:
@@ -126,7 +129,7 @@ class Base(Layer, Graphable):
 
         @returns self, for chaining API calls.
         """
-        self.__name_servers = servers
+        self.__name_servers = normalizeAddressList(servers)
 
         return self
 
@@ -138,6 +141,65 @@ class Base(Layer, Graphable):
         """
         return self.__name_servers
 
+    def enableIpv6(self, rootPrefix: str = DEFAULT_IPV6_ROOT_PREFIX) -> Base:
+        """!
+        @brief Enable optional IPv6 addressing for new ASes and IXes.
+
+        @param rootPrefix root IPv6 prefix. Defaults to 2000::/12.
+
+        @returns self, for chaining API calls.
+        """
+        if self.__ipv6_addressing is not None:
+            assert self.__ipv6_addressing.getRootPrefix() == IPv6Network(normalizePrefix(rootPrefix)), (
+                "IPv6 is already enabled with root prefix {}".format(self.__ipv6_addressing.getRootPrefix())
+            )
+            return self
+
+        self.__ipv6_addressing = Ipv6Addressing(rootPrefix)
+        for ix in self.__ixes.values():
+            net = ix.getPeeringLan()
+            if net.hasIpv6Prefix() and net.getIpv6PrefixIntent() != "auto":
+                self.__ipv6_addressing.claimPrefix(net.getIpv6Prefix())
+        for asobj in self.__ases.values():
+            asobj.setIpv6Addressing(self.__ipv6_addressing)
+        for ixid, ix in self.__ixes.items():
+            net = ix.getPeeringLan()
+            if net.getIpv6PrefixIntent() == "auto" and not net.hasIpv6Prefix():
+                net.setIpv6Prefix(self.__ipv6_addressing.assignIxPrefix(ixid))
+        return self
+
+    def isIpv6Enabled(self) -> bool:
+        """!
+        @brief Check if optional IPv6 addressing is enabled.
+
+        @returns true if IPv6 is enabled.
+        """
+        return self.__ipv6_addressing is not None
+
+    def getIpv6Addressing(self) -> Ipv6Addressing:
+        """!
+        @brief Get the optional IPv6 addressing allocator.
+
+        @returns allocator, or None when IPv6 is disabled.
+        """
+        return self.__ipv6_addressing
+
+    def getIpv6RootPrefix(self):
+        """!
+        @brief Get the IPv6 root prefix, if optional IPv6 is enabled.
+
+        @returns IPv6 root prefix, or None when IPv6 is disabled.
+        """
+        return self.__ipv6_addressing.getRootPrefix() if self.__ipv6_addressing is not None else None
+
+    def getIpv6ReservedPrefixes(self) -> List:
+        """!
+        @brief Get IPv6 prefixes reserved by the automatic allocator.
+
+        @returns list of IPv6 prefixes, or an empty list when IPv6 is disabled.
+        """
+        return self.__ipv6_addressing.getReservedPrefixes() if self.__ipv6_addressing is not None else []
+
     def createAutonomousSystem(self, asn: int) -> AutonomousSystem:
         """!
         @brief Create a new AutonomousSystem.
@@ -147,7 +209,7 @@ class Base(Layer, Graphable):
         @throws AssertionError if asn exists.
         """
         assert asn not in self.__ases, "as{} already exist.".format(asn)
-        self.__ases[asn] = AutonomousSystem(asn)
+        self.__ases[asn] = AutonomousSystem(asn, ipv6Addressing=self.__ipv6_addressing)
         return self.__ases[asn]
 
     def getAutonomousSystem(self, asn: int) -> AutonomousSystem:
@@ -168,9 +230,11 @@ class Base(Layer, Graphable):
         @param asObject AS object.
         """
         asn = asObject.getAsn()
+        if self.__ipv6_addressing is not None:
+            asObject.setIpv6Addressing(self.__ipv6_addressing)
         self.__ases[asn] = asObject
 
-    def createInternetExchange(self, asn: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs=True, rsAddress = None) -> InternetExchange:
+    def createInternetExchange(self, asn: int, prefix: str = "auto", aac: AddressAssignmentConstraint = None, create_rs=True, rsAddress = None, ipv6Prefix = "auto", rsIpv6Address = "auto") -> InternetExchange:
         """!
         @brief Create a new InternetExchange.
 
@@ -183,7 +247,19 @@ class Base(Layer, Graphable):
         @throws AssertionError if IX exists.
         """
         assert asn not in self.__ixes, "ix{} already exist.".format(asn)
-        self.__ixes[asn] = InternetExchange(asn, prefix, aac, create_rs, rsAddress)
+        ix_ipv6_prefix = None
+        if ipv6Prefix is not None:
+            if ipv6Prefix == "auto":
+                ix_ipv6_prefix = self.__ipv6_addressing.assignIxPrefix(asn) if self.__ipv6_addressing is not None else None
+                ix_ipv6_intent = "auto"
+            else:
+                ix_ipv6_prefix = normalizePrefix(ipv6Prefix)
+                ix_ipv6_intent = "explicit"
+                if self.__ipv6_addressing is not None:
+                    self.__ipv6_addressing.claimPrefix(ix_ipv6_prefix)
+        else:
+            ix_ipv6_intent = None
+        self.__ixes[asn] = InternetExchange(asn, prefix, aac, create_rs, rsAddress, ix_ipv6_prefix, rsIpv6Address, ix_ipv6_intent)
         return self.__ixes[asn]
 
     def getInternetExchange(self, asn: int) -> InternetExchange:
@@ -204,6 +280,12 @@ class Base(Layer, Graphable):
         @param ixObject IX object.
         """
         asn = ixObject.getId()
+        if self.__ipv6_addressing is not None:
+            net = ixObject.getPeeringLan()
+            if net.hasIpv6Prefix() and net.getIpv6PrefixIntent() != "auto":
+                self.__ipv6_addressing.claimPrefix(net.getIpv6Prefix())
+            if net.getIpv6PrefixIntent() == "auto" and not net.hasIpv6Prefix():
+                net.setIpv6Prefix(self.__ipv6_addressing.assignIxPrefix(asn))
         self.__ixes[asn] = ixObject
 
     def getAsns(self) -> List[int]:

--- a/test_ipv6_repository_readiness.py
+++ b/test_ipv6_repository_readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import socket
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent
 CORE = ROOT / "seedemu" / "core"
+LAYERS = ROOT / "seedemu" / "layers"
 
 
 def _load_core_module(name: str, filename: str):
@@ -36,6 +38,65 @@ def _load_core_module(name: str, filename: str):
     spec = importlib.util.spec_from_file_location(module_name, CORE / filename)
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _ensure_core_exports_for_layer_imports():
+    """Expose core symbols needed by direct layer module loading."""
+
+    core = sys.modules["seedemu.core"]
+    exports = {
+        "AddressAssignmentConstraint": ("AddressAssignmentConstraint", "AddressAssignmentConstraint"),
+        "AutonomousSystem": ("AutonomousSystem", "AutonomousSystem"),
+        "DEFAULT_IPV6_ROOT_PREFIX": ("Ipv6Addressing", "DEFAULT_IPV6_ROOT_PREFIX"),
+        "Emulator": ("Emulator", "Emulator"),
+        "Graphable": ("Graphable", "Graphable"),
+        "InternetExchange": ("InternetExchange", "InternetExchange"),
+        "Ipv6Addressing": ("Ipv6Addressing", "Ipv6Addressing"),
+        "Layer": ("Layer", "Layer"),
+        "Node": ("Node", "Node"),
+        "normalizeAddressList": ("Addressing", "normalizeAddressList"),
+        "normalizePrefix": ("Addressing", "normalizePrefix"),
+    }
+    for export_name, (module_name, attr_name) in exports.items():
+        module = _load_core_module(module_name, "{}.py".format(module_name))
+        setattr(core, export_name, getattr(module, attr_name))
+
+
+def _load_layer_module(name: str, filename: str):
+    _ensure_core_exports_for_layer_imports()
+    if "seedemu.options.Sysctl" not in sys.modules:
+        options = types.ModuleType("seedemu.options")
+        options.__path__ = [str(ROOT / "seedemu" / "options")]
+        sys.modules.setdefault("seedemu.options", options)
+        sysctl = types.ModuleType("seedemu.options.Sysctl")
+
+        class SysctlOpts:
+            def components_recursive(self):
+                return []
+
+        sysctl.SysctlOpts = SysctlOpts
+        sys.modules["seedemu.options.Sysctl"] = sysctl
+
+    layers_name = "seedemu.layers"
+    if layers_name not in sys.modules:
+        layers_spec = importlib.util.spec_from_loader(layers_name, loader=None, is_package=True)
+        layers = importlib.util.module_from_spec(layers_spec)
+        layers.__path__ = [str(LAYERS)]
+        sys.modules[layers_name] = layers
+
+    module_name = "{}.{}".format(layers_name, name)
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, LAYERS / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -45,6 +106,14 @@ Ipv6AddressingModule = _load_core_module("Ipv6Addressing", "Ipv6Addressing.py")
 
 AddressFamily = Addressing.AddressFamily
 Ipv6Addressing = Ipv6AddressingModule.Ipv6Addressing
+
+
+def _load_seedemu_class(module_name: str, class_name: str):
+    if module_name == "Base":
+        module = _load_layer_module(module_name, "{}.py".format(module_name))
+        return getattr(module, class_name)
+    module = _load_core_module(module_name, "{}.py".format(module_name))
+    return getattr(module, class_name)
 
 
 def test_endpoint_helpers_preserve_ipv4_and_bracket_ipv6():
@@ -122,3 +191,156 @@ def test_ipv6_allocator_rejects_root_overlap_but_allows_disjoint_user_prefixes()
 
     with pytest.raises(AssertionError):
         allocator.claimPrefix("2000:ffff::/64")
+
+
+def test_topology_ipv6_is_opt_in_and_preserves_ipv4_accessors():
+    Base = _load_seedemu_class("Base", "Base")
+
+    base = Base()
+    as150 = base.createAutonomousSystem(150)
+    net = as150.createNetwork("net0")
+    host = as150.createHost("host").joinNetwork("net0", address="10.150.0.71")
+
+    assert not base.isIpv6Enabled()
+    assert str(net.getPrefix()) == "10.150.0.0/24"
+    assert not net.hasIpv6Prefix()
+
+    class _Registry:
+        def has(self, scope, type, name):
+            return scope == "150" and type == "net" and name == "net0"
+
+        def get(self, scope, type, name):
+            return net
+
+    class _Emulator:
+        def getRegistry(self):
+            return _Registry()
+
+    host.configure(_Emulator())
+    iface = host.getInterfaces()[0]
+
+    assert str(iface.getAddress()) == "10.150.0.71"
+    assert not iface.hasIpv6Address()
+    assert iface.getIpv6Address() is None
+
+
+def test_base_enable_ipv6_backfills_networks_and_interfaces():
+    Base = _load_seedemu_class("Base", "Base")
+
+    base = Base()
+    as150 = base.createAutonomousSystem(150)
+    net = as150.createNetwork("net0")
+    host = as150.createHost("host").joinNetwork("net0")
+
+    base.enableIpv6()
+
+    assert base.isIpv6Enabled()
+    assert str(base.getIpv6RootPrefix()) == "2000::/12"
+    assert str(net.getIpv6Prefix()) == "2000:0:96::/64"
+
+    class _Registry:
+        def has(self, scope, type, name):
+            return scope == "150" and type == "net" and name == "net0"
+
+        def get(self, scope, type, name):
+            return net
+
+    class _Emulator:
+        def getRegistry(self):
+            return _Registry()
+
+    host.configure(_Emulator())
+    iface = host.getInterfaces()[0]
+
+    assert str(iface.getAddress()) == "10.150.0.71"
+    assert str(iface.getIpv6Address()) == "2000:0:96::47"
+
+
+def test_explicit_ipv6_prefix_address_and_opt_out():
+    Base = _load_seedemu_class("Base", "Base")
+
+    base = Base(enableIpv6=True)
+    as151 = base.createAutonomousSystem(151)
+    net = as151.createNetwork("net0", ipv6Prefix=" [2000:0:151::] / 64 ")
+    fixed = as151.createHost("fixed").joinNetwork(
+        "net0",
+        address="10.151.0.10",
+        ipv6Address=" [2000:0:151::10] ",
+    )
+    v4_only = as151.createHost("v4only").joinNetwork(
+        "net0",
+        address="10.151.0.11",
+        ipv6Address=None,
+    )
+
+    assert str(net.getIpv6Prefix()) == "2000:0:151::/64"
+
+    class _Registry:
+        def has(self, scope, type, name):
+            return scope == "151" and type == "net" and name == "net0"
+
+        def get(self, scope, type, name):
+            return net
+
+    class _Emulator:
+        def getRegistry(self):
+            return _Registry()
+
+    fixed.configure(_Emulator())
+    v4_only.configure(_Emulator())
+
+    assert str(fixed.getInterfaces()[0].getAddress()) == "10.151.0.10"
+    assert str(fixed.getInterfaces()[0].getIpv6Address()) == "2000:0:151::10"
+    assert str(v4_only.getInterfaces()[0].getAddress()) == "10.151.0.11"
+    assert not v4_only.getInterfaces()[0].hasIpv6Address()
+
+    with pytest.raises(AssertionError):
+        as151.createHost("bad").joinNetwork("net0", ipv6Address="2000:0:152::1").configure(_Emulator())
+
+
+def test_ix_ipv6_prefix_and_route_server_address_are_explicit():
+    Base = _load_seedemu_class("Base", "Base")
+
+    base = Base(enableIpv6=True)
+    ix = base.createInternetExchange(
+        100,
+        ipv6Prefix="2000:8:0:100::/64",
+        rsIpv6Address="2000:8:0:100::100",
+    )
+    net = ix.getPeeringLan()
+
+    assert str(net.getIpv6Prefix()) == "2000:8:0:100::/64"
+
+    rs = ix.getRouteServerNode()
+
+    class _Registry:
+        def has(self, scope, type, name):
+            return scope == "ix" and type == "net" and name == "ix100"
+
+        def get(self, scope, type, name):
+            return net
+
+    class _Emulator:
+        def getRegistry(self):
+            return _Registry()
+
+    rs.configure(_Emulator())
+    iface = rs.getInterfaces()[0]
+
+    assert str(iface.getAddress()) == "10.100.0.100"
+    assert str(iface.getIpv6Address()) == "2000:8:0:100::100"
+
+
+def test_router_backend_legacy_values_stay_rejected():
+    Router = _load_seedemu_class("Node", "Router")
+    NodeRole = _load_core_module("enums", "enums.py").NodeRole
+
+    router = Router("r1", NodeRole.Router, 150)
+    assert router.getRoutingBackend() == "bird"
+    router.setRoutingBackend("frr")
+    assert router.getRoutingBackend() == "frr"
+
+    with pytest.raises(AssertionError):
+        router.setRoutingBackend("exabgp")
+    with pytest.raises(AssertionError):
+        router.setRoutingBackend("external")


### PR DESCRIPTION
## Summary

This PR is the second staged IPv6 readiness re-landing onto `development2`. It builds on the helper foundation PR and adds optional IPv6 topology state to the core model while preserving IPv4 defaults.

The scope is intentionally limited to model/API state:

- `Base(enableIpv6=True)` and `base.enableIpv6(...)`
- deterministic IPv6 allocator wiring into AS and IX creation
- optional IPv6 prefixes on `Network`
- optional IPv6 addresses on `Interface`
- `joinNetwork(..., ipv6Address=...)` and per-interface opt-out
- explicit IX IPv6 prefix and route-server IPv6 address intent
- documentation updates reflecting that topology state has landed

This PR does **not** add Docker Compose IPv6 output, Routing BIRD/FRR IPv6 rendering, ExaBGP IPv6 runtime behavior, Looking Glass IPv6 runtime behavior, DNS/hosts migration, or A15/A16/A17 examples. Those remain follow-up PRs.

## Compatibility boundary

IPv4 remains the default:

- `Base()` is IPv4-only.
- `Network.getPrefix()` remains IPv4.
- `Interface.getAddress()` remains IPv4.
- Existing `joinNetwork(..., address="auto")` behavior is preserved.
- `Router.setRoutingBackend()` still accepts only `bird|frr`; `exabgp` and `external` are explicitly rejected by tests.

Legacy control-plane paths are not reintroduced:

- no `FrrBgp` layer
- no `routingBackend="exabgp"` or `routingBackend="external"`
- no ExaBGP-as-router renderer path
- no Routing template migration in this PR

## Implementation notes

- `Base` owns optional `Ipv6Addressing` and can enable IPv6 at construction or before render.
- `AutonomousSystem` receives the allocator and assigns `/64` prefixes to local networks when IPv6 is enabled.
- `InternetExchange` stores optional IPv6 peering LAN state and route-server IPv6 attachment intent.
- `Network` stores optional IPv6 prefix state and deterministic IPv6 assignment rules, including IX participant collision handling.
- `Interface` stores IPv6 beside IPv4 without changing IPv4 accessors.
- `Node` accepts `ipv6Address="auto"`, explicit IPv6 literals, and `ipv6Address=None` opt-out.
- Docs now distinguish landed topology state from still-pending compiler/routing/service runtime support.

## Validation

Ran locally:

```bash
git diff --check HEAD~1..HEAD
/tmp/seedemu-ipv6-foundation-venv/bin/python -m pytest -q test_ipv6_repository_readiness.py
python3 -m compileall seedemu/core seedemu/layers/Base.py
```

Results:

- `git diff --check HEAD~1..HEAD`: passed
- `pytest test_ipv6_repository_readiness.py`: `10 passed`
- `compileall seedemu/core seedemu/layers/Base.py`: passed

`compileall` reports the existing `BaseFileTemplates["interface_setup_script"]` invalid-escape warning; this PR leaves that runtime script behavior unchanged.

## Reviewer focus

Please review the model/API boundary carefully: this PR should make IPv6 topology state available without changing generated artifacts or daemon behavior. Docker/runtime and Routing changes should remain out of this PR.
