### PR TITLE
Make feature CI example-first for agent evidence

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -30,6 +30,7 @@ jobs:
   static:
     name: Static
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4
@@ -56,6 +57,7 @@ jobs:
     name: Unit
     needs: static
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4
@@ -80,6 +82,7 @@ jobs:
     name: Example Compile
     needs: static
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4
@@ -105,6 +108,7 @@ jobs:
     needs: example-compile
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['run-example-build'] == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4
@@ -130,6 +134,7 @@ jobs:
     needs: example-compile
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['run-runtime-integration'] == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
       - name: Check out the source repository
         uses: actions/checkout@v4

--- a/test_ci_runner.py
+++ b/test_ci_runner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+
+RUN_CI_PATH = Path(__file__).parent / "tests" / "ci" / "run_ci.py"
+SPEC = importlib.util.spec_from_file_location("seedemu_ci_runner_under_test", RUN_CI_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+run_ci = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_ci)
+
+
+def test_feature_selector_uses_manifest_examples() -> None:
+    manifest = run_ci.load_manifest()
+
+    assert run_ci._selected_example_ids(manifest, "compile", [], ["routing-bird-frr"]) == [
+        "basic-a12-bgp-mixed-backend"
+    ]
+    assert run_ci._selected_example_ids(manifest, "compile", ["basic-a00-simple-as"], []) == [
+        "basic-a00-simple-as"
+    ]
+
+
+def test_covered_feature_requires_declared_evidence() -> None:
+    manifest = copy.deepcopy(run_ci.load_manifest())
+    manifest["coverage_policy"]["required_features"].append("empty-covered-feature")
+    manifest["features"]["empty-covered-feature"] = {
+        "status": "covered",
+        "description": "Invalid covered feature without evidence.",
+        "unit_groups": [],
+        "compile_examples": [],
+        "build_examples": [],
+        "runtime_groups": [],
+    }
+
+    assert (
+        "feature empty-covered-feature is covered but declares no evidence"
+        in run_ci._validate_manifest(manifest)
+    )
+
+
+def test_run_command_streams_output_to_log(tmp_path) -> None:
+    check = run_ci._run_command(
+        "stream-smoke",
+        [sys.executable, "-c", "print('hello from stdout')"],
+        tmp_path,
+    )
+
+    assert check["status"] == "passed"
+    log_path = run_ci.REPO_ROOT / check["log_path"]
+    assert "[stdout] hello from stdout" in log_path.read_text(encoding="utf-8")
+
+
+def test_docker_compose_command_falls_back_to_legacy_binary(monkeypatch) -> None:
+    class Result:
+        returncode = 1
+
+    monkeypatch.setattr(run_ci.subprocess, "run", lambda *args, **kwargs: Result())
+    monkeypatch.setattr(run_ci.shutil, "which", lambda name: "/usr/local/bin/docker-compose")
+
+    assert run_ci._docker_compose_command() == ["/usr/local/bin/docker-compose"]

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -1,36 +1,75 @@
-# Feature-Oriented CI
+# Example-First CI
 
-The pull-request workflow is intentionally organized around SEED features rather
-than broad example buckets. The manifest in `feature_manifest.json` is the source
-of truth for which features are covered by unit tests, representative example
-compilation, selected Docker builds, and optional runtime integration probes.
+The pull-request workflow is organized around feature evidence, with examples as
+the primary reusable test unit for both agents and GitHub Actions. The manifest
+in `feature_manifest.json` is the source of truth for feature coverage, example
+compile outputs, Docker compose files, import smoke checks, and selected runtime
+groups.
 
-The CI runner writes both human-readable logs and machine-readable artifacts:
+The runner executes the manifest. It should not hard-code the project feature
+set, import smoke surface, or compose output layout.
 
-- `ci-summary.json` records every command, return code, duration, and log path.
+## Artifacts
+
+Every stage writes human-readable logs and machine-readable evidence:
+
+- `ci-summary.json` records every check, command, return code, duration, and log
+  path.
 - `junit.xml` records the same stage in a format GitHub and review tooling can
   ingest.
-- `feature-coverage.json` records the manifest-derived coverage state, including
-  declared gaps such as IPv6 work that has not landed on this integration line.
+- `feature-coverage.json` records manifest-derived feature and example evidence,
+  including declared gaps.
+- `logs/*.log` contains streamed command output, so large Docker build/runtime
+  logs do not have to be kept in memory.
 
-The static stage compiles importable Python source plus representative examples.
-It intentionally excludes embedded payload templates under
-`seedemu/services/EthereumService/EthTemplates/`, where some historical `.py`
-filenames contain shell script content copied into containers.
+## Local Entry Points
 
-Run stages locally from the repository root:
+Run the default PR gates from the repository root:
 
 ```bash
 python3 tests/ci/run_ci.py static --artifact-dir ci-artifacts/static
 python3 tests/ci/run_ci.py unit --artifact-dir ci-artifacts/unit
 python3 tests/ci/run_ci.py example-compile --artifact-dir ci-artifacts/example-compile
-python3 tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-build
 ```
 
-Docker image builds and runtime integration are available as explicit entry
-points, but they are not default pull-request gates in this PR:
+Use selectors when an agent or reviewer only needs the evidence for one feature,
+example, or test group:
+
+```bash
+python3 tests/ci/run_ci.py example-compile --feature routing-bird-frr --artifact-dir ci-artifacts/example-routing
+python3 tests/ci/run_ci.py example-compile --example basic-a00-simple-as --artifact-dir ci-artifacts/example-a00
+python3 tests/ci/run_ci.py unit --group control-plane-unit --artifact-dir ci-artifacts/unit-control-plane
+```
+
+Docker image builds and runtime integration are explicit entry points. They are
+available for manual workflow dispatch or local review, but they are not default
+pull-request gates:
 
 ```bash
 python3 tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-build
 python3 tests/ci/run_ci.py runtime-integration --artifact-dir ci-artifacts/runtime-integration
 ```
+
+## Manifest Contract
+
+`coverage_policy.required_features` declares the feature ids that must be
+tracked by this integration line. Adding or removing a required feature is a
+manifest change, not a Python runner change.
+
+Each `covered` feature must declare at least one evidence source: a unit group,
+compile example, build example, or runtime group. Use `declared-gap` for work
+that is intentionally tracked but not yet covered by this line. Do not mark a
+feature `covered` until its evidence is present and runnable.
+
+Each example declares:
+
+- `script`, `args`, `env`, and `clean` for reproducible generation.
+- `features` and `tags` for agent/reviewer discovery.
+- `compile.enabled` and `compile.outputs` for generated-file evidence.
+- `build.enabled` and `build.compose_file` for Docker build evidence.
+- `runtime.enabled` for future runtime probe wiring.
+
+The static stage compiles importable Python source plus the selected example
+directories. It intentionally excludes embedded payload templates under
+`seedemu/services/EthereumService/EthTemplates/`, where some historical `.py`
+filenames contain shell script content copied into containers.

--- a/tests/ci/feature_manifest.json
+++ b/tests/ci/feature_manifest.json
@@ -1,5 +1,55 @@
 {
   "schema": 1,
+  "coverage_policy": {
+    "required_features": [
+      "ipv4-default",
+      "ipv6-core",
+      "routing-bird-frr",
+      "exabgp-service",
+      "looking-glass",
+      "dns-endpoint",
+      "legacy-guard"
+    ],
+    "covered_requires_evidence": true
+  },
+  "static": {
+    "compile_targets": [
+      "seedemu",
+      "tests/control_plane",
+      "tests/ci",
+      "test_ci_runner.py"
+    ],
+    "compile_exclude": "seedemu/services/EthereumService/EthTemplates/",
+    "import_smoke": [
+      {
+        "statement": "from seedemu.layers.Base import Base"
+      },
+      {
+        "statement": "from seedemu.layers.Routing import Routing, Router"
+      },
+      {
+        "statement": "from seedemu.layers.Ebgp import Ebgp"
+      },
+      {
+        "statement": "from seedemu.layers.Ibgp import Ibgp"
+      },
+      {
+        "statement": "from seedemu.layers.Ospf import Ospf"
+      },
+      {
+        "statement": "from seedemu.services.ExaBgpService import ExaBgpService"
+      },
+      {
+        "statement": "from seedemu.services.BgpLookingGlassService import BgpLookingGlassService"
+      },
+      {
+        "statement": "from seedemu.compiler.Docker import Docker"
+      },
+      {
+        "statement": "import runpy; runpy.run_path('tests/ci/run_ci.py', run_name='seed_ci_runner_smoke')"
+      }
+    ]
+  },
   "features": {
     "ipv4-default": {
       "status": "covered",
@@ -63,6 +113,10 @@
     }
   },
   "unit_groups": {
+    "ci-runner-unit": {
+      "description": "Example-first CI runner manifest, selector, and logging checks.",
+      "pytest_args": ["test_ci_runner.py"]
+    },
     "control-plane-unit": {
       "description": "Control-plane API, rendering, service, and legacy guard checks.",
       "pytest_args": ["tests/control_plane/test_bgp_control_plane_extensions.py"]
@@ -81,19 +135,43 @@
       "description": "Small IPv4 default behavior smoke example.",
       "script": "examples/basic/A00_simple_as/simple_as.py",
       "args": ["amd"],
+      "features": ["ipv4-default"],
+      "tags": ["basic", "ipv4-default", "docker-compile", "docker-build"],
       "clean": ["output"],
-      "expected": ["output/docker-compose.yml"],
-      "compile": true,
-      "build": true
+      "compile": {
+        "enabled": true,
+        "outputs": ["output/docker-compose.yml"],
+        "timeout": 900
+      },
+      "build": {
+        "enabled": true,
+        "compose_file": "output/docker-compose.yml",
+        "timeout": 1800
+      },
+      "runtime": {
+        "enabled": false
+      }
     },
     "basic-a12-bgp-mixed-backend": {
       "description": "Mixed BIRD/FRR routing backend example.",
       "script": "examples/basic/A12_bgp_mixed_backend/bgp_mixed_backend.py",
       "args": ["amd"],
+      "features": ["routing-bird-frr"],
+      "tags": ["basic", "routing", "bird", "frr", "docker-compile", "docker-build"],
       "clean": ["output"],
-      "expected": ["output/docker-compose.yml"],
-      "compile": true,
-      "build": true
+      "compile": {
+        "enabled": true,
+        "outputs": ["output/docker-compose.yml"],
+        "timeout": 900
+      },
+      "build": {
+        "enabled": true,
+        "compose_file": "output/docker-compose.yml",
+        "timeout": 1800
+      },
+      "runtime": {
+        "enabled": false
+      }
     },
     "basic-a13-exabgp-control-plane": {
       "description": "ExaBGP service plus Binding control-plane speaker example.",
@@ -102,10 +180,22 @@
       "env": {
         "SEED_A13_EXABGP_PORT": "5101"
       },
+      "features": ["exabgp-service"],
+      "tags": ["basic", "exabgp", "service-binding", "docker-compile", "docker-build"],
       "clean": ["output"],
-      "expected": ["output/docker-compose.yml"],
-      "compile": true,
-      "build": true
+      "compile": {
+        "enabled": true,
+        "outputs": ["output/docker-compose.yml"],
+        "timeout": 900
+      },
+      "build": {
+        "enabled": true,
+        "compose_file": "output/docker-compose.yml",
+        "timeout": 1800
+      },
+      "runtime": {
+        "enabled": false
+      }
     },
     "basic-a14-bgp-event-looking-glass": {
       "description": "Looking Glass route-state observer plus separate ExaBGP event dashboard example.",
@@ -115,19 +205,43 @@
         "SEED_A14_LG_PORT": "5002",
         "SEED_A14_EVENT_PORT": "5003"
       },
+      "features": ["looking-glass"],
+      "tags": ["basic", "looking-glass", "exabgp-events", "docker-compile", "docker-build"],
       "clean": ["output"],
-      "expected": ["output/docker-compose.yml"],
-      "compile": true,
-      "build": true
+      "compile": {
+        "enabled": true,
+        "outputs": ["output/docker-compose.yml"],
+        "timeout": 900
+      },
+      "build": {
+        "enabled": true,
+        "compose_file": "output/docker-compose.yml",
+        "timeout": 1800
+      },
+      "runtime": {
+        "enabled": false
+      }
     },
     "internet-b02-mini-internet-with-dns": {
       "description": "Mini Internet with DNS component and local DNS endpoints.",
       "script": "examples/internet/B02_mini_internet_with_dns/mini_internet_with_dns.py",
       "args": ["amd"],
+      "features": ["dns-endpoint"],
+      "tags": ["internet", "dns", "docker-compile", "docker-build"],
       "clean": ["output", "base_internet.bin", "dns_component.bin"],
-      "expected": ["output/docker-compose.yml"],
-      "compile": true,
-      "build": true
+      "compile": {
+        "enabled": true,
+        "outputs": ["output/docker-compose.yml"],
+        "timeout": 900
+      },
+      "build": {
+        "enabled": true,
+        "compose_file": "output/docker-compose.yml",
+        "timeout": 1800
+      },
+      "runtime": {
+        "enabled": false
+      }
     },
     "internet-b30-mini-internet-exabgp-ix": {
       "description": "Internet-scale ExaBGP IX speaker compile coverage.",
@@ -136,10 +250,21 @@
       "env": {
         "SEED_B30_EXABGP_PORT": "5130"
       },
+      "features": ["exabgp-service"],
+      "tags": ["internet", "exabgp", "ix", "docker-compile"],
       "clean": ["output", "base_internet.bin"],
-      "expected": ["output/docker-compose.yml"],
-      "compile": true,
-      "build": false
+      "compile": {
+        "enabled": true,
+        "outputs": ["output/docker-compose.yml"],
+        "timeout": 900
+      },
+      "build": {
+        "enabled": false,
+        "compose_file": "output/docker-compose.yml"
+      },
+      "runtime": {
+        "enabled": false
+      }
     }
   }
 }

--- a/tests/ci/run_ci.py
+++ b/tests/ci/run_ci.py
@@ -6,13 +6,14 @@ import json
 import os
 import re
 import shutil
+import selectors
 import subprocess
 import sys
 import time
 import traceback
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -41,6 +42,40 @@ def _tail(text: str, limit: int = 4000) -> str:
     return text[-limit:]
 
 
+def _example_flag(example: dict[str, Any], key: str) -> bool:
+    value = example.get(key, False)
+    if isinstance(value, dict):
+        return bool(value.get("enabled", False))
+    return bool(value)
+
+
+def _example_timeout(example: dict[str, Any], key: str, default: int) -> int:
+    value = example.get(key, {})
+    if isinstance(value, dict):
+        return int(value.get("timeout", example.get("timeout", default)))
+    if key == "build":
+        return int(example.get("build_timeout", default))
+    return int(example.get("timeout", default))
+
+
+def _example_outputs(example: dict[str, Any]) -> list[str]:
+    compile_config = example.get("compile", {})
+    if isinstance(compile_config, dict):
+        return list(compile_config.get("outputs", example.get("expected", [])))
+    return list(example.get("expected", []))
+
+
+def _example_compose_file(example: dict[str, Any]) -> str:
+    build_config = example.get("build", {})
+    if isinstance(build_config, dict):
+        return str(
+            build_config.get(
+                "compose_file", example.get("compose_file", "output/docker-compose.yml")
+            )
+        )
+    return str(example.get("compose_file", "output/docker-compose.yml"))
+
+
 def load_manifest() -> dict[str, Any]:
     return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
@@ -54,43 +89,64 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[str]:
     unit_groups = manifest.get("unit_groups", {})
     runtime_groups = manifest.get("runtime_groups", {})
     examples = manifest.get("examples", {})
-    required_features = {
-        "ipv4-default",
-        "ipv6-core",
-        "routing-bird-frr",
-        "exabgp-service",
-        "looking-glass",
-        "dns-endpoint",
-        "legacy-guard",
-    }
+    coverage_policy = manifest.get("coverage_policy", {})
+    required_features = set(coverage_policy.get("required_features", []))
     missing = sorted(required_features.difference(features))
     if missing:
         errors.append(f"missing required feature declarations: {', '.join(missing)}")
 
     for feature_id, feature in features.items():
+        evidence = []
         for group_id in feature.get("unit_groups", []):
             if group_id not in unit_groups:
                 errors.append(f"feature {feature_id} references missing unit group {group_id}")
+            else:
+                evidence.append(f"unit:{group_id}")
         for group_id in feature.get("runtime_groups", []):
             if group_id not in runtime_groups:
                 errors.append(f"feature {feature_id} references missing runtime group {group_id}")
+            else:
+                evidence.append(f"runtime:{group_id}")
         for example_id in feature.get("compile_examples", []):
             if example_id not in examples:
-                errors.append(f"feature {feature_id} references missing compile example {example_id}")
+                errors.append(
+                    f"feature {feature_id} references missing compile example {example_id}"
+                )
+            elif not _example_flag(examples[example_id], "compile"):
+                errors.append(f"feature {feature_id} references non-compile example {example_id}")
+            else:
+                evidence.append(f"compile:{example_id}")
         for example_id in feature.get("build_examples", []):
             if example_id not in examples:
-                errors.append(f"feature {feature_id} references missing build example {example_id}")
+                errors.append(
+                    f"feature {feature_id} references missing build example {example_id}"
+                )
+            elif not _example_flag(examples[example_id], "build"):
+                errors.append(f"feature {feature_id} references non-build example {example_id}")
+            else:
+                evidence.append(f"build:{example_id}")
+        if feature.get("status") == "covered" and coverage_policy.get(
+            "covered_requires_evidence", True
+        ):
+            if not evidence:
+                errors.append(f"feature {feature_id} is covered but declares no evidence")
 
     for example_id, example in examples.items():
         script = REPO_ROOT / example.get("script", "")
         if not script.is_file():
             errors.append(f"example {example_id} script does not exist: {_rel(script)}")
-        for expected in example.get("expected", []):
+        for feature_id in example.get("features", []):
+            if feature_id not in features:
+                errors.append(f"example {example_id} references missing feature {feature_id}")
+        for expected in _example_outputs(example):
             if Path(expected).is_absolute():
                 errors.append(f"example {example_id} expected path must be relative: {expected}")
         for clean in example.get("clean", []):
             if Path(clean).is_absolute():
                 errors.append(f"example {example_id} clean path must be relative: {clean}")
+        compose_file = _example_compose_file(example)
+        if Path(compose_file).is_absolute():
+            errors.append(f"example {example_id} compose file must be relative: {compose_file}")
     return errors
 
 
@@ -106,10 +162,24 @@ def feature_coverage(manifest: dict[str, Any]) -> dict[str, Any]:
             "runtime_groups": feature.get("runtime_groups", []),
             "notes": feature.get("notes", ""),
         }
+    examples = {}
+    for example_id, example in sorted(manifest["examples"].items()):
+        examples[example_id] = {
+            "description": example.get("description", ""),
+            "features": example.get("features", []),
+            "tags": example.get("tags", []),
+            "compile": _example_flag(example, "compile"),
+            "build": _example_flag(example, "build"),
+            "runtime": _example_flag(example, "runtime"),
+            "outputs": _example_outputs(example),
+            "compose_file": _example_compose_file(example),
+        }
     return {
         "schema": manifest["schema"],
         "generated_by": "tests/ci/run_ci.py",
+        "coverage_policy": manifest.get("coverage_policy", {}),
         "features": features,
+        "examples": examples,
     }
 
 
@@ -149,7 +219,9 @@ def _write_junit(stage: str, checks: list[dict[str, Any]], path: Path) -> None:
             )
             failure.text = check.get("details", "")
         elif check["status"] == "skipped":
-            skipped_node = ET.SubElement(case, "skipped", {"message": check.get("message", "skipped")})
+            skipped_node = ET.SubElement(
+                case, "skipped", {"message": check.get("message", "skipped")}
+            )
             skipped_node.text = check.get("details", "")
     path.parent.mkdir(parents=True, exist_ok=True)
     ET.ElementTree(suite).write(path, encoding="utf-8", xml_declaration=True)
@@ -166,11 +238,7 @@ def _stage_result(stage: str, checks: list[dict[str, Any]], artifact_dir: Path) 
 
     print(f"[seed-ci] stage={stage} status={summary['status']} artifact_dir={_rel(artifact_dir)}")
     for check in checks:
-        print(
-            "[seed-ci] "
-            f"{check['status']}: {check['name']} "
-            f"log={check.get('log_path', '')}"
-        )
+        print(f"[seed-ci] {check['status']}: {check['name']} log={check.get('log_path', '')}")
         if check["status"] == "failed":
             command = check.get("command")
             if command:
@@ -195,41 +263,78 @@ def _run_command(
     log_path = artifact_dir / "logs" / f"{_slug(name)}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        result = subprocess.run(
-            cmd,
-            cwd=str(cwd),
-            env=env,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
-        )
+        with log_path.open("w", encoding="utf-8") as log:
+            log.write("COMMAND: {}\nCWD: {}\n\n".format(" ".join(cmd), _rel(cwd)))
+            log.flush()
+            process = subprocess.Popen(
+                cmd,
+                cwd=str(cwd),
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=1,
+            )
+            stdout_tail = ""
+            stderr_tail = ""
+            sel = selectors.DefaultSelector()
+            assert process.stdout is not None
+            assert process.stderr is not None
+            sel.register(process.stdout, selectors.EVENT_READ, "stdout")
+            sel.register(process.stderr, selectors.EVENT_READ, "stderr")
+            timed_out = False
+            deadline = None if timeout is None else start + timeout
+            while sel.get_map():
+                if deadline is None:
+                    wait = 1.0
+                else:
+                    wait = max(0.0, min(1.0, deadline - time.monotonic()))
+                    if wait == 0.0:
+                        timed_out = True
+                        process.kill()
+                for key, _ in sel.select(wait):
+                    line = key.fileobj.readline()
+                    if not line:
+                        sel.unregister(key.fileobj)
+                        continue
+                    stream_name = key.data
+                    log.write(f"[{stream_name}] {line}")
+                    if stream_name == "stdout":
+                        stdout_tail = _tail(stdout_tail + line)
+                    else:
+                        stderr_tail = _tail(stderr_tail + line)
+                if timed_out:
+                    break
+            returncode = process.wait()
+            if timed_out:
+                returncode = -1
+            duration = time.monotonic() - start
+            log.write(f"\nEXIT: {returncode}\n")
+            if timed_out:
+                log.write(f"TIMEOUT: {timeout}s\n")
         duration = time.monotonic() - start
-        log_path.write_text(
-            "COMMAND: {}\nCWD: {}\nEXIT: {}\n\nSTDOUT:\n{}\n\nSTDERR:\n{}\n".format(
-                " ".join(cmd),
-                _rel(cwd),
-                result.returncode,
-                result.stdout,
-                result.stderr,
-            ),
-            encoding="utf-8",
-        )
-        status = "passed" if result.returncode == 0 else "failed"
+        status = "passed" if returncode == 0 else "failed"
+        message = "command passed"
+        if timed_out:
+            message = f"command timed out after {timeout}s"
+        elif status == "failed":
+            message = "command failed"
         return {
             "name": name,
             "status": status,
             "command": cmd,
             "cwd": _rel(cwd),
-            "returncode": result.returncode,
+            "returncode": returncode,
             "duration_s": duration,
             "log_path": _rel(log_path),
-            "stdout_tail": _tail(result.stdout),
-            "stderr_tail": _tail(result.stderr),
-            "message": "command failed" if status == "failed" else "command passed",
-            "details": _tail(result.stdout + "\n" + result.stderr),
+            "stdout_tail": stdout_tail,
+            "stderr_tail": stderr_tail,
+            "message": message,
+            "details": _tail(stdout_tail + "\n" + stderr_tail),
         }
-    except Exception as exc:  # pragma: no cover - defensive diagnostics for CI infrastructure failures.
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - defensive diagnostics for CI infrastructure failures.
         duration = time.monotonic() - start
         details = traceback.format_exc()
         log_path.write_text(details, encoding="utf-8")
@@ -263,12 +368,119 @@ def _git_diff_check_command() -> list[str]:
     return ["git", "diff", "--check"]
 
 
+def _docker_compose_command() -> list[str]:
+    docker_compose = subprocess.run(
+        ["docker", "compose", "version"],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if docker_compose.returncode == 0:
+        return ["docker", "compose"]
+    legacy_compose = shutil.which("docker-compose")
+    if legacy_compose:
+        return [legacy_compose]
+    return ["docker", "compose"]
+
+
 def _example_ids(manifest: dict[str, Any], key: str) -> list[str]:
     ids: list[str] = []
     for example_id, example in manifest["examples"].items():
-        if example.get(key):
+        if _example_flag(example, key):
             ids.append(example_id)
     return ids
+
+
+def _selected_unit_group_ids(
+    manifest: dict[str, Any], groups: Sequence[str], features: Sequence[str]
+) -> list[str]:
+    selected = set(groups)
+    for feature_id in features:
+        if feature_id not in manifest["features"]:
+            continue
+        selected.update(manifest["features"][feature_id].get("unit_groups", []))
+    ids = list(manifest["unit_groups"])
+    if selected:
+        ids = [group_id for group_id in ids if group_id in selected]
+    return ids
+
+
+def _selected_runtime_group_ids(
+    manifest: dict[str, Any], groups: Sequence[str], features: Sequence[str]
+) -> list[str]:
+    selected = set(groups)
+    for feature_id in features:
+        if feature_id not in manifest["features"]:
+            continue
+        selected.update(manifest["features"][feature_id].get("runtime_groups", []))
+    ids = list(manifest["runtime_groups"])
+    if selected:
+        ids = [group_id for group_id in ids if group_id in selected]
+    return ids
+
+
+def _selected_example_ids(
+    manifest: dict[str, Any],
+    key: str,
+    examples: Sequence[str],
+    features: Sequence[str],
+) -> list[str]:
+    selected = set(examples)
+    feature_set = set(features)
+    for feature_id in features:
+        if feature_id not in manifest["features"]:
+            continue
+        feature = manifest["features"][feature_id]
+        if key == "compile":
+            selected.update(feature.get("compile_examples", []))
+        elif key == "build":
+            selected.update(feature.get("build_examples", []))
+    ids = _example_ids(manifest, key)
+    if feature_set:
+        ids = [
+            example_id
+            for example_id in ids
+            if example_id in selected
+            or feature_set.intersection(manifest["examples"][example_id].get("features", []))
+        ]
+    elif selected:
+        ids = [example_id for example_id in ids if example_id in selected]
+    return ids
+
+
+def _validate_selectors(
+    manifest: dict[str, Any],
+    *,
+    groups: Sequence[str],
+    features: Sequence[str],
+    examples: Sequence[str],
+) -> list[str]:
+    errors: list[str] = []
+    for feature_id in features:
+        if feature_id not in manifest["features"]:
+            errors.append(f"unknown feature selector: {feature_id}")
+    all_groups = set(manifest.get("unit_groups", {})) | set(manifest.get("runtime_groups", {}))
+    for group_id in groups:
+        if group_id not in all_groups:
+            errors.append(f"unknown group selector: {group_id}")
+    for example_id in examples:
+        if example_id not in manifest["examples"]:
+            errors.append(f"unknown example selector: {example_id}")
+    return errors
+
+
+def _selector_check(errors: list[str]) -> dict[str, Any] | None:
+    if not errors:
+        return None
+    return {
+        "name": "selectors",
+        "status": "failed",
+        "duration_s": 0.0,
+        "message": "selector validation failed",
+        "details": "\n".join(errors),
+        "log_path": "",
+    }
 
 
 def _pythonpath_env(extra: dict[str, str] | None = None) -> dict[str, str]:
@@ -318,12 +530,12 @@ def _compile_example(
         artifact_dir,
         cwd=example_dir,
         env=_pythonpath_env(example.get("env", {})),
-        timeout=int(example.get("timeout", 900)),
+        timeout=_example_timeout(example, "compile", 900),
     )
     if check["status"] != "passed":
         return check
 
-    missing = [item for item in example.get("expected", []) if not (example_dir / item).exists()]
+    missing = [item for item in _example_outputs(example) if not (example_dir / item).exists()]
     if missing:
         check["status"] = "failed"
         check["message"] = "expected compile outputs are missing"
@@ -331,11 +543,34 @@ def _compile_example(
     return check
 
 
-def run_static(artifact_dir: Path) -> int:
+def _import_smoke_code(manifest: dict[str, Any]) -> str:
+    imports = manifest.get("static", {}).get("import_smoke", [])
+    statements: list[str] = []
+    for item in imports:
+        if isinstance(item, str):
+            statements.append(f"import {item}")
+        elif "statement" in item:
+            statements.append(item["statement"])
+        else:
+            module = item["module"]
+            names = ", ".join(item.get("names", []))
+            if names:
+                statements.append(f"from {module} import {names}")
+            else:
+                statements.append(f"import {module}")
+    return "; ".join(statements)
+
+
+def run_static(
+    artifact_dir: Path, *, features: Sequence[str], examples: Sequence[str], groups: Sequence[str]
+) -> int:
     manifest = load_manifest()
     checks: list[dict[str, Any]] = []
 
     errors = _validate_manifest(manifest)
+    errors.extend(
+        _validate_selectors(manifest, groups=groups, features=features, examples=examples)
+    )
     coverage = feature_coverage(manifest)
     _json_dump(artifact_dir / "feature-coverage.json", coverage)
     checks.append(
@@ -351,18 +586,18 @@ def run_static(artifact_dir: Path) -> int:
 
     checks.append(_run_command("whitespace", _git_diff_check_command(), artifact_dir))
 
-    compile_targets = [
-        "seedemu",
-        "tests/control_plane",
-        "tests/ci",
-    ]
+    static_config = manifest.get("static", {})
+    compile_targets = list(static_config.get("compile_targets", ["seedemu", "tests/ci"]))
     example_dirs = sorted(
         {
             str(Path(manifest["examples"][example_id]["script"]).parent)
-            for example_id in _example_ids(manifest, "compile")
+            for example_id in _selected_example_ids(manifest, "compile", examples, features)
         }
     )
     compile_targets.extend(example_dirs)
+    compile_exclude = static_config.get(
+        "compile_exclude", "seedemu/services/EthereumService/EthTemplates/"
+    )
     checks.append(
         _run_command(
             "compileall",
@@ -372,28 +607,35 @@ def run_static(artifact_dir: Path) -> int:
                 "compileall",
                 "-q",
                 "-x",
-                "seedemu/services/EthereumService/EthTemplates/",
+                compile_exclude,
             ]
             + compile_targets,
             artifact_dir,
         )
     )
 
-    smoke = (
-        "import seedemu; "
-        "from seedemu.layers import Base, Routing, Ebgp, Ibgp, Ospf; "
-        "from seedemu.services import ExaBgpService, BgpLookingGlassService; "
-        "from seedemu.compiler import Docker; "
-        "import tests.ci.run_ci"
+    smoke = _import_smoke_code(manifest)
+    checks.append(
+        _run_command(
+            "import-smoke", [sys.executable, "-c", smoke], artifact_dir, env=_pythonpath_env()
+        )
     )
-    checks.append(_run_command("import-smoke", [sys.executable, "-c", smoke], artifact_dir, env=_pythonpath_env()))
     return _stage_result("static", checks, artifact_dir)
 
 
-def run_unit(artifact_dir: Path) -> int:
+def run_unit(
+    artifact_dir: Path, *, features: Sequence[str], groups: Sequence[str], examples: Sequence[str]
+) -> int:
     manifest = load_manifest()
     checks: list[dict[str, Any]] = []
-    for group_id, group in manifest["unit_groups"].items():
+    selector_check = _selector_check(
+        _validate_selectors(manifest, groups=groups, features=features, examples=examples)
+    )
+    if selector_check:
+        checks.append(selector_check)
+        return _stage_result("unit", checks, artifact_dir)
+    for group_id in _selected_unit_group_ids(manifest, groups, features):
+        group = manifest["unit_groups"][group_id]
         junit_path = artifact_dir / f"pytest-{_slug(group_id)}.xml"
         cmd = [
             sys.executable,
@@ -402,23 +644,51 @@ def run_unit(artifact_dir: Path) -> int:
             "-q",
             f"--junitxml={junit_path}",
         ] + list(group["pytest_args"])
-        checks.append(_run_command(f"pytest:{group_id}", cmd, artifact_dir, env=_pytest_env(), timeout=900))
+        checks.append(
+            _run_command(f"pytest:{group_id}", cmd, artifact_dir, env=_pytest_env(), timeout=900)
+        )
     return _stage_result("unit", checks, artifact_dir)
 
 
-def run_example_compile(artifact_dir: Path) -> int:
+def run_example_compile(
+    artifact_dir: Path, *, features: Sequence[str], examples: Sequence[str], groups: Sequence[str]
+) -> int:
     manifest = load_manifest()
+    selector_check = _selector_check(
+        _validate_selectors(manifest, groups=groups, features=features, examples=examples)
+    )
+    if selector_check:
+        return _stage_result("example-compile", [selector_check], artifact_dir)
     checks = [
         _compile_example(example_id, manifest["examples"][example_id], artifact_dir, clean=True)
-        for example_id in _example_ids(manifest, "compile")
+        for example_id in _selected_example_ids(manifest, "compile", examples, features)
     ]
     return _stage_result("example-compile", checks, artifact_dir)
 
 
-def run_example_build(artifact_dir: Path) -> int:
+def _missing_compose_check(example_id: str, compose_file: Path) -> dict[str, Any]:
+    return {
+        "name": f"compose:{example_id}",
+        "status": "failed",
+        "duration_s": 0.0,
+        "message": "compose file is missing before docker build",
+        "details": f"Missing compose file: {_rel(compose_file)}",
+        "log_path": "",
+    }
+
+
+def run_example_build(
+    artifact_dir: Path, *, features: Sequence[str], examples: Sequence[str], groups: Sequence[str]
+) -> int:
     manifest = load_manifest()
     checks: list[dict[str, Any]] = []
-    for example_id in _example_ids(manifest, "build"):
+    selector_check = _selector_check(
+        _validate_selectors(manifest, groups=groups, features=features, examples=examples)
+    )
+    if selector_check:
+        checks.append(selector_check)
+        return _stage_result("example-build", checks, artifact_dir)
+    for example_id in _selected_example_ids(manifest, "build", examples, features):
         example = manifest["examples"][example_id]
         compile_check = _compile_example(
             example_id,
@@ -432,23 +702,35 @@ def run_example_build(artifact_dir: Path) -> int:
             continue
 
         script = REPO_ROOT / example["script"]
-        compose_file = script.parent / "output" / "docker-compose.yml"
+        compose_file = script.parent / _example_compose_file(example)
+        if not compose_file.is_file():
+            checks.append(_missing_compose_check(example_id, compose_file))
+            continue
         checks.append(
             _run_command(
                 f"docker-build:{example_id}",
-                ["docker", "compose", "-f", str(compose_file), "build"],
+                _docker_compose_command() + ["-f", str(compose_file), "build"],
                 artifact_dir,
                 env=_pythonpath_env(example.get("env", {})),
-                timeout=int(example.get("build_timeout", 1800)),
+                timeout=_example_timeout(example, "build", 1800),
             )
         )
     return _stage_result("example-build", checks, artifact_dir)
 
 
-def run_runtime_integration(artifact_dir: Path) -> int:
+def run_runtime_integration(
+    artifact_dir: Path, *, features: Sequence[str], groups: Sequence[str], examples: Sequence[str]
+) -> int:
     manifest = load_manifest()
     checks: list[dict[str, Any]] = []
-    for group_id, group in manifest["runtime_groups"].items():
+    selector_check = _selector_check(
+        _validate_selectors(manifest, groups=groups, features=features, examples=examples)
+    )
+    if selector_check:
+        checks.append(selector_check)
+        return _stage_result("runtime-integration", checks, artifact_dir)
+    for group_id in _selected_runtime_group_ids(manifest, groups, features):
+        group = manifest["runtime_groups"][group_id]
         junit_path = artifact_dir / f"pytest-{_slug(group_id)}.xml"
         cmd = [
             sys.executable,
@@ -457,7 +739,9 @@ def run_runtime_integration(artifact_dir: Path) -> int:
             "-q",
             f"--junitxml={junit_path}",
         ] + list(group["pytest_args"])
-        checks.append(_run_command(f"runtime:{group_id}", cmd, artifact_dir, env=_pytest_env(), timeout=7200))
+        checks.append(
+            _run_command(f"runtime:{group_id}", cmd, artifact_dir, env=_pytest_env(), timeout=7200)
+        )
     return _stage_result("runtime-integration", checks, artifact_dir)
 
 
@@ -467,7 +751,20 @@ def parse_args() -> argparse.Namespace:
         "stage",
         choices=["static", "unit", "example-compile", "example-build", "runtime-integration"],
     )
-    parser.add_argument("--artifact-dir", default="ci-artifacts", help="Directory for logs, JSON, and JUnit output.")
+    parser.add_argument(
+        "--artifact-dir",
+        default="ci-artifacts",
+        help="Directory for logs, JSON, and JUnit output.",
+    )
+    parser.add_argument(
+        "--feature", action="append", default=[], help="Only run evidence linked to this feature."
+    )
+    parser.add_argument(
+        "--example", action="append", default=[], help="Only run this example evidence."
+    )
+    parser.add_argument(
+        "--group", action="append", default=[], help="Only run this unit or runtime group."
+    )
     return parser.parse_args()
 
 
@@ -476,15 +773,25 @@ def main() -> int:
     artifact_dir = (REPO_ROOT / args.artifact_dir).resolve()
     artifact_dir.mkdir(parents=True, exist_ok=True)
     if args.stage == "static":
-        return run_static(artifact_dir)
+        return run_static(
+            artifact_dir, features=args.feature, examples=args.example, groups=args.group
+        )
     if args.stage == "unit":
-        return run_unit(artifact_dir)
+        return run_unit(
+            artifact_dir, features=args.feature, groups=args.group, examples=args.example
+        )
     if args.stage == "example-compile":
-        return run_example_compile(artifact_dir)
+        return run_example_compile(
+            artifact_dir, features=args.feature, examples=args.example, groups=args.group
+        )
     if args.stage == "example-build":
-        return run_example_build(artifact_dir)
+        return run_example_build(
+            artifact_dir, features=args.feature, examples=args.example, groups=args.group
+        )
     if args.stage == "runtime-integration":
-        return run_runtime_integration(artifact_dir)
+        return run_runtime_integration(
+            artifact_dir, features=args.feature, groups=args.group, examples=args.example
+        )
     raise AssertionError(f"unknown stage: {args.stage}")
 
 


### PR DESCRIPTION
## Summary

This PR tightens the next-generation CI runner around an example-first evidence model. The manifest now declares the feature coverage policy, import smoke surface, example outputs, compose files, tags, and feature links; the Python runner executes that declaration instead of hard-coding project feature policy or assuming a fixed example layout.

The intent is to make examples a reusable evidence unit for both agents and GitHub Actions. Agents can now run only the feature, example, or group evidence they need, while the default PR workflow keeps the lightweight gates focused on static checks, unit checks, and representative example compilation.

## Key Changes

- Move required feature policy and static import smoke declarations into `tests/ci/feature_manifest.json`.
- Expand example declarations with `features`, `tags`, `compile`, `build`, and `runtime` evidence metadata.
- Add `--feature`, `--example`, and `--group` selectors to `tests/ci/run_ci.py` for targeted agent and reviewer checks.
- Stream command output directly into per-check logs instead of buffering large Docker output in memory.
- Resolve build compose files from the manifest and fail clearly if the selected compose file is missing.
- Prefer `docker compose` but fall back to `docker-compose` for local agent environments.
- Add CI runner unit tests for selector behavior, covered-feature evidence validation, streamed logging, and compose command fallback.
- Add job-level timeouts to the pull-request workflow.
- Update `tests/ci/README.md` with the example-first CI and agent contract.

## Scope and Boundaries

This PR only changes the CI and agent evidence architecture. It does not change SEED core, routing semantics, control-plane APIs, Docker compiler behavior, or IPv4/IPv6 runtime behavior.

The `ipv6-core` feature remains a `declared-gap` in this integration-line manifest. It is intentionally not marked as covered here until the IPv6 readiness examples and probes are merged into this line.

## Validation

Passed locally:

- `/tmp/seedemu-example-ci-venv/bin/python -m py_compile tests/ci/run_ci.py test_ci_runner.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/seedemu-example-ci-venv/bin/python -m pytest -q test_ci_runner.py`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py static --artifact-dir ci-artifacts/static-current`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py unit --group ci-runner-unit --artifact-dir ci-artifacts/unit-ci-runner-current`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py example-compile --artifact-dir ci-artifacts/example-compile-current`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py example-compile --feature routing-bird-frr --artifact-dir ci-artifacts/example-routing-current`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py example-compile --example basic-a00-simple-as --artifact-dir ci-artifacts/example-a00-current`
- `git diff --check origin/development2..HEAD`

## Known Local Limitations

The local machine only has Python 3.12, while GitHub Actions uses Python 3.10. A full local `unit` stage is blocked by the existing legacy `tests/__init__.py -> ethereum -> web3/parsimonious` import chain because `parsimonious` uses `inspect.getargspec`, which was removed in Python 3.12. The new `ci-runner-unit` group passes and avoids that legacy package side effect.

The optional Docker-heavy `example-build` path was not used as a default gate for this PR. In earlier local probing, the runner reached the manifest-selected compose file and selected the compose command correctly, but Docker Hub registry access failed locally with connection reset or timeout errors.