### PR TITLE
Add IPv6 Docker compiler dual-stack output

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -8,17 +8,21 @@ tests or code review reveal a better path.
 
 Already established in this branch:
 
+- shared endpoint/address helpers in `seedemu.core`;
 - optional IPv6 core state for networks and interfaces;
 - deterministic IPv6 allocation under default `2000::/12`;
 - Docker dual-stack output for IPv6-enabled networks;
+- optional IPv6 service network and custom container / Internet Map attachment
+  support in the Docker compiler;
+- repository readiness design and user manual updates;
+
+Not yet re-landed on `development2`:
+
 - BIRD/FRR IPv6 BGP and OSPFv3 rendering;
 - ExaBGP IPv6 control-plane announcements;
 - Looking Glass IPv6 route-state observation;
-- repository readiness design and user manual updates;
-- shared endpoint/address helpers in `seedemu.core`;
 - baseline dual-stack DNS and `/etc/hosts` behavior;
-- IPv6-aware `Filter` / `Binding` matching;
-- optional IPv6 service network and custom container attachment support.
+- IPv6-aware `Filter` / `Binding` matching.
 
 Before adding more work, verify the baseline still passes:
 

--- a/docs/designs/ipv6-repository-readiness-design.md
+++ b/docs/designs/ipv6-repository-readiness-design.md
@@ -28,11 +28,15 @@ The first PR landed the contract and shared helper foundation:
 - design, user, and agent-facing migration documents.
 
 The core-topology PR adds optional IPv6 model state to `Base`, AS networks, IX
-LANs, node interfaces, and route-server attachments. It intentionally does not
-claim that Docker, Routing, ExaBGP, Looking Glass, DNS, `/etc/hosts`, or
-repository services are already dual-stack on `development2`. Their rows below
-describe the target migration contract and must be treated as implemented only
-after follow-up PRs add code and tests.
+LANs, node interfaces, and route-server attachments.
+
+The Docker-compiler PR adds Compose dual-stack output for networks and
+interfaces that already carry IPv6 state, optional IPv6 service-network
+prefixes, and explicit static IPv6 attachment output for custom containers and
+Internet Map. It intentionally does not claim that Routing, ExaBGP, Looking
+Glass, DNS, `/etc/hosts`, or repository services are already dual-stack on
+`development2`. Their rows below describe the target migration contract and
+must be treated as implemented only after follow-up PRs add code and tests.
 
 ## Address-Family Contract
 
@@ -79,19 +83,20 @@ Landing foundation:
 
 - Optional IPv6 root prefix and deterministic AS/IX `/64` allocation.
 - IPv6 state on `Network` and `Interface`.
-
-Target follow-up foundation:
-
-- IPv6-aware BGP/OSPF intent rendering for BIRD and FRR.
-- IPv6-aware ExaBGP speaker service and Looking Glass route-state queries.
-- Docker Compose dual-stack network/IPAM and service `ipv6_address` output.
-- IPv6-aware `Filter` / `Binding` matching and `Action.NEW` placement.
+- Docker Compose dual-stack network/IPAM and service `ipv6_address` output for
+  explicitly IPv6-enabled model state.
 - Optional IPv6 service network prefix, with per-node `ipv6_address` emitted
   only for service-network attachments that carry IPv6 state.
 - Optional IPv6 address on `attachCustomContainer(...)` and
   `attachInternetMap(...)`; explicit static IPv4/IPv6 attachment addresses are
   normalized before compose fields and metadata labels are emitted, and
   mismatched address-family inputs are rejected.
+
+Target follow-up foundation:
+
+- IPv6-aware BGP/OSPF intent rendering for BIRD and FRR.
+- IPv6-aware ExaBGP speaker service and Looking Glass route-state queries.
+- IPv6-aware `Filter` / `Binding` matching and `Action.NEW` placement.
 
 Deferred core items:
 
@@ -105,14 +110,14 @@ Deferred core items:
 
 | Area | Status | Migration rule |
 | --- | --- | --- |
-| Routing control plane | Supported | Keep protocol intent family-aware; render backend syntax only in `Routing`. |
-| ExaBGP | Supported | Service speaker may use IPv4 or IPv6 shared peer address; static announcement prefixes use shared prefix normalization before rendering. |
-| Looking Glass | Supported | Route-state views separate IPv4/IPv6 output; frontend-to-proxy URLs use shared URL helpers, default to IPv4, and may explicitly select bracketed IPv6 proxy endpoints. |
+| Routing control plane | Pending follow-up | Keep protocol intent family-aware; render backend syntax only in `Routing`. |
+| ExaBGP | Pending follow-up | Service speaker may use IPv4 or IPv6 shared peer address; static announcement prefixes use shared prefix normalization before rendering. |
+| Looking Glass | Pending follow-up | Route-state views separate IPv4/IPv6 output; frontend-to-proxy URLs use shared URL helpers, default to IPv4, and may explicitly select bracketed IPv6 proxy endpoints. |
 | Docker compiler | Supported | Emit IPv6 only for networks/interfaces carrying IPv6 state. |
-| `/etc/hosts` | Baseline dual-stack | Generate IPv4 and IPv6 entries when available; keep service-network Bridge addresses for service-only nodes, and skip IX peering addresses. |
-| DNS authoritative | Baseline dual-stack | Generate A and AAAA for node-backed records; manual A/AAAA and glue record literals use shared normalization, including bracketed IPv6 literals, and reject address-family mismatches such as A-with-IPv6 or AAAA-with-IPv4; authoritative zone inputs and master-IP zone keys are normalized to canonical DNS zone names, and masters may include both address families; reverse DNS keeps IPv4 `in-addr.arpa.` PTR records and adds `ip6.arpa.` PTR records only when interfaces carry IPv6 state. |
-| Domain Registrar | Compatible | Dynamic DNS updates preserve A as the default record type, allow explicit AAAA submissions, and reject submitted IP addresses whose family does not match the selected A/AAAA record type; TLD placement and runtime behavior remain the existing Domain Registrar model. |
-| DNS cache | Compatible | Prefer IPv4 for old resolver behavior; accept IPv6 forwarders/root hints, normalize manual A/AAAA root-hint literals through the shared helper, normalize forward-zone names to canonical DNS zone names, and use shared node-address helpers for forward-zone fallback to authoritative zone servers. |
+| `/etc/hosts` | Pending follow-up | Generate IPv4 and IPv6 entries when available; keep service-network Bridge addresses for service-only nodes, and skip IX peering addresses. |
+| DNS authoritative | Pending follow-up | Generate A and AAAA for node-backed records; manual A/AAAA and glue record literals use shared normalization, including bracketed IPv6 literals, and reject address-family mismatches such as A-with-IPv6 or AAAA-with-IPv4; authoritative zone inputs and master-IP zone keys are normalized to canonical DNS zone names, and masters may include both address families; reverse DNS keeps IPv4 `in-addr.arpa.` PTR records and adds `ip6.arpa.` PTR records only when interfaces carry IPv6 state. |
+| Domain Registrar | Pending follow-up | Dynamic DNS updates preserve A as the default record type, allow explicit AAAA submissions, and reject submitted IP addresses whose family does not match the selected A/AAAA record type; TLD placement and runtime behavior remain the existing Domain Registrar model. |
+| DNS cache | Pending follow-up | Prefer IPv4 for old resolver behavior; accept IPv6 forwarders/root hints, normalize manual A/AAAA root-hint literals through the shared helper, normalize forward-zone names to canonical DNS zone names, and use shared node-address helpers for forward-zone fallback to authoritative zone servers. |
 | Web/CA | Compatible | Existing IPv4 behavior preserved; CA certificate-install filters match IPv4/IPv6 address and prefix selectors through shared node address/prefix helpers; CA IP/network helper parsing uses shared address and prefix normalization; CA domain inputs trim DNS names and normalize padded or bracketed IPv4/IPv6 endpoint literals before ACME directory URLs use shared URL helpers, but Web HTTPS and ACME runtime behavior still need validation before a full support claim. |
 | Cymru IP origin | IPv4-first | Origin ASN TXT mapping remains IPv4-only; accepted IPv4 prefix inputs use shared prefix normalization, and IPv6 prefixes are rejected explicitly rather than partially mapped. |
 | Traffic services | Compatible | Raw receiver targets are unchanged; receiver vnodes can be resolved to IPv4 or IPv6 targets through shared node-address helpers, and generated reachability probes select IPv6 ping for IPv6 literal targets, but each tool still needs runtime validation before a full support claim. |

--- a/docs/user_manual/ipv6.md
+++ b/docs/user_manual/ipv6.md
@@ -3,9 +3,11 @@
 IPv6 support is being added as an optional repository-level capability. The
 current `development2` landing provides shared address-family helpers,
 deterministic IPv6 prefix allocation, optional topology IPv6 state, and the
-migration contract. Docker compiler output, routing, ExaBGP, Looking Glass,
-DNS, and service runtime support are staged for follow-up PRs and should not be
-treated as fully available until their code, examples, and tests land.
+migration contract. The Docker compiler now emits dual-stack Compose output
+only for explicitly IPv6-enabled networks and attachments. Routing, ExaBGP,
+Looking Glass, DNS, and service runtime support are staged for follow-up PRs
+and should not be treated as fully available until their code, examples, and
+tests land.
 
 Existing emulations remain IPv4-only by default. New IPv6 work must preserve
 the existing IPv4 APIs and add IPv6 state beside them instead of changing old
@@ -142,9 +144,6 @@ for the design boundary.
 
 ## Docker Compiler
 
-The compiler behavior described here is the target migration contract. It is
-not enabled by this helper-foundation PR alone.
-
 The Docker compiler emits IPv6 runtime configuration only for networks that
 have IPv6 prefixes. Dual-stack networks include `enable_ipv6: true`, IPv6 IPAM,
 and service-level `ipv6_address` entries only for interfaces carrying IPv6
@@ -164,14 +163,18 @@ behavior.
 ## Repository Readiness
 
 IPv6 support is being expanded as a repository-level contract. This PR lands
-the helper foundation and documentation boundary. Later PRs must update this
-section as each feature is implemented and verified on `development2`.
+the Docker compiler portion of that contract on top of the helper and topology
+foundation. Later PRs must update this section as each feature is implemented
+and verified on `development2`.
 
 Target categories:
 
-- supported: core addressing, Docker dual-stack networks, BIRD/FRR BGP,
-  OSPFv3, ExaBGP, Looking Glass;
-- baseline dual-stack: DNS authoritative and reverse records, and `/etc/hosts`;
+- landed: core addressing, optional topology IPv6 state, Docker dual-stack
+  networks, optional IPv6 service network, and custom container / Internet Map
+  static IPv6 attachment output;
+- pending control-plane target: BIRD/FRR BGP, OSPFv3, ExaBGP, Looking Glass;
+- pending DNS baseline target: DNS authoritative and reverse records, and
+  `/etc/hosts`;
 - compatible but not fully migrated: DNS cache, Domain Registrar dynamic A/AAAA
   updates, Web/CA, traffic wrappers, Kubo bootstrap endpoints, Botnet
   C2/dropper endpoint formatting, Monero seed/RPC endpoint formatting,

--- a/seedemu/compiler/Docker.py
+++ b/seedemu/compiler/Docker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from seedemu.core.Emulator import Emulator
-from seedemu.core import Node, Network, Compiler, BaseSystem, BaseOption, Scope, ScopeType, ScopeTier, OptionHandling, BaseVolume, OptionMode
+from seedemu.core import Node, Network, Compiler, BaseSystem, BaseOption, Scope, ScopeType, ScopeTier, OptionHandling, BaseVolume, OptionMode, normalizeAddressList
 from seedemu.core.enums import NodeRole, NetworkType
 from .DockerImage import DockerImage
 from .DockerImageConstant import *
@@ -9,7 +9,7 @@ from hashlib import md5
 from functools import cmp_to_key
 from os import mkdir, chdir
 from re import sub
-from ipaddress import IPv4Network, IPv4Address
+from ipaddress import IPv4Network, IPv4Address, IPv6Network, IPv6Address
 from shutil import copyfile
 import json
 from yaml import dump
@@ -87,7 +87,7 @@ while read -sr line; do {
 }; done
 """
 
-DockerCompilerFileTemplates['replace_address_script'] = '''\
+DockerCompilerFileTemplates['replace_address_script'] = r'''\
 #!/bin/bash
 ip -j addr | jq -cr '.[]' | while read -r iface; do {
     ifname="`jq -cr '.ifname' <<< "$iface"`"
@@ -176,15 +176,29 @@ DockerCompilerFileTemplates['compose_service_network_address'] = """\
                 ipv4_address: {address}
 """
 
+DockerCompilerFileTemplates['compose_service_network_ipv6_address'] = """\
+                ipv6_address: {address}
+"""
+
 DockerCompilerFileTemplates['compose_network'] = """\
     {netId}:
+{enableIpv6}
         driver_opts:
             com.docker.network.driver.mtu: {mtu}
         ipam:
             config:
                 - subnet: {prefix}
+{ipv6Ipam}
         labels:
 {labelList}
+"""
+
+DockerCompilerFileTemplates['compose_network_enable_ipv6'] = """\
+        enable_ipv6: true
+"""
+
+DockerCompilerFileTemplates['compose_network_ipv6_ipam'] = """\
+                - subnet: {prefix}
 """
 
 DockerCompilerFileTemplates['seedemu_internet_map'] = """\
@@ -208,7 +222,7 @@ DockerCompilerFileTemplates['environment_variable_entry'] = """\
 DockerCompilerFileTemplates['network_entry'] = """\
         networks:
              {network_name_field}:
-                    {ipv4_address_field}
+{address_fields}\
 """
 
 DockerCompilerFileTemplates['custom_compose_label_meta'] = """\
@@ -473,6 +487,7 @@ class Docker(Compiler):
     __naming_scheme: str
     __self_managed_network: bool
     __dummy_network_pool: Generator[IPv4Network, None, None]
+    __dummy_ipv6_network_pool: Generator[IPv6Network, None, None]
 
 
     __internet_map_enabled: bool
@@ -500,6 +515,8 @@ class Docker(Compiler):
         selfManagedNetwork: bool = False,
         dummyNetworksPool: str = '10.128.0.0/9',
         dummyNetworksMask: int = 24,
+        dummyIpv6NetworksPool: str = 'fd00:ffff::/48',
+        dummyIpv6NetworksMask: int = 64,
         internetMapEnabled: bool = True,
         internetMapPort: int = 8080,
         etherViewEnabled: bool = False,
@@ -529,6 +546,10 @@ class Docker(Compiler):
         loopback IP addresses. Default to 10.128.0.0/9.
         @param dummyNetworksMask (optional) mask of dummy networks. Default to
         24.
+        @param dummyIpv6NetworksPool (optional) dummy IPv6 networks pool for
+        self-managed dual-stack networks. Default to fd00:ffff::/48.
+        @param dummyIpv6NetworksMask (optional) mask of dummy IPv6 networks.
+        Default to 64.
         @param internetMapEnabled (optional) set if seedemu internetMap should be enabled.
         Default to False. Note that the seedemu internetMap allows unauthenticated
         access to all nodes, which can potentially allow root access to the
@@ -547,6 +568,7 @@ class Docker(Compiler):
         self.__naming_scheme = namingScheme
         self.__self_managed_network = selfManagedNetwork
         self.__dummy_network_pool = IPv4Network(dummyNetworksPool).subnets(new_prefix = dummyNetworksMask)
+        self.__dummy_ipv6_network_pool = IPv6Network(dummyIpv6NetworksPool).subnets(new_prefix = dummyIpv6NetworksMask)
 
         self.__internet_map_enabled = internetMapEnabled
         self.__internet_map_port = internetMapPort
@@ -844,6 +866,12 @@ class Docker(Compiler):
             value = net.getPrefix()
         )
 
+        if net.hasIpv6Prefix():
+            labels += DockerCompilerFileTemplates['compose_label_meta'].format(
+                key = 'ipv6_prefix',
+                value = net.getIpv6Prefix()
+            )
+
         if net.getDisplayName() != None:
             labels += DockerCompilerFileTemplates['compose_label_meta'].format(
                 key = 'displayname',
@@ -951,6 +979,12 @@ class Docker(Compiler):
                 key = 'net.{}.address'.format(n),
                 value = '{}/{}'.format(iface.getAddress(), net.getPrefix().prefixlen)
             )
+
+            if iface.hasIpv6Address():
+                labels += DockerCompilerFileTemplates['compose_label_meta'].format(
+                    key = 'net.{}.ipv6_address'.format(n),
+                    value = '{}/{}'.format(iface.getIpv6Address(), net.getIpv6Prefix().prefixlen)
+                )
 
             n += 1
 
@@ -1092,14 +1126,37 @@ class Docker(Compiler):
                     node.getAsn(), node.getName()
                 ))
 
-            if address == None:
-                address = ""
-            else:
-                address = DockerCompilerFileTemplates['compose_service_network_address'].format(address = address)
+            ipv6_address = iface.getIpv6Address() if iface.hasIpv6Address() else None
+            if self.__self_managed_network and net.getType() != NetworkType.Bridge and iface.hasIpv6Address():
+                d6_index: int = net.getAttribute('dummy_ipv6_prefix_index')
+                d6_prefix: IPv6Network = net.getAttribute('dummy_ipv6_prefix')
+                d6_address = d6_prefix[d6_index]
+
+                net.setAttribute('dummy_ipv6_prefix_index', d6_index + 1)
+
+                dummy_addr_map += '{}/{},{}/{}\n'.format(
+                    d6_address, d6_prefix.prefixlen,
+                    iface.getIpv6Address(), iface.getNet().getIpv6Prefix().prefixlen
+                )
+
+                ipv6_address = d6_address
+
+                self._log('using self-managed network: using dummy address {}/{} for {}/{} on as{}/{}'.format(
+                    d6_address, d6_prefix.prefixlen, iface.getIpv6Address(), iface.getNet().getIpv6Prefix().prefixlen,
+                    node.getAsn(), node.getName()
+                ))
+
+            address_entries = ""
+            if address != None:
+                address_entries += DockerCompilerFileTemplates['compose_service_network_address'].format(address = address)
+            if ipv6_address is not None:
+                address_entries += DockerCompilerFileTemplates['compose_service_network_ipv6_address'].format(
+                    address=ipv6_address
+                )
 
             node_nets += DockerCompilerFileTemplates['compose_service_network'].format(
                 netId = real_netname,
-                address = address
+                address = address_entries
             )
         return node_nets, dummy_addr_map
 
@@ -1283,6 +1340,12 @@ class Docker(Compiler):
                             opt_keyvals.append(f'- {s.strip()}')
                     else:
                         opt_keyvals.append(repr(o))
+        if node.getRole() in {NodeRole.Router, NodeRole.BorderRouter, NodeRole.OpenVpnRouter, NodeRole.RouteServer}:
+            if any(iface.hasIpv6Address() for iface in node.getInterfaces()):
+                opt_keyvals.append('- net.ipv6.conf.all.forwarding=1')
+                opt_keyvals.append('- net.ipv6.conf.default.forwarding=1')
+                opt_keyvals.append('- net.ipv6.conf.all.disable_ipv6=0')
+                opt_keyvals.append('- net.ipv6.conf.default.disable_ipv6=0')
         if len(opt_keyvals) > 0:
             return DockerCompilerFileTemplates['compose_sysctl'] + '           ' + '\n           '.join( opt_keyvals )
         else:
@@ -1391,11 +1454,25 @@ class Docker(Compiler):
             net.setAttribute('dummy_prefix', pfx)
             net.setAttribute('dummy_prefix_index', 2)
             self._log('self-managed network: using dummy prefix {}'.format(pfx))
+            if net.hasIpv6Prefix():
+                pfx6 = next(self.__dummy_ipv6_network_pool)
+                net.setAttribute('dummy_ipv6_prefix', pfx6)
+                net.setAttribute('dummy_ipv6_prefix_index', 2)
+                self._log('self-managed network: using dummy IPv6 prefix {}'.format(pfx6))
 
+
+        ipv6_ipam = ""
+        enable_ipv6 = ""
+        if net.hasIpv6Prefix():
+            ipv6_prefix = net.getAttribute('dummy_ipv6_prefix') if self.__self_managed_network and net.getType() != NetworkType.Bridge else net.getIpv6Prefix()
+            enable_ipv6 = DockerCompilerFileTemplates['compose_network_enable_ipv6']
+            ipv6_ipam = DockerCompilerFileTemplates['compose_network_ipv6_ipam'].format(prefix=ipv6_prefix)
 
         return DockerCompilerFileTemplates['compose_network'].format(
             netId = self._getRealNetName(net),
             prefix = net.getAttribute('dummy_prefix') if self.__self_managed_network and net.getType() != NetworkType.Bridge else net.getPrefix(),
+            enableIpv6 = enable_ipv6,
+            ipv6Ipam = ipv6_ipam,
             mtu = net.getMtu(),
             labelList = self._getNetMeta(net)
         )
@@ -1581,6 +1658,7 @@ class Docker(Compiler):
         return toplevelvolumes
 
     def attachInternetMap(self, asn: int = -1, net: str = '', ip_address: str = '',
+                      ipv6_address: str = '',
                       port_forwarding: str = '', env: list = [],
                       show_on_map=False, node_name='seedemu_internet_map') -> Docker:
         """!
@@ -1593,6 +1671,8 @@ class Docker(Compiler):
         @param net the name of the network that this container is attached to.
         @param ip_address the IP address set for this container. If no IP address is provided,
             docker will provide one when building the image.
+        @param ipv6_address the IPv6 address set for this container. If no IPv6 address is
+            provided, docker will provide one when the attached network supports IPv6.
         @param port_forwarding the port forwarding field.
         @param env the list of the environment variables.
         @param show_on_map it is show on the map.
@@ -1613,13 +1693,13 @@ class Docker(Compiler):
                 clientImage=SEEDEMU_INTERNET_MAP_IMAGE,
                 containerName=node_name,
             ),
-            asn=asn, net=net, ip_address=ip_address, port_forwarding=port_forwarding, env=env, show_on_map=show_on_map,
+            asn=asn, net=net, ip_address=ip_address, ipv6_address=ipv6_address, port_forwarding=port_forwarding, env=env, show_on_map=show_on_map,
             node_name=node_name
         )
         return self
 
     def attachCustomContainer(self, compose_entry: str, asn: int = -1, net: str = '',
-                              ip_address: str = '', port_forwarding: str = '', env: list = [],
+                              ip_address: str = '', ipv6_address: str = '', port_forwarding: str = '', env: list = [],
                               show_on_map=False, node_name: str = 'unnamed') -> Docker:
         """!
         @brief add an pre-built container image to the emulator (the entry should not
@@ -1632,6 +1712,8 @@ class Docker(Compiler):
         @param net the name of the network that this container is attached to.
         @param ip_address the IP address set for this container. If no IP address is provided,
             docker will provide one when building the image.
+        @param ipv6_address the IPv6 address set for this container. If no IPv6 address is
+            provided, docker will provide one when the attached network supports IPv6.
         @param port_forwarding the port forwarding field.
 
         @param env the list of the environment variables.
@@ -1642,6 +1724,14 @@ class Docker(Compiler):
         """
 
         self._log('attaching an existing container to {}:{}'.format(asn, net))
+
+        if asn >= 0:
+            if ip_address != '':
+                ip_address = normalizeAddressList([ip_address])[0]
+                IPv4Address(ip_address)
+            if ipv6_address != '':
+                ipv6_address = normalizeAddressList([ipv6_address])[0]
+                IPv6Address(ipv6_address)
 
         self.__custom_services += compose_entry
 
@@ -1665,27 +1755,28 @@ class Docker(Compiler):
             net_prefix = self._contextToPrefix(asn, 'net')
             real_netname = '{}{}'.format(net_prefix, net)
 
-            # Construct the IP address field (leave it empty if IP address is not provided)
-            if ip_address == '':
-                ipv4_address_entry = ''
-            else:
-                ipv4_address_entry = 'ipv4_address: {}'.format(ip_address)
+            # Construct IP address fields (leave empty when addresses are not provided)
+            address_fields = ''
+            if ip_address != '':
+                address_fields += '                    ipv4_address: {}\n'.format(ip_address)
+            if ipv6_address != '':
+                address_fields += '                    ipv6_address: {}\n'.format(ipv6_address)
 
             self.__custom_services += DockerCompilerFileTemplates['network_entry'].format(
                 network_name_field=real_netname,
-                ipv4_address_field=ipv4_address_entry
+                address_fields=address_fields
             )
             self.__custom_services += '\n'
 
         if show_on_map:
             self.__custom_services += DockerCompilerFileTemplates['custom_compose_label_meta'].format(labelList=self._getCustomNodeMeta(
-                asn, node_name, net, ip_address
+                asn, node_name, net, ip_address, ipv6_address
             ))
             self.__custom_services += '\n'
 
         return self
 
-    def _getCustomNodeMeta(self, asn: int = -1, node_name: str = '', net: str = '', ip_address: str = '', ) -> str:
+    def _getCustomNodeMeta(self, asn: int = -1, node_name: str = '', net: str = '', ip_address: str = '', ipv6_address: str = '') -> str:
         """!
         @brief get custom node metadata labels.
 
@@ -1717,6 +1808,11 @@ class Docker(Compiler):
             labels += DockerCompilerFileTemplates['compose_label_meta'].format(
                 key='net.0.address',
                 value=ip_address
+            )
+        if ipv6_address:
+            labels += DockerCompilerFileTemplates['compose_label_meta'].format(
+                key='net.0.ipv6_address',
+                value=ipv6_address
             )
         labels += DockerCompilerFileTemplates['compose_label_meta'].format(
             key='custom',

--- a/seedemu/core/Emulator.py
+++ b/seedemu/core/Emulator.py
@@ -4,10 +4,11 @@ from .ExternalConnectivityProvider import ExternalConnectivityProvider
 from .Merger import Mergeable, Merger
 from .Registry import Registry, Registrable, Printable
 from .Network import Network
+from .Addressing import normalizePrefix
 from seedemu import core
 from typing import Dict, Set, Tuple, List
 from sys import prefix, stderr
-from ipaddress import IPv4Address, IPv4Network
+from ipaddress import IPv4Address, IPv4Network, IPv6Network
 import pickle
 
 class BindingDatabase(Registrable, Printable):
@@ -89,9 +90,10 @@ class Emulator:
 
     __service_net: Network
     __service_net_prefix: str
+    __service_net_ipv6_prefix: str
     __ecp: ExternalConnectivityProvider
 
-    def __init__(self, serviceNetworkPrefix: str = '192.168.66.0/24'):
+    def __init__(self, serviceNetworkPrefix: str = '192.168.66.0/24', serviceNetworkIpv6Prefix: str = None):
         """!
         @brief Construct a new emulation.
 
@@ -100,6 +102,8 @@ class Emulator:
         emulation, and provide access between the emulation nodes and the host
         node. Service network will not be created unless some layer/service/as
         asks for it.
+        @param serviceNetworkIpv6Prefix (optional) IPv6 prefix for the service
+        network. The service network remains IPv4-only unless this is set.
         """
         self.__rendered = False
         self.__dependencies_db = {}
@@ -112,6 +116,7 @@ class Emulator:
         self.__registry.register('seedemu', 'list', 'bindingdb', self.__bindings)
 
         self.__service_net_prefix = serviceNetworkPrefix
+        self.__service_net_ipv6_prefix = serviceNetworkIpv6Prefix
         self.__service_net = None
         self.__ecp = ExternalConnectivityProvider()
 
@@ -330,7 +335,25 @@ class Emulator:
         @returns service network.
         """
         if self.__service_net == None:
-            self.__service_net = self.__registry.register('seedemu', 'net', '000_svc', Network('000_svc', NetworkType.Bridge, IPv4Network(self.__service_net_prefix), direct = False))
+            ipv6_prefix = (
+                IPv6Network(normalizePrefix(self.__service_net_ipv6_prefix))
+                if self.__service_net_ipv6_prefix is not None
+                else None
+            )
+            ipv6_intent = "explicit" if ipv6_prefix is not None else None
+            self.__service_net = self.__registry.register(
+                'seedemu',
+                'net',
+                '000_svc',
+                Network(
+                    '000_svc',
+                    NetworkType.Bridge,
+                    IPv4Network(self.__service_net_prefix),
+                    direct = False,
+                    ipv6Prefix = ipv6_prefix,
+                    ipv6PrefixIntent = ipv6_intent,
+                ),
+            )
 
         return self.__service_net
 

--- a/seedemu/core/Node.py
+++ b/seedemu/core/Node.py
@@ -1155,16 +1155,22 @@ fill_placeholder = """\
 gw="`ip rou show default | cut -d' ' -f3`"
 if [ -z "$gw" ]; then
 
-    #line=$(<"/ifinfo.txt")
-    line=$(grep '^000_svc:' "/ifinfo.txt")
+    line=$(awk -F'|' '$1 == "000_svc" && $2 !~ /:/ { print; exit }' "/ifinfo.txt")
+    if [ -z "$line" ]; then
+        line=$(grep '^000_svc:' "/ifinfo.txt" | head -n1)
+    fi
     if [ -z "$line" ]; then
         echo "Error: Could not find 000_svc in /ifinfo.txt" >&2
         exit 1
     fi
-    ip_portion=$(echo "$line" | cut -d':' -f2)
+    if [[ "$line" == *"|"* ]]; then
+        ip_portion=$(echo "$line" | cut -d'|' -f2)
+    else
+        ip_portion=$(echo "$line" | cut -d':' -f2)
+    fi
     ip_only=$(echo "$ip_portion" | cut -d'/' -f1)
     docker_host="${ip_only%.*}.1"
-    if [ -z "$docker_host"]; then
+    if [ -z "$docker_host" ]; then
         echo "Error: Could not determine the default route required to configure BIRD." >&2
         exit 1;
     else

--- a/seedemu/layers/Base.py
+++ b/seedemu/layers/Base.py
@@ -5,33 +5,72 @@ from typing import Dict, List
 from seedemu.options.Sysctl import SysctlOpts
 BaseFileTemplates: Dict[str, str] = {}
 
-BaseFileTemplates["interface_setup_script"] = """\
+BaseFileTemplates["interface_setup_script"] = r"""\
 #!/bin/bash
 cidr_to_net() {
-    ipcalc -n "$1" | sed -E -n 's/^Network: +([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}) +.*/\\1/p'
+    case "$1" in
+        *:*) return ;;
+        *) ipcalc -n "$1" | sed -E -n 's/^Network: +([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}) +.*/\1/p' ;;
+    esac
 }
 
-ip -j addr | jq -cr '.[]' | while read -r iface; do {
-    ifname="`jq -cr '.ifname' <<< "$iface"`"
-    jq -cr '.addr_info[]' <<< "$iface" | while read -r iaddr; do {
-        addr="`jq -cr '"\(.local)/\(.prefixlen)"' <<< "$iaddr"`"
-        net="`cidr_to_net "$addr"`"
-        [ -z "$net" ] && continue
-        line="`grep "$net" < ifinfo.txt`"
+lookup_ifinfo() {
+    local cidr="$1"
+    local line net
+    line="`awk -F'|' -v cidr="$cidr" '$2 == cidr { print; exit }' /ifinfo.txt`"
+    if [ ! -z "$line" ]; then
+        echo "$line"
+        return
+    fi
+    net="`cidr_to_net "$cidr"`"
+    if [ ! -z "$net" ]; then
+        line="`awk -F'|' -v cidr="$net" '$2 == cidr { print; exit }' /ifinfo.txt`"
+        if [ ! -z "$line" ]; then
+            echo "$line"
+            return
+        fi
+        grep -F "$net" /ifinfo.txt | head -n1
+    fi
+}
+
+parse_ifinfo() {
+    local line="$1"
+    if [[ "$line" == *"|"* ]]; then
+        new_ifname="`cut -d'|' -f1 <<< "$line"`"
+        latency="`cut -d'|' -f3 <<< "$line"`"
+        bw="`cut -d'|' -f4 <<< "$line"`"
+        loss="`cut -d'|' -f5 <<< "$line"`"
+    else
         new_ifname="`cut -d: -f1 <<< "$line"`"
         latency="`cut -d: -f3 <<< "$line"`"
         bw="`cut -d: -f4 <<< "$line"`"
-        [ "$bw" = 0 ] && bw=1000000000000
         loss="`cut -d: -f5 <<< "$line"`"
-        [ ! -z "$new_ifname" ] && {
-            ip li set "$ifname" down
-            ip li set "$ifname" name "$new_ifname"
-            ip li set "$new_ifname" up
-            tc qdisc add dev "$new_ifname" root handle 1:0 tbf rate "${bw}bit" buffer 1000000 limit 1000
-            tc qdisc add dev "$new_ifname" parent 1:0 handle 10: netem delay "${latency}ms" loss "${loss}%"
-        }
-    }; done
-}; done
+    fi
+}
+
+ip -j addr | jq -cr '.[]' | while read -r iface; do
+    ifname="`jq -cr '.ifname' <<< "$iface"`"
+    line=""
+    while read -r iaddr; do
+        addr="`jq -cr '"\(.local)/\(.prefixlen)"' <<< "$iaddr"`"
+        line="`lookup_ifinfo "$addr"`"
+        [ ! -z "$line" ] && break
+    done < <(jq -cr '.addr_info[]?' <<< "$iface")
+    [ -z "$line" ] && continue
+    parse_ifinfo "$line"
+    [ -z "$new_ifname" ] && continue
+    [ "$bw" = 0 ] && bw=1000000000000
+    if [ "$ifname" != "$new_ifname" ]; then
+        sysctl -w net.ipv6.conf.all.keep_addr_on_down=1 > /dev/null 2>&1
+        sysctl -w net.ipv6.conf.default.keep_addr_on_down=1 > /dev/null 2>&1
+        sysctl -w "net.ipv6.conf.${ifname}.keep_addr_on_down=1" > /dev/null 2>&1
+        ip li set "$ifname" down
+        ip li set "$ifname" name "$new_ifname"
+        ip li set "$new_ifname" up
+    fi
+    tc qdisc add dev "$new_ifname" root handle 1:0 tbf rate "${bw}bit" buffer 1000000 limit 1000
+    tc qdisc add dev "$new_ifname" parent 1:0 handle 10: netem delay "${latency}ms" loss "${loss}%"
+done
 """
 
 
@@ -113,7 +152,11 @@ class Base(Layer, Graphable):
             for iface in node.getInterfaces():
                 net = iface.getNet()
                 [l, b, d] = iface.getLinkProperties()
-                ifinfo += '{}:{}:{}:{}:{}\n'.format(net.getName(), net.getPrefix(), l, b, d)
+                if iface.getAddress() is not None:
+                    ifinfo += '{}|{}/{}|{}|{}|{}\n'.format(net.getName(), iface.getAddress(), net.getPrefix().prefixlen, l, b, d)
+                ifinfo += '{}|{}|{}|{}|{}\n'.format(net.getName(), net.getPrefix(), l, b, d)
+                if iface.hasIpv6Address():
+                    ifinfo += '{}|{}/{}|{}|{}|{}\n'.format(net.getName(), iface.getIpv6Address(), net.getIpv6Prefix().prefixlen, l, b, d)
 
             node.setFile('/ifinfo.txt', ifinfo)
             node.setFile('/interface_setup', BaseFileTemplates['interface_setup_script'])

--- a/test_ipv6_repository_readiness.py
+++ b/test_ipv6_repository_readiness.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import socket
 import sys
+import textwrap
 import types
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 ROOT = Path(__file__).resolve().parent
@@ -106,6 +109,56 @@ Ipv6AddressingModule = _load_core_module("Ipv6Addressing", "Ipv6Addressing.py")
 
 AddressFamily = Addressing.AddressFamily
 Ipv6Addressing = Ipv6AddressingModule.Ipv6Addressing
+
+
+def _run_real_docker_compile(tmp_path, setup_code: str):
+    """Compile through the real Docker module in a clean Python process."""
+
+    output = tmp_path / "output_{}".format(len(list(tmp_path.glob("output_*"))))
+    setup_code = textwrap.dedent(setup_code).strip()
+    script = textwrap.dedent(
+        """
+        from pathlib import Path
+        import importlib.util
+        import sys
+        import types
+
+        ROOT = Path({root!r})
+        OUTPUT = Path({output!r})
+
+        seedemu = types.ModuleType("seedemu")
+        seedemu.__path__ = [str(ROOT / "seedemu")]
+        sys.modules["seedemu"] = seedemu
+        for name in ["core", "layers", "compiler"]:
+            module = types.ModuleType("seedemu." + name)
+            module.__path__ = [str(ROOT / "seedemu" / name)]
+            sys.modules["seedemu." + name] = module
+
+        spec = importlib.util.spec_from_file_location(
+            "seedemu.core",
+            ROOT / "seedemu" / "core" / "__init__.py",
+            submodule_search_locations=[str(ROOT / "seedemu" / "core")],
+        )
+        core = importlib.util.module_from_spec(spec)
+        sys.modules["seedemu.core"] = core
+        spec.loader.exec_module(core)
+
+        from seedemu.core.Emulator import Emulator
+        from seedemu.layers.Base import Base
+        from seedemu.compiler.Docker import Docker
+
+        {setup_code}
+        """
+    ).format(root=str(ROOT), output=str(output), setup_code=setup_code)
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(ROOT),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    compose_text = (output / "docker-compose.yml").read_text()
+    return compose_text, yaml.safe_load(compose_text)
 
 
 def _load_seedemu_class(module_name: str, class_name: str):
@@ -344,3 +397,185 @@ def test_router_backend_legacy_values_stay_rejected():
         router.setRoutingBackend("exabgp")
     with pytest.raises(AssertionError):
         router.setRoutingBackend("external")
+
+
+def test_docker_compiler_keeps_ipv4_default_compose_ipv4_only(tmp_path):
+    compose_text, compose = _run_real_docker_compile(
+        tmp_path,
+        """
+        emu = Emulator()
+        base = Base()
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        as150.createHost("h1").joinNetwork("net0")
+        emu.addLayer(base)
+        emu.render()
+        emu.compile(Docker(internetMapEnabled=False), str(OUTPUT), override=True)
+        """,
+    )
+
+    assert "enable_ipv6" not in compose_text
+    assert "ipv6_address" not in compose_text
+
+    net = compose["networks"]["net_150_net0"]
+    assert "enable_ipv6" not in net
+    assert net["ipam"]["config"] == [{"subnet": "10.150.0.0/24"}]
+
+    service_net = compose["services"]["hnode_150_h1"]["networks"]["net_150_net0"]
+    assert service_net == {"ipv4_address": "10.150.0.71"}
+
+
+def test_docker_compiler_emits_ipv6_only_for_ipv6_interfaces(tmp_path):
+    _, compose = _run_real_docker_compile(
+        tmp_path,
+        """
+        emu = Emulator()
+        base = Base(enableIpv6=True)
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        as150.createHost("h1").joinNetwork("net0")
+        as150.createHost("v4only").joinNetwork("net0", ipv6Address=None)
+        emu.addLayer(base)
+        emu.render()
+        emu.compile(Docker(internetMapEnabled=False), str(OUTPUT), override=True)
+        """,
+    )
+
+    net = compose["networks"]["net_150_net0"]
+    assert net["enable_ipv6"] is True
+    assert net["ipam"]["config"] == [
+        {"subnet": "10.150.0.0/24"},
+        {"subnet": "2000:0:96::/64"},
+    ]
+    assert net["labels"]["org.seedsecuritylabs.seedemu.meta.ipv6_prefix"] == "2000:0:96::/64"
+
+    h1_net = compose["services"]["hnode_150_h1"]["networks"]["net_150_net0"]
+    assert h1_net["ipv4_address"] == "10.150.0.71"
+    assert h1_net["ipv6_address"] == "2000:0:96::47"
+
+    v4only_net = compose["services"]["hnode_150_v4only"]["networks"]["net_150_net0"]
+    assert v4only_net == {"ipv4_address": "10.150.0.72"}
+
+
+def test_service_network_ipv6_is_explicit(tmp_path):
+    _, default_compose = _run_real_docker_compile(
+        tmp_path,
+        """
+        emu = Emulator()
+        base = Base()
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        as150.createHost("h1").joinNetwork("net0")
+        emu.addLayer(base)
+        emu.getServiceNetwork()
+        emu.render()
+        emu.compile(Docker(internetMapEnabled=False), str(OUTPUT), override=True)
+        """,
+    )
+
+    default_service_net = default_compose["networks"]["000_svc"]
+    assert "enable_ipv6" not in default_service_net
+    assert default_service_net["ipam"]["config"] == [{"subnet": "192.168.66.0/24"}]
+
+    _, ipv6_compose = _run_real_docker_compile(
+        tmp_path,
+        """
+        emu = Emulator(serviceNetworkIpv6Prefix=" fd00:66:: / 64 ")
+        base = Base()
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        as150.createHost("h1").joinNetwork("net0")
+        emu.addLayer(base)
+        emu.getServiceNetwork()
+        emu.render()
+        emu.compile(Docker(internetMapEnabled=False), str(OUTPUT), override=True)
+        """,
+    )
+
+    ipv6_service_net = ipv6_compose["networks"]["000_svc"]
+    assert ipv6_service_net["enable_ipv6"] is True
+    assert ipv6_service_net["ipam"]["config"] == [
+        {"subnet": "192.168.66.0/24"},
+        {"subnet": "fd00:66::/64"},
+    ]
+
+
+def test_custom_container_and_internet_map_ipv6_attachment_is_explicit(tmp_path):
+    _, compose = _run_real_docker_compile(
+        tmp_path,
+        """
+        emu = Emulator()
+        base = Base(enableIpv6=True)
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        as150.createHost("h1").joinNetwork("net0")
+        emu.addLayer(base)
+        emu.render()
+
+        docker = Docker(internetMapEnabled=False)
+        docker.attachCustomContainer(
+            "    probe_v4:\\n        image: alpine:latest\\n",
+            asn=150,
+            net="net0",
+            ip_address="10.150.0.200",
+            show_on_map=True,
+            node_name="probe_v4",
+        )
+        docker.attachInternetMap(
+            asn=150,
+            net="net0",
+            ip_address=" 10.150.0.201 ",
+            ipv6_address=" [2000:0:96::201] ",
+            node_name="seedemu_internet_map",
+        )
+        emu.compile(docker, str(OUTPUT), override=True)
+        """,
+    )
+
+    probe_net = compose["services"]["probe_v4"]["networks"]["net_150_net0"]
+    assert probe_net == {"ipv4_address": "10.150.0.200"}
+    assert "org.seedsecuritylabs.seedemu.meta.net.0.ipv6_address" not in compose["services"]["probe_v4"]["labels"]
+
+    map_net = compose["services"]["seedemu_internet_map"]["networks"]["net_150_net0"]
+    assert map_net["ipv4_address"] == "10.150.0.201"
+    assert map_net["ipv6_address"] == "2000:0:96::201"
+
+
+def test_custom_container_attachment_rejects_mismatched_address_families(tmp_path):
+    _run_real_docker_compile(
+        tmp_path,
+        """
+        docker = Docker(internetMapEnabled=False)
+        try:
+            docker.attachCustomContainer(
+                "    bad_v4:\\n        image: alpine:latest\\n",
+                asn=150,
+                net="net0",
+                ip_address="2000:0:96::202",
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("IPv6 literal was accepted in ip_address")
+
+        try:
+            docker.attachInternetMap(
+                asn=150,
+                net="net0",
+                ipv6_address="10.150.0.202",
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("IPv4 literal was accepted in ipv6_address")
+
+        emu = Emulator()
+        base = Base()
+        as150 = base.createAutonomousSystem(150)
+        as150.createNetwork("net0")
+        as150.createHost("h1").joinNetwork("net0")
+        emu.addLayer(base)
+        emu.render()
+        emu.compile(docker, str(OUTPUT), override=True)
+        """,
+    )


### PR DESCRIPTION
## Summary

This PR continues the staged IPv6 readiness work after the merged core topology PR (#514). It lands the Docker compiler portion of the repository-wide optional IPv6 contract while preserving IPv4-only defaults.

Key points:

- Compose remains IPv4-only unless the model explicitly carries IPv6 state.
- Dual-stack networks emit `enable_ipv6: true` and IPv6 IPAM only when `Network.hasIpv6Prefix()` is true.
- Per-service `ipv6_address` is emitted only for interfaces that carry IPv6 addresses.
- `Emulator(serviceNetworkIpv6Prefix=...)` enables an optional dual-stack service network without changing the default service network.
- `attachCustomContainer(...)` and `attachInternetMap(...)` accept explicit static `ipv6_address` values, normalize padded/bracketed literals, and reject mismatched IPv4/IPv6 fields.
- Self-managed Docker networks now receive dummy IPv6 prefixes and address rewrites when the original network is dual-stack.
- Router containers with IPv6 interfaces get IPv6 forwarding sysctls; this does not add any ExaBGP router backend or routing-layer legacy path.
- Documentation and task status are tightened so Routing, ExaBGP, Looking Glass, DNS, and service runtime support are still described as follow-up work, not as already re-landed on `development2`.

## Legacy Guardrails

This PR intentionally keeps the control-plane cleanup boundary intact:

- `Router.setRoutingBackend(...)` remains limited to `bird` and `frr`.
- `exabgp` and `external` router backend values remain rejected.
- ExaBGP remains a Service + Binding shape, not a Router backend.
- No `FrrBgp` layer shim or Routing ExaBGP-as-router path is introduced.

## Validation

Local validation run on the rebased branch (`63d3937e`, base `development2` after #514):

```bash
git diff --check origin/development2..HEAD
/tmp/seedemu-ipv6-foundation-venv/bin/python -m pytest -q test_ipv6_repository_readiness.py
python3 -m compileall seedemu/core seedemu/layers/Base.py seedemu/compiler/Docker.py
```

Results:

- `git diff --check`: passed.
- `test_ipv6_repository_readiness.py`: 15 passed.
- `compileall`: passed for `seedemu/core`, `seedemu/layers/Base.py`, and `seedemu/compiler/Docker.py`.

Note: `test_bgp_control_plane_extensions.py` is not present on the current `development2` line after #514, so this Docker compiler PR does not run that later control-plane test file.

## Runtime / Generated Output Coverage

The added tests compile minimal real Docker outputs and parse `docker-compose.yml` to verify:

- IPv4 default examples do not emit `enable_ipv6`, `ipv6_address`, or IPv6 IPAM.
- Explicit IPv6 topology state emits dual-stack network config and per-node IPv6 addresses.
- `ipv6Address=None` suppresses per-node `ipv6_address` even on dual-stack networks.
- The service network remains IPv4-only by default and becomes dual-stack only with `serviceNetworkIpv6Prefix`.
- Custom container and Internet Map static IPv6 attachment output is explicit, normalized, and address-family checked.

This PR does not claim BIRD/FRR/ExaBGP/Looking Glass runtime IPv6 support; those remain follow-up PRs.
