### PR TITLE
Fix UnicodeDecodeError on non-UTF-8 locales when importing seedemu

### DIFF
--- a/seedemu/services/ChainlinkService/ChainlinkTemplates/ChainlinkFileTemplate.py
+++ b/seedemu/services/ChainlinkService/ChainlinkTemplates/ChainlinkFileTemplate.py
@@ -8,7 +8,7 @@ def get_file_content(filename):
     @return the content of the file
     """
     real_filename = os.path.dirname(os.path.realpath(__file__)) + "/" + filename
-    with open(real_filename, "r") as file:
+    with open(real_filename, "r", encoding="utf-8") as file:
         return file.read()
 
 

--- a/seedemu/services/EthereumService/EthTemplates/EthServerFileTemplates.py
+++ b/seedemu/services/EthereumService/EthTemplates/EthServerFileTemplates.py
@@ -8,7 +8,7 @@ def get_file_content(filename):
     @return the content of the file
     """
     real_filename = os.path.dirname(os.path.realpath(__file__)) + "/" + filename
-    with open(real_filename, "r") as file:
+    with open(real_filename, "r", encoding="utf-8") as file:
         return file.read()
 
 

--- a/seedemu/services/TrafficService/scapy_traffic_service.py
+++ b/seedemu/services/TrafficService/scapy_traffic_service.py
@@ -11,7 +11,7 @@ class ScapyGenerator(TrafficGenerator):
         @param filename the file name
         @return the content of the file
         """
-        with open(filename, "r") as file:
+        with open(filename, "r", encoding="utf-8") as file:
             return file.read()
 
     def install_softwares(self, node: Node):


### PR DESCRIPTION
## Problem

On a host whose preferred encoding is not UTF-8, `import seedemu` fails immediately:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "seedemu\__init__.py", line 2, in <module>
    from .layers import *
  File "seedemu\layers\__init__.py", line 6, in <module>
    from .Dnssec import Dnssec
  File "seedemu\layers\Dnssec.py", line 4, in <module>
    from seedemu.services import DomainNameServer, DomainNameService
  File "seedemu\services\__init__.py", line 11, in <module>
    from .EthereumService import *
  File "seedemu\services\EthereumService\__init__.py", line 6, in <module>
    from .EthTemplates import *
  File "seedemu\services\EthereumService\EthTemplates\__init__.py", line 5, in <module>
    from .EthServerFileTemplates     import EthServerFileTemplates, \
  File "seedemu\services\EthereumService\EthTemplates\EthServerFileTemplates.py", line 18, in <module>
    'fetch_bn_enr':    get_file_content("files_ethereum/fetch_bn_enr.sh"),
  File "seedemu\services\EthereumService\EthTemplates\EthServerFileTemplates.py", line 12, in get_file_content
    return file.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0xb3 in position 187: illegal multibyte sequence
```

## Cause

`get_file_content()` reads template files with `open(path, "r")` and no `encoding`, so Python falls back to `locale.getpreferredencoding()`. That is UTF-8 on the CI runners and on Linux/macOS generally, but `cp936` (GBK) on a Chinese Windows install, and other non-UTF-8 codepages elsewhere.

`files_ethereum/fetch_bn_enr.sh` uses emoji in its progress messages (`⏳`, `✅`, `❌`). `⏳` is U+23F3, encoded as `E2 8F B3`; GBK consumes `E2 8F` as one character and then fails on `B3` at offset 187, which is exactly the error above.

Two details make this worse than it first appears:

- The call is evaluated at **import time**, inside a module-level dict literal, so the failure is not deferred until the Ethereum service is actually used.
- The import chain reaches it through `layers/Dnssec.py`, so it equally blocks users who only run DNS, BGP or routing labs and never touch blockchain features.

## Fix

Pass `encoding="utf-8"` in the three host-side template readers:

- `seedemu/services/EthereumService/EthTemplates/EthServerFileTemplates.py`
- `seedemu/services/ChainlinkService/ChainlinkTemplates/ChainlinkFileTemplate.py`
- `seedemu/services/TrafficService/scapy_traffic_service.py`

These template files are UTF-8 on disk, so this simply makes the declared encoding match reality instead of leaving it to the host locale.

## Scope

Only the readers that run **on the host** during emulator generation are changed. Other `open(..., "r")` calls under `services/` either run **inside the containers**, where the locale is UTF-8 anyway, or read ASCII-only keystore and address files, so they cannot hit this. I kept the diff to three lines rather than doing a repo-wide sweep.

For completeness: `EthereumService/EthUtil.py` and `FaucetServer.py` do read keyfiles host-side without an explicit encoding. They are safe today because that content is ASCII JSON, so I left them untouched — happy to include them if you would prefer the defensive change.

## Verification

Windows 11, `locale.getpreferredencoding(False)` reports `cp936` and `sys.flags.utf8_mode` is `0`:

|  | before | after |
| --- | --- | --- |
| `python -c "import seedemu"` | `UnicodeDecodeError` | succeeds |
| `examples/basic/A00_simple_as` | only runs with `PYTHONUTF8=1` | runs as-is |

Behaviour on UTF-8 hosts is unchanged, since the explicit encoding matches what those hosts already selected.
