### PR TITLE
Rename control-plane regression example to A63

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -22,7 +22,7 @@ on:
           - A03b
           - A05
           - A06
-          - A14
+          - A63
           - A62
           - B00
           - B02
@@ -105,8 +105,8 @@ jobs:
             examples/basic/A05_components/test_runtime.py \
             examples/basic/A06_merge_emulation/merge_emulation.py \
             examples/basic/A06_merge_emulation/test_runtime.py \
-            examples/basic/A14_control_plane_regression/control_plane_regression.py \
-            examples/basic/A14_control_plane_regression/test_runtime.py \
+            examples/basic/A63_control_plane_regression/control_plane_regression.py \
+            examples/basic/A63_control_plane_regression/test_runtime.py \
             examples/basic/A62_route_reflector/route_reflector.py \
             examples/basic/A62_route_reflector/test_runtime.py \
             examples/internet/B00_mini_internet/mini_internet.py \
@@ -127,7 +127,7 @@ jobs:
           python seedemu/testing/cli.py clean examples/basic/A03b_from_real_world/example.yaml
           python seedemu/testing/cli.py clean examples/basic/A05_components/example.yaml
           python seedemu/testing/cli.py clean examples/basic/A06_merge_emulation/example.yaml
-          python seedemu/testing/cli.py clean examples/basic/A14_control_plane_regression/example.yaml
+          python seedemu/testing/cli.py clean examples/basic/A63_control_plane_regression/example.yaml
           python seedemu/testing/cli.py clean examples/basic/A62_route_reflector/example.yaml
           python seedemu/testing/cli.py clean examples/internet/B00_mini_internet/example.yaml
           python seedemu/testing/cli.py clean examples/internet/B02_mini_internet_with_dns/example.yaml
@@ -172,10 +172,10 @@ jobs:
             category: basic
             requires_mpls: false
             manifest: examples/basic/A06_merge_emulation/example.yaml
-          - code: A14
+          - code: A63
             category: basic
             requires_mpls: false
-            manifest: examples/basic/A14_control_plane_regression/example.yaml
+            manifest: examples/basic/A63_control_plane_regression/example.yaml
           - code: A62
             category: basic
             requires_mpls: false
@@ -281,10 +281,10 @@ jobs:
             category: basic
             requires_mpls: false
             manifest: examples/basic/A06_merge_emulation/example.yaml
-          - code: A14
+          - code: A63
             category: basic
             requires_mpls: false
-            manifest: examples/basic/A14_control_plane_regression/example.yaml
+            manifest: examples/basic/A63_control_plane_regression/example.yaml
           - code: A62
             category: basic
             requires_mpls: false

--- a/examples/basic/A63_control_plane_regression/README.md
+++ b/examples/basic/A63_control_plane_regression/README.md
@@ -1,4 +1,4 @@
-# A14 Control-Plane Regression
+# A63 Control-Plane Regression
 
 This example is the compact runtime regression entry for the control-plane
 foundation work. It intentionally keeps several independent slices in one
@@ -20,7 +20,7 @@ Covered slices:
 Run it locally:
 
 ```bash
-python -m seedemu.testing.cli clean examples/basic/A14_control_plane_regression/example.yaml
-python -m seedemu.testing.cli compile examples/basic/A14_control_plane_regression/example.yaml
-COMPOSE_PROJECT_NAME=seedemu-a14-control-plane python -m seedemu.testing.cli all examples/basic/A14_control_plane_regression/example.yaml
+python -m seedemu.testing.cli clean examples/basic/A63_control_plane_regression/example.yaml
+python -m seedemu.testing.cli compile examples/basic/A63_control_plane_regression/example.yaml
+COMPOSE_PROJECT_NAME=seedemu-a63-control-plane python -m seedemu.testing.cli all examples/basic/A63_control_plane_regression/example.yaml
 ```

--- a/examples/basic/A63_control_plane_regression/control_plane_regression.py
+++ b/examples/basic/A63_control_plane_regression/control_plane_regression.py
@@ -24,7 +24,7 @@ EXABGP_PREFIX = "198.51.100.0/24"
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Build the A14 control-plane regression example.")
+    parser = argparse.ArgumentParser(description="Build the A63 control-plane regression example.")
     parser.add_argument("legacy_platform", nargs="?", choices=["amd", "arm"])
     parser.add_argument("--platform", choices=["amd", "arm"])
     parser.add_argument("--output", default=str(SCRIPT_DIR / "output"))
@@ -188,7 +188,7 @@ def main() -> int:
 
     if args.dumpfile:
         emu.dump(args.dumpfile)
-        print("Saved A14 emulator to {}".format(args.dumpfile))
+        print("Saved A63 emulator to {}".format(args.dumpfile))
         return 0
 
     if args.render:
@@ -197,7 +197,7 @@ def main() -> int:
     output_dir = Path(args.output).resolve()
     output_dir.parent.mkdir(parents=True, exist_ok=True)
     emu.compile(Docker(platform=resolve_platform(args.platform)), str(output_dir), override=args.override)
-    print("Generated A14 Docker output in {}".format(output_dir))
+    print("Generated A63 Docker output in {}".format(output_dir))
     return 0
 
 

--- a/examples/basic/A63_control_plane_regression/example.yaml
+++ b/examples/basic/A63_control_plane_regression/example.yaml
@@ -1,4 +1,4 @@
-id: basic-a14-control-plane-regression
+id: basic-a63-control-plane-regression
 name: Control-Plane Regression
 description: A compact regression topology for route-server, mixed BIRD/FRR, FRR route-reflector, ExaBGP service, and MPLS readiness coverage.
 runner: internet
@@ -33,7 +33,7 @@ build:
 runtime:
   compose: output/docker-compose.yml
   readiness:
-    - name: A14 control-plane services are running
+    - name: A63 control-plane services are running
       type: compose-ps
       services:
         - rs_ix_ix100
@@ -89,6 +89,6 @@ probes:
     interval: 5
 
 test_programs:
-  - name: A14 control-plane regression runtime validation
+  - name: A63 control-plane regression runtime validation
     script: test_runtime.py
     timeout: 1200

--- a/examples/basic/A63_control_plane_regression/test_runtime.py
+++ b/examples/basic/A63_control_plane_regression/test_runtime.py
@@ -145,7 +145,7 @@ def main() -> int:
     if as20_r4:
         test.exec_check("AS20 r4 has MPLS/LDP on net2", as20_r4, "grep -q '^net2$' /mpls_ifaces.txt && grep -q 'mpls ldp' /etc/frr/frr.conf")
 
-    test.write_summary("a14-control-plane-runtime-test.json")
+    test.write_summary("a63-control-plane-runtime-test.json")
     return test.exit_code()
 
 


### PR DESCRIPTION
## Summary

This is a small corrective PR after #550 was merged with the new control-plane regression example numbered as A14.

It renames the example to `A63_control_plane_regression` and updates the PR workflow entry from `A14` to `A63`. The runtime topology and validation logic are unchanged.

## Why

Using A63 is more robust for the basic-example namespace:

- It avoids any possible collision with IPv6 work or lower-numbered examples that may use A14.
- It naturally follows the existing `A62_route_reflector` control-plane example.
- It keeps this example's role clear as a later, comprehensive control-plane regression entry.

## Changes

- Rename `examples/basic/A14_control_plane_regression` to `examples/basic/A63_control_plane_regression`.
- Update manifest id, README commands, runtime summary filename, and user-facing example labels from A14 to A63.
- Update `.github/workflows/on-pull-request.yaml` selected example option, static py-compile paths, manifest clean validation, compile matrix, and runtime matrix from A14 to A63.

## Verification

```bash
git diff --check
python3 -m py_compile \
  seedemu/testing/base.py \
  seedemu/testing/internet.py \
  seedemu/testing/blockchain.py \
  seedemu/testing/satellite.py \
  seedemu/testing/registry.py \
  seedemu/testing/runtime.py \
  seedemu/testing/cli.py \
  examples/basic/A63_control_plane_regression/control_plane_regression.py \
  examples/basic/A63_control_plane_regression/test_runtime.py
/tmp/seedemu-a14-venv/bin/python -m seedemu.testing.cli clean examples/basic/A63_control_plane_regression/example.yaml
/tmp/seedemu-a14-venv/bin/python -m seedemu.testing.cli compile examples/basic/A63_control_plane_regression/example.yaml
COMPOSE_PROJECT_NAME=seedemu-a63-control-plane \
DOCKER_CONFIG=/tmp/seedemu-docker-config-a14 \
/tmp/seedemu-a14-venv/bin/python -m seedemu.testing.cli all \
  examples/basic/A63_control_plane_regression/example.yaml \
  --artifact-dir ci-artifacts/a63-rename-pr
```

Results:

- `git diff --check`: passed.
- CI-style py-compile list including A63: passed.
- A63 clean/compile: passed.
- A63 full lifecycle: passed build, up, readiness, probes, custom runtime validation, and down.
