### PR TITLE
Add runtime evidence manifests for CI probes

### DIFF
--- a/test_ci_runner.py
+++ b/test_ci_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -22,6 +23,20 @@ def test_feature_selector_uses_manifest_examples() -> None:
     ]
     assert run_ci._selected_example_ids(manifest, "compile", ["basic-a00-simple-as"], []) == [
         "basic-a00-simple-as"
+    ]
+
+
+def test_runtime_probe_selector_uses_manifest_features_and_examples() -> None:
+    manifest = run_ci.load_manifest()
+
+    assert run_ci._selected_runtime_probe_ids(manifest, [], ["looking-glass"], []) == [
+        "a14-looking-glass"
+    ]
+    assert run_ci._selected_runtime_probe_ids(
+        manifest, [], [], ["basic-a13-exabgp-control-plane"]
+    ) == ["a13-exabgp-service"]
+    assert run_ci._selected_example_ids(manifest, "runtime", [], ["routing-bird-frr"]) == [
+        "basic-a12-bgp-mixed-backend"
     ]
 
 
@@ -53,6 +68,35 @@ def test_run_command_streams_output_to_log(tmp_path) -> None:
     assert check["status"] == "passed"
     log_path = run_ci.REPO_ROOT / check["log_path"]
     assert "[stdout] hello from stdout" in log_path.read_text(encoding="utf-8")
+
+
+def test_stage_result_writes_ai_ready_artifacts(tmp_path) -> None:
+    result = run_ci._stage_result(
+        "unit",
+        [
+            {
+                "name": "failing-check",
+                "status": "failed",
+                "duration_s": 0.0,
+                "message": "intentional failure",
+                "details": "failure details",
+                "features": ["example-feature"],
+                "examples": ["example-id"],
+                "command": ["false"],
+                "log_path": "logs/failing-check.log",
+            }
+        ],
+        tmp_path,
+    )
+
+    assert result == 1
+    failure_summary = json.loads((tmp_path / "failure-summary.json").read_text())
+    assert failure_summary["failed_count"] == 1
+    assert failure_summary["failures"][0]["features"] == ["example-feature"]
+
+    artifact_manifest = json.loads((tmp_path / "artifact-manifest.json").read_text())
+    kinds = {artifact["kind"] for artifact in artifact_manifest["artifacts"]}
+    assert {"stage-summary", "junit", "failure-summary", "artifact-manifest"}.issubset(kinds)
 
 
 def test_docker_compose_command_falls_back_to_legacy_binary(monkeypatch) -> None:

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -4,7 +4,7 @@ The pull-request workflow is organized around feature evidence, with examples as
 the primary reusable test unit for both agents and GitHub Actions. The manifest
 in `feature_manifest.json` is the source of truth for feature coverage, example
 compile outputs, Docker compose files, import smoke checks, and selected runtime
-groups.
+groups and probes.
 
 The runner executes the manifest. It should not hard-code the project feature
 set, import smoke surface, or compose output layout.
@@ -18,7 +18,11 @@ Every stage writes human-readable logs and machine-readable evidence:
 - `junit.xml` records the same stage in a format GitHub and review tooling can
   ingest.
 - `feature-coverage.json` records manifest-derived feature and example evidence,
-  including declared gaps.
+  including declared gaps and runtime probes.
+- `failure-summary.json` records failed and skipped checks with feature/example
+  labels, command lines, log paths, and a short failure tail.
+- `artifact-manifest.json` indexes the files emitted by the stage, including
+  summaries, JUnit files, logs, and feature coverage.
 - `logs/*.log` contains streamed command output, so large Docker build/runtime
   logs do not have to be kept in memory.
 
@@ -39,6 +43,8 @@ example, or test group:
 python3 tests/ci/run_ci.py example-compile --feature routing-bird-frr --artifact-dir ci-artifacts/example-routing
 python3 tests/ci/run_ci.py example-compile --example basic-a00-simple-as --artifact-dir ci-artifacts/example-a00
 python3 tests/ci/run_ci.py unit --group control-plane-unit --artifact-dir ci-artifacts/unit-control-plane
+python3 tests/ci/run_ci.py runtime-integration --feature exabgp-service --artifact-dir ci-artifacts/runtime-exabgp
+python3 tests/ci/run_ci.py runtime-integration --example basic-a14-bgp-event-looking-glass --artifact-dir ci-artifacts/runtime-a14
 ```
 
 Docker image builds and runtime integration are explicit entry points. They are
@@ -50,6 +56,13 @@ python3 tests/ci/run_ci.py example-build --artifact-dir ci-artifacts/example-bui
 python3 tests/ci/run_ci.py runtime-integration --artifact-dir ci-artifacts/runtime-integration
 ```
 
+Runtime integration uses `runtime_probes` when the manifest declares them. A
+probe binds one pytest node to the feature ids, examples, evidence statements,
+and runtime group that it validates. This lets agents run a single high-value
+runtime check without executing the entire integration group. Selecting a
+feature or example with no runtime probe records a skipped check instead of
+silently falling back to unrelated runtime coverage.
+
 ## Manifest Contract
 
 `coverage_policy.required_features` declares the feature ids that must be
@@ -57,9 +70,10 @@ tracked by this integration line. Adding or removing a required feature is a
 manifest change, not a Python runner change.
 
 Each `covered` feature must declare at least one evidence source: a unit group,
-compile example, build example, or runtime group. Use `declared-gap` for work
-that is intentionally tracked but not yet covered by this line. Do not mark a
-feature `covered` until its evidence is present and runnable.
+compile example, build example, runtime group, or runtime probe. Use
+`declared-gap` for work that is intentionally tracked but not yet covered by
+this line. Do not mark a feature `covered` until its evidence is present and
+runnable.
 
 Each example declares:
 
@@ -67,7 +81,14 @@ Each example declares:
 - `features` and `tags` for agent/reviewer discovery.
 - `compile.enabled` and `compile.outputs` for generated-file evidence.
 - `build.enabled` and `build.compose_file` for Docker build evidence.
-- `runtime.enabled` for future runtime probe wiring.
+- `runtime.enabled` and `runtime.probes` for runtime evidence wiring.
+
+Each runtime probe declares:
+
+- `group` for workflow-dispatch and timeout ownership.
+- `features` and `examples` for selector matching.
+- `pytest_args` for the exact pytest node to run.
+- `evidence` for the human/AI-readable runtime assertions covered by the probe.
 
 The static stage compiles importable Python source plus the selected example
 directories. It intentionally excludes embedded payload templates under

--- a/tests/ci/feature_manifest.json
+++ b/tests/ci/feature_manifest.json
@@ -74,7 +74,8 @@
       "unit_groups": ["control-plane-unit"],
       "compile_examples": ["basic-a12-bgp-mixed-backend"],
       "build_examples": ["basic-a12-bgp-mixed-backend"],
-      "runtime_groups": ["control-plane-runtime"]
+      "runtime_groups": ["control-plane-runtime"],
+      "runtime_probes": ["a12-mixed-backend", "exabgp-to-frr-peer"]
     },
     "exabgp-service": {
       "status": "covered",
@@ -85,7 +86,8 @@
         "internet-b30-mini-internet-exabgp-ix"
       ],
       "build_examples": ["basic-a13-exabgp-control-plane"],
-      "runtime_groups": ["control-plane-runtime"]
+      "runtime_groups": ["control-plane-runtime"],
+      "runtime_probes": ["a13-exabgp-service", "exabgp-to-frr-peer", "b30-exabgp-ix"]
     },
     "looking-glass": {
       "status": "covered",
@@ -93,7 +95,8 @@
       "unit_groups": ["control-plane-unit"],
       "compile_examples": ["basic-a14-bgp-event-looking-glass"],
       "build_examples": ["basic-a14-bgp-event-looking-glass"],
-      "runtime_groups": ["control-plane-runtime"]
+      "runtime_groups": ["control-plane-runtime"],
+      "runtime_probes": ["a14-looking-glass"]
     },
     "dns-endpoint": {
       "status": "covered",
@@ -127,7 +130,84 @@
       "description": "Docker runtime probes for selected BIRD/FRR, ExaBGP, and Looking Glass examples.",
       "pytest_args": ["-m", "integration", "tests/control_plane/test_bgp_runtime_matrix.py"],
       "default": false,
-      "notes": "Manual workflow-dispatch entry for this PR. PR3 will make runtime evidence richer and artifact-indexed."
+      "notes": "Manual workflow-dispatch entry. Individual probes are declared in runtime_probes for feature/example-level evidence."
+    }
+  },
+  "runtime_probes": {
+    "a12-mixed-backend": {
+      "description": "A12 fresh build plus BIRD/FRR runtime convergence.",
+      "group": "control-plane-runtime",
+      "features": ["routing-bird-frr"],
+      "examples": ["basic-a12-bgp-mixed-backend"],
+      "pytest_args": [
+        "tests/control_plane/test_bgp_runtime_matrix.py::test_runtime_a12_mixed_backend_fresh_build"
+      ],
+      "evidence": [
+        "FRR OSPF neighbor reaches Full",
+        "FRR BGP summary sees the BIRD peer",
+        "host and router IPv4 reachability converges",
+        "BIRD route attributes include expected large community",
+        "Internet map HTTP endpoint is reachable"
+      ]
+    },
+    "a13-exabgp-service": {
+      "description": "A13 ExaBgpService plus Binding runtime speaker.",
+      "group": "control-plane-runtime",
+      "features": ["exabgp-service"],
+      "examples": ["basic-a13-exabgp-control-plane"],
+      "pytest_args": [
+        "tests/control_plane/test_bgp_runtime_matrix.py::test_runtime_a13_exabgp_fresh_build"
+      ],
+      "evidence": [
+        "ExaBGP dashboard HTTP endpoint is reachable",
+        "ExaBGP, dashboard, and event sink processes are running",
+        "BIRD peer learns the static ExaBGP announcement"
+      ]
+    },
+    "a14-looking-glass": {
+      "description": "A14 route-state Looking Glass plus separate ExaBGP event dashboard.",
+      "group": "control-plane-runtime",
+      "features": ["looking-glass"],
+      "examples": ["basic-a14-bgp-event-looking-glass"],
+      "pytest_args": [
+        "tests/control_plane/test_bgp_runtime_matrix.py::test_runtime_a14_observability_fresh_build"
+      ],
+      "evidence": [
+        "Looking Glass route-state endpoint is reachable",
+        "ExaBGP event dashboard endpoint is reachable",
+        "Looking Glass frontend/proxy processes are running",
+        "Looking Glass host reaches the observed router"
+      ]
+    },
+    "exabgp-to-frr-peer": {
+      "description": "Synthetic ExaBgpService speaker peering with an FRR router.",
+      "group": "control-plane-runtime",
+      "features": ["routing-bird-frr", "exabgp-service"],
+      "examples": [],
+      "pytest_args": [
+        "tests/control_plane/test_bgp_runtime_matrix.py::test_runtime_exabgp_to_frr_peer"
+      ],
+      "evidence": [
+        "ExaBGP dashboard HTTP endpoint is reachable",
+        "FRR BGP summary reaches Established for the ExaBGP peer",
+        "FRR installs the ExaBGP static announcement"
+      ]
+    },
+    "b30-exabgp-ix": {
+      "description": "B30 mini Internet ExaBGP IX speaker runtime.",
+      "group": "control-plane-runtime",
+      "features": ["exabgp-service"],
+      "examples": ["internet-b30-mini-internet-exabgp-ix"],
+      "pytest_args": [
+        "tests/control_plane/test_bgp_runtime_matrix.py::test_runtime_b30_mini_internet_exabgp_ix_fresh_build"
+      ],
+      "evidence": [
+        "ExaBGP IX dashboard HTTP endpoint is reachable",
+        "external speaker container runs ExaBGP, dashboard, and event sink",
+        "ExaBGP config declares both IX peers and static announcement",
+        "both BIRD peers learn the IX tool route",
+        "ExaBGP event log is readable"
+      ]
     }
   },
   "examples": {
@@ -170,7 +250,8 @@
         "timeout": 1800
       },
       "runtime": {
-        "enabled": false
+        "enabled": true,
+        "probes": ["a12-mixed-backend"]
       }
     },
     "basic-a13-exabgp-control-plane": {
@@ -194,7 +275,8 @@
         "timeout": 1800
       },
       "runtime": {
-        "enabled": false
+        "enabled": true,
+        "probes": ["a13-exabgp-service"]
       }
     },
     "basic-a14-bgp-event-looking-glass": {
@@ -219,7 +301,8 @@
         "timeout": 1800
       },
       "runtime": {
-        "enabled": false
+        "enabled": true,
+        "probes": ["a14-looking-glass"]
       }
     },
     "internet-b02-mini-internet-with-dns": {
@@ -263,7 +346,8 @@
         "compose_file": "output/docker-compose.yml"
       },
       "runtime": {
-        "enabled": false
+        "enabled": true,
+        "probes": ["b30-exabgp-ix"]
       }
     }
   }

--- a/tests/ci/run_ci.py
+++ b/tests/ci/run_ci.py
@@ -36,6 +36,86 @@ def _json_dump(path: Path, data: Any) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _artifact_kind(path: Path) -> str:
+    if path.name == "ci-summary.json":
+        return "stage-summary"
+    if path.name == "feature-coverage.json":
+        return "feature-coverage"
+    if path.name == "failure-summary.json":
+        return "failure-summary"
+    if path.name == "artifact-manifest.json":
+        return "artifact-manifest"
+    if path.name == "junit.xml" or path.name.startswith("pytest-") and path.suffix == ".xml":
+        return "junit"
+    if path.parent.name == "logs":
+        return "command-log"
+    return "artifact"
+
+
+def _write_artifact_manifest(stage: str, artifact_dir: Path) -> None:
+    manifest_path = artifact_dir / "artifact-manifest.json"
+    artifacts = []
+    for path in sorted(artifact_dir.rglob("*")):
+        if not path.is_file() or path == manifest_path:
+            continue
+        artifacts.append(
+            {
+                "path": _rel(path),
+                "kind": _artifact_kind(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+
+    artifacts.append(
+        {
+            "path": _rel(manifest_path),
+            "kind": "artifact-manifest",
+            "size_bytes": None,
+        }
+    )
+    manifest = {
+        "schema": 1,
+        "stage": stage,
+        "generated_by": "tests/ci/run_ci.py",
+        "artifacts": artifacts,
+    }
+    _json_dump(manifest_path, manifest)
+    artifacts[-1]["size_bytes"] = manifest_path.stat().st_size
+    _json_dump(manifest_path, manifest)
+
+
+def _write_failure_summary(stage: str, checks: list[dict[str, Any]], artifact_dir: Path) -> None:
+    failures = []
+    skipped = []
+    for check in checks:
+        entry = {
+            "name": check["name"],
+            "message": check.get("message", ""),
+            "log_path": check.get("log_path", ""),
+            "features": check.get("features", []),
+            "examples": check.get("examples", []),
+            "command": check.get("command", []),
+        }
+        if check["status"] == "failed":
+            entry["details_tail"] = _tail(check.get("details", ""), limit=1200)
+            failures.append(entry)
+        elif check["status"] == "skipped":
+            skipped.append(entry)
+
+    _json_dump(
+        artifact_dir / "failure-summary.json",
+        {
+            "schema": 1,
+            "stage": stage,
+            "status": "failed" if failures else "passed",
+            "failed_count": len(failures),
+            "skipped_count": len(skipped),
+            "failures": failures,
+            "skipped": skipped,
+        },
+    )
+
+
 def _tail(text: str, limit: int = 4000) -> str:
     if len(text) <= limit:
         return text
@@ -65,6 +145,13 @@ def _example_outputs(example: dict[str, Any]) -> list[str]:
     return list(example.get("expected", []))
 
 
+def _example_runtime_probes(example: dict[str, Any]) -> list[str]:
+    runtime_config = example.get("runtime", {})
+    if isinstance(runtime_config, dict):
+        return list(runtime_config.get("probes", []))
+    return []
+
+
 def _example_compose_file(example: dict[str, Any]) -> str:
     build_config = example.get("build", {})
     if isinstance(build_config, dict):
@@ -88,6 +175,7 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[str]:
     features = manifest.get("features", {})
     unit_groups = manifest.get("unit_groups", {})
     runtime_groups = manifest.get("runtime_groups", {})
+    runtime_probes = manifest.get("runtime_probes", {})
     examples = manifest.get("examples", {})
     coverage_policy = manifest.get("coverage_policy", {})
     required_features = set(coverage_policy.get("required_features", []))
@@ -107,6 +195,16 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[str]:
                 errors.append(f"feature {feature_id} references missing runtime group {group_id}")
             else:
                 evidence.append(f"runtime:{group_id}")
+        for probe_id in feature.get("runtime_probes", []):
+            if probe_id not in runtime_probes:
+                errors.append(f"feature {feature_id} references missing runtime probe {probe_id}")
+            elif feature_id not in runtime_probes[probe_id].get("features", []):
+                errors.append(
+                    f"feature {feature_id} references runtime probe {probe_id} "
+                    "that does not link back to the feature"
+                )
+            else:
+                evidence.append(f"runtime-probe:{probe_id}")
         for example_id in feature.get("compile_examples", []):
             if example_id not in examples:
                 errors.append(
@@ -138,6 +236,14 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[str]:
         for feature_id in example.get("features", []):
             if feature_id not in features:
                 errors.append(f"example {example_id} references missing feature {feature_id}")
+        for probe_id in _example_runtime_probes(example):
+            if probe_id not in runtime_probes:
+                errors.append(f"example {example_id} references missing runtime probe {probe_id}")
+            elif example_id not in runtime_probes[probe_id].get("examples", []):
+                errors.append(
+                    f"example {example_id} references runtime probe {probe_id} "
+                    "that does not link back to the example"
+                )
         for expected in _example_outputs(example):
             if Path(expected).is_absolute():
                 errors.append(f"example {example_id} expected path must be relative: {expected}")
@@ -147,6 +253,23 @@ def _validate_manifest(manifest: dict[str, Any]) -> list[str]:
         compose_file = _example_compose_file(example)
         if Path(compose_file).is_absolute():
             errors.append(f"example {example_id} compose file must be relative: {compose_file}")
+
+    for probe_id, probe in runtime_probes.items():
+        group_id = probe.get("group")
+        if group_id not in runtime_groups:
+            errors.append(f"runtime probe {probe_id} references missing group {group_id}")
+        if not probe.get("pytest_args"):
+            errors.append(f"runtime probe {probe_id} must declare pytest_args")
+        for feature_id in probe.get("features", []):
+            if feature_id not in features:
+                errors.append(f"runtime probe {probe_id} references missing feature {feature_id}")
+        for example_id in probe.get("examples", []):
+            if example_id not in examples:
+                errors.append(f"runtime probe {probe_id} references missing example {example_id}")
+            elif not _example_flag(examples[example_id], "runtime"):
+                errors.append(
+                    f"runtime probe {probe_id} references runtime-disabled example {example_id}"
+                )
     return errors
 
 
@@ -160,6 +283,7 @@ def feature_coverage(manifest: dict[str, Any]) -> dict[str, Any]:
             "compile_examples": feature.get("compile_examples", []),
             "build_examples": feature.get("build_examples", []),
             "runtime_groups": feature.get("runtime_groups", []),
+            "runtime_probes": feature.get("runtime_probes", []),
             "notes": feature.get("notes", ""),
         }
     examples = {}
@@ -171,8 +295,19 @@ def feature_coverage(manifest: dict[str, Any]) -> dict[str, Any]:
             "compile": _example_flag(example, "compile"),
             "build": _example_flag(example, "build"),
             "runtime": _example_flag(example, "runtime"),
+            "runtime_probes": _example_runtime_probes(example),
             "outputs": _example_outputs(example),
             "compose_file": _example_compose_file(example),
+        }
+    runtime_probes = {}
+    for probe_id, probe in sorted(manifest.get("runtime_probes", {}).items()):
+        runtime_probes[probe_id] = {
+            "description": probe.get("description", ""),
+            "group": probe.get("group", ""),
+            "features": probe.get("features", []),
+            "examples": probe.get("examples", []),
+            "pytest_args": probe.get("pytest_args", []),
+            "evidence": probe.get("evidence", []),
         }
     return {
         "schema": manifest["schema"],
@@ -180,7 +315,12 @@ def feature_coverage(manifest: dict[str, Any]) -> dict[str, Any]:
         "coverage_policy": manifest.get("coverage_policy", {}),
         "features": features,
         "examples": examples,
+        "runtime_probes": runtime_probes,
     }
+
+
+def _write_feature_coverage(manifest: dict[str, Any], artifact_dir: Path) -> None:
+    _json_dump(artifact_dir / "feature-coverage.json", feature_coverage(manifest))
 
 
 def _write_junit(stage: str, checks: list[dict[str, Any]], path: Path) -> None:
@@ -235,6 +375,8 @@ def _stage_result(stage: str, checks: list[dict[str, Any]], artifact_dir: Path) 
     }
     _json_dump(artifact_dir / "ci-summary.json", summary)
     _write_junit(stage, checks, artifact_dir / "junit.xml")
+    _write_failure_summary(stage, checks, artifact_dir)
+    _write_artifact_manifest(stage, artifact_dir)
 
     print(f"[seed-ci] stage={stage} status={summary['status']} artifact_dir={_rel(artifact_dir)}")
     for check in checks:
@@ -420,6 +562,30 @@ def _selected_runtime_group_ids(
     return ids
 
 
+def _selected_runtime_probe_ids(
+    manifest: dict[str, Any],
+    groups: Sequence[str],
+    features: Sequence[str],
+    examples: Sequence[str],
+) -> list[str]:
+    group_filter = set(groups)
+    feature_filter = set(features)
+    example_filter = set(examples)
+    selected: list[str] = []
+    for probe_id, probe in manifest.get("runtime_probes", {}).items():
+        if group_filter and probe.get("group") not in group_filter:
+            continue
+        if feature_filter or example_filter:
+            probe_features = set(probe.get("features", []))
+            probe_examples = set(probe.get("examples", []))
+            if feature_filter.isdisjoint(probe_features) and example_filter.isdisjoint(
+                probe_examples
+            ):
+                continue
+        selected.append(probe_id)
+    return selected
+
+
 def _selected_example_ids(
     manifest: dict[str, Any],
     key: str,
@@ -436,6 +602,11 @@ def _selected_example_ids(
             selected.update(feature.get("compile_examples", []))
         elif key == "build":
             selected.update(feature.get("build_examples", []))
+        elif key == "runtime":
+            for probe_id in feature.get("runtime_probes", []):
+                selected.update(
+                    manifest.get("runtime_probes", {}).get(probe_id, {}).get("examples", [])
+                )
     ids = _example_ids(manifest, key)
     if feature_set:
         ids = [
@@ -479,6 +650,28 @@ def _selector_check(errors: list[str]) -> dict[str, Any] | None:
         "duration_s": 0.0,
         "message": "selector validation failed",
         "details": "\n".join(errors),
+        "log_path": "",
+    }
+
+
+def _runtime_no_probe_check(
+    *, features: Sequence[str], examples: Sequence[str], groups: Sequence[str]
+) -> dict[str, Any]:
+    return {
+        "name": "runtime-probe-selection",
+        "status": "skipped",
+        "duration_s": 0.0,
+        "message": "no runtime probe matches the selected feature/example/group",
+        "details": json.dumps(
+            {
+                "features": list(features),
+                "examples": list(examples),
+                "groups": list(groups),
+            },
+            sort_keys=True,
+        ),
+        "features": list(features),
+        "examples": list(examples),
         "log_path": "",
     }
 
@@ -571,8 +764,7 @@ def run_static(
     errors.extend(
         _validate_selectors(manifest, groups=groups, features=features, examples=examples)
     )
-    coverage = feature_coverage(manifest)
-    _json_dump(artifact_dir / "feature-coverage.json", coverage)
+    _write_feature_coverage(manifest, artifact_dir)
     checks.append(
         {
             "name": "manifest",
@@ -627,6 +819,7 @@ def run_unit(
     artifact_dir: Path, *, features: Sequence[str], groups: Sequence[str], examples: Sequence[str]
 ) -> int:
     manifest = load_manifest()
+    _write_feature_coverage(manifest, artifact_dir)
     checks: list[dict[str, Any]] = []
     selector_check = _selector_check(
         _validate_selectors(manifest, groups=groups, features=features, examples=examples)
@@ -654,6 +847,7 @@ def run_example_compile(
     artifact_dir: Path, *, features: Sequence[str], examples: Sequence[str], groups: Sequence[str]
 ) -> int:
     manifest = load_manifest()
+    _write_feature_coverage(manifest, artifact_dir)
     selector_check = _selector_check(
         _validate_selectors(manifest, groups=groups, features=features, examples=examples)
     )
@@ -681,6 +875,7 @@ def run_example_build(
     artifact_dir: Path, *, features: Sequence[str], examples: Sequence[str], groups: Sequence[str]
 ) -> int:
     manifest = load_manifest()
+    _write_feature_coverage(manifest, artifact_dir)
     checks: list[dict[str, Any]] = []
     selector_check = _selector_check(
         _validate_selectors(manifest, groups=groups, features=features, examples=examples)
@@ -722,6 +917,7 @@ def run_runtime_integration(
     artifact_dir: Path, *, features: Sequence[str], groups: Sequence[str], examples: Sequence[str]
 ) -> int:
     manifest = load_manifest()
+    _write_feature_coverage(manifest, artifact_dir)
     checks: list[dict[str, Any]] = []
     selector_check = _selector_check(
         _validate_selectors(manifest, groups=groups, features=features, examples=examples)
@@ -729,6 +925,37 @@ def run_runtime_integration(
     if selector_check:
         checks.append(selector_check)
         return _stage_result("runtime-integration", checks, artifact_dir)
+
+    probe_ids = _selected_runtime_probe_ids(manifest, groups, features, examples)
+    for probe_id in probe_ids:
+        probe = manifest["runtime_probes"][probe_id]
+        junit_path = artifact_dir / f"pytest-{_slug(probe_id)}.xml"
+        group = manifest["runtime_groups"][probe["group"]]
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            f"--junitxml={junit_path}",
+        ] + list(probe["pytest_args"])
+        check = _run_command(
+            f"runtime-probe:{probe_id}",
+            cmd,
+            artifact_dir,
+            env=_pytest_env(),
+            timeout=int(probe.get("timeout", group.get("timeout", 7200))),
+        )
+        check["features"] = probe.get("features", [])
+        check["examples"] = probe.get("examples", [])
+        checks.append(check)
+    if checks:
+        return _stage_result("runtime-integration", checks, artifact_dir)
+    if features or examples:
+        checks.append(
+            _runtime_no_probe_check(features=features, examples=examples, groups=groups)
+        )
+        return _stage_result("runtime-integration", checks, artifact_dir)
+
     for group_id in _selected_runtime_group_ids(manifest, groups, features):
         group = manifest["runtime_groups"][group_id]
         junit_path = artifact_dir / f"pytest-{_slug(group_id)}.xml"


### PR DESCRIPTION
## Summary

This PR adds the runtime-evidence layer on top of the example-first CI runner that was merged in #517. The runner now emits machine-readable artifact indexes and failure summaries for every stage, and the manifest can declare individual runtime probes with feature, example, pytest-node, and evidence metadata.

The goal is to make runtime checks reviewable and agent-addressable without turning the runner back into a policy engine. CI still executes the manifest; the manifest now owns the runtime evidence map.

## Key Changes

- Add `artifact-manifest.json` for every runner stage so review tools and agents can discover emitted summaries, logs, JUnit files, and feature coverage.
- Add `failure-summary.json` for every runner stage with failed or skipped checks, feature/example labels, command lines, log paths, and short failure tails.
- Extend `feature-coverage.json` with runtime probe metadata.
- Add `runtime_probes` to `tests/ci/feature_manifest.json` for the existing A12, A13, A14, B30, and synthetic ExaBGP-to-FRR runtime checks.
- Link covered control-plane features to exact runtime probes while keeping `ipv6-core` as `declared-gap` on this integration line.
- Teach `runtime-integration` to run manifest-selected probes by `--feature`, `--example`, or `--group`.
- Prevent explicit feature/example runtime selections with no matching probe from silently falling back to unrelated runtime coverage.
- Expand runner unit tests for runtime probe selection and AI-readable artifact output.
- Update `tests/ci/README.md` with the runtime probe and artifact contract.

## Scope and Boundaries

This PR only changes CI evidence plumbing, manifest declarations, tests, and CI documentation. It does not change SEED core, Docker compiler behavior, routing semantics, ExaBGP semantics, Looking Glass semantics, or IPv4/IPv6 defaults.

A15/A16/A17 are not present on the current `development2` line, so this PR does not claim IPv6 runtime coverage. `ipv6-core` remains a `declared-gap` until those examples and probes are actually merged into this integration line.

## Validation

Passed locally:

- `python3 -m json.tool tests/ci/feature_manifest.json`
- `/tmp/seedemu-example-ci-venv/bin/python -m py_compile tests/ci/run_ci.py test_ci_runner.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/seedemu-example-ci-venv/bin/python -m pytest -q test_ci_runner.py`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py static --artifact-dir ci-artifacts/static-runtime-evidence-final`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py unit --group ci-runner-unit --artifact-dir ci-artifacts/unit-runtime-evidence-final`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py example-compile --artifact-dir ci-artifacts/example-compile-runtime-evidence-final`
- `/tmp/seedemu-example-ci-venv/bin/python tests/ci/run_ci.py runtime-integration --feature ipv4-default --artifact-dir ci-artifacts/runtime-no-probe-final`
- `git diff --check`

The runtime no-probe selector intentionally records a skipped check and does not run unrelated control-plane runtime probes.

## Runtime Notes

Positive runtime probes remain Docker-heavy and are still behind `workflow_dispatch` through the existing `Runtime Integration` job. This PR makes those probes individually declared and selectable; it does not move Docker runtime into default PR gates.